### PR TITLE
구독 생명주기 상태 확장 + Apple CONSUMPTION_REQUEST 응답 API

### DIFF
--- a/packages/server/src/__tests__/lifecycle-states.test.ts
+++ b/packages/server/src/__tests__/lifecycle-states.test.ts
@@ -1,0 +1,496 @@
+/**
+ * Lifecycle state tests — grace_period / on_hold introduced as first-class
+ * SubscriptionStatus values.
+ *
+ * Covers:
+ *   - Apple webhook: DID_FAIL_TO_RENEW (subtype GRACE_PERIOD vs none), GRACE_PERIOD_EXPIRED
+ *   - Google webhook: SUBSCRIPTION_IN_GRACE_PERIOD, SUBSCRIPTION_ON_HOLD
+ *   - status route: active=true for grace_period, active=false for on_hold
+ *   - CONSUMPTION_REQUEST: invokes consumptionInfoProvider then PUTs to Apple
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+import express from 'express';
+import { generateKeyPairSync } from 'crypto';
+import type { OneSubServerConfig, SubscriptionInfo } from '@onesub/shared';
+import { SUBSCRIPTION_STATUS } from '@onesub/shared';
+import { createWebhookRouter } from '../routes/webhook.js';
+import { createStatusRouter } from '../routes/status.js';
+import { InMemorySubscriptionStore, InMemoryPurchaseStore } from '../store.js';
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+function makeJws(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'ES256' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.fakesig`;
+}
+
+interface TestServer {
+  request: (method: 'POST' | 'GET', path: string, body?: unknown) => Promise<{ status: number; body: unknown }>;
+}
+
+function spinUp(handler: express.Express): TestServer {
+  return {
+    async request(method, path, body) {
+      const server = handler.listen(0);
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      try {
+        const url = `http://127.0.0.1:${port}${path}`;
+        const init: RequestInit = { method };
+        if (body !== undefined) {
+          init.headers = { 'Content-Type': 'application/json' };
+          init.body = JSON.stringify(body);
+        }
+        const resp = await fetch(url, init);
+        const text = await resp.text();
+        let parsed: unknown = text;
+        try { parsed = JSON.parse(text); } catch { /* keep as text */ }
+        return { status: resp.status, body: parsed };
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    },
+  };
+}
+
+function buildAppleWebhookServer(config: OneSubServerConfig): {
+  store: InMemorySubscriptionStore;
+  purchaseStore: InMemoryPurchaseStore;
+  server: TestServer;
+} {
+  const store = new InMemorySubscriptionStore();
+  const purchaseStore = new InMemoryPurchaseStore();
+  const app = express();
+  app.use(express.json());
+  app.use(createWebhookRouter(config, store, purchaseStore));
+  return { store, purchaseStore, server: spinUp(app) };
+}
+
+function buildGoogleWebhookServer(config: OneSubServerConfig): {
+  store: InMemorySubscriptionStore;
+  server: TestServer;
+} {
+  const store = new InMemorySubscriptionStore();
+  const purchaseStore = new InMemoryPurchaseStore();
+  const app = express();
+  app.use(express.json());
+  app.use(createWebhookRouter(config, store, purchaseStore));
+  return { store, server: spinUp(app) };
+}
+
+function buildStatusServer(): { store: InMemorySubscriptionStore; server: TestServer } {
+  const store = new InMemorySubscriptionStore();
+  const app = express();
+  app.use(express.json());
+  app.use(createStatusRouter(store));
+  return { store, server: spinUp(app) };
+}
+
+const sampleSub = (overrides?: Partial<SubscriptionInfo>): SubscriptionInfo => ({
+  userId: 'user_x',
+  productId: 'pro_monthly',
+  platform: 'apple',
+  status: 'active',
+  expiresAt: '2027-01-01T00:00:00.000Z',
+  originalTransactionId: 'orig_x',
+  purchasedAt: '2026-01-01T00:00:00.000Z',
+  willRenew: true,
+  ...overrides,
+});
+
+function appleSubscriptionTx(overrides?: Record<string, unknown>): Record<string, unknown> {
+  return {
+    bundleId: 'com.example.app',
+    type: 'Auto-Renewable Subscription',
+    productId: 'pro_monthly',
+    transactionId: 'tx_sub_1',
+    originalTransactionId: 'orig_apple_sub',
+    purchaseDate: Date.now(),
+    expiresDate: Date.now() + 86400000,
+    ...overrides,
+  };
+}
+
+// ── Apple subtype mapping ───────────────────────────────────────────────────
+
+describe('Apple webhook — DID_FAIL_TO_RENEW + GRACE_PERIOD_EXPIRED', () => {
+  let store: InMemorySubscriptionStore;
+  let server: TestServer;
+  const config: OneSubServerConfig = {
+    apple: { bundleId: 'com.example.app', skipJwsVerification: true },
+    database: { url: '' },
+  };
+
+  beforeEach(() => {
+    const built = buildAppleWebhookServer(config);
+    store = built.store;
+    server = built.server;
+  });
+
+  async function postApple(notificationType: string, subtype?: string) {
+    const signedTransactionInfo = makeJws(appleSubscriptionTx());
+    const payload: Record<string, unknown> = {
+      notificationType,
+      data: { signedTransactionInfo, signedRenewalInfo: makeJws({}) },
+    };
+    if (subtype) payload.subtype = subtype;
+    const signedPayload = makeJws(payload);
+    return server.request('POST', '/onesub/webhook/apple', { signedPayload });
+  }
+
+  it('DID_FAIL_TO_RENEW + subtype GRACE_PERIOD → grace_period', async () => {
+    await store.save(sampleSub({ originalTransactionId: 'orig_apple_sub' }));
+    const resp = await postApple('DID_FAIL_TO_RENEW', 'GRACE_PERIOD');
+    expect(resp.status).toBe(200);
+    expect((await store.getByTransactionId('orig_apple_sub'))?.status).toBe(
+      SUBSCRIPTION_STATUS.GRACE_PERIOD,
+    );
+  });
+
+  it('DID_FAIL_TO_RENEW (no subtype) → on_hold', async () => {
+    await store.save(sampleSub({ originalTransactionId: 'orig_apple_sub' }));
+    const resp = await postApple('DID_FAIL_TO_RENEW');
+    expect(resp.status).toBe(200);
+    expect((await store.getByTransactionId('orig_apple_sub'))?.status).toBe(
+      SUBSCRIPTION_STATUS.ON_HOLD,
+    );
+  });
+
+  it('GRACE_PERIOD_EXPIRED → on_hold (not expired — billing retry continues)', async () => {
+    await store.save(sampleSub({ originalTransactionId: 'orig_apple_sub' }));
+    const resp = await postApple('GRACE_PERIOD_EXPIRED');
+    expect(resp.status).toBe(200);
+    expect((await store.getByTransactionId('orig_apple_sub'))?.status).toBe(
+      SUBSCRIPTION_STATUS.ON_HOLD,
+    );
+  });
+
+  it('EXPIRED → expired (terminal)', async () => {
+    await store.save(sampleSub({ originalTransactionId: 'orig_apple_sub' }));
+    const resp = await postApple('EXPIRED');
+    expect(resp.status).toBe(200);
+    expect((await store.getByTransactionId('orig_apple_sub'))?.status).toBe(
+      SUBSCRIPTION_STATUS.EXPIRED,
+    );
+  });
+});
+
+// ── Google IN_GRACE_PERIOD / ON_HOLD ────────────────────────────────────────
+
+function googlePushBody(notificationType: number) {
+  const json = JSON.stringify({
+    version: '1.0',
+    packageName: 'com.example.app',
+    eventTimeMillis: String(Date.now()),
+    subscriptionNotification: {
+      version: '1.0',
+      notificationType,
+      purchaseToken: 'tok_google_sub',
+      subscriptionId: 'pro_monthly',
+    },
+  });
+  return {
+    message: { data: Buffer.from(json).toString('base64'), messageId: '1' },
+    subscription: 'projects/x/subscriptions/y',
+  };
+}
+
+describe('Google webhook — IN_GRACE_PERIOD / ON_HOLD', () => {
+  let store: InMemorySubscriptionStore;
+  let server: TestServer;
+  const config: OneSubServerConfig = {
+    google: { packageName: 'com.example.app' }, // no serviceAccountKey → no Play API re-fetch
+    database: { url: '' },
+  };
+
+  beforeEach(() => {
+    const built = buildGoogleWebhookServer(config);
+    store = built.store;
+    server = built.server;
+  });
+
+  it('IN_GRACE_PERIOD (6) → grace_period', async () => {
+    await store.save(sampleSub({
+      platform: 'google',
+      originalTransactionId: 'tok_google_sub',
+    }));
+    const resp = await server.request('POST', '/onesub/webhook/google', googlePushBody(6));
+    expect(resp.status).toBe(200);
+    expect((await store.getByTransactionId('tok_google_sub'))?.status).toBe(
+      SUBSCRIPTION_STATUS.GRACE_PERIOD,
+    );
+  });
+
+  it('ON_HOLD (5) → on_hold', async () => {
+    await store.save(sampleSub({
+      platform: 'google',
+      originalTransactionId: 'tok_google_sub',
+    }));
+    const resp = await server.request('POST', '/onesub/webhook/google', googlePushBody(5));
+    expect(resp.status).toBe(200);
+    expect((await store.getByTransactionId('tok_google_sub'))?.status).toBe(
+      SUBSCRIPTION_STATUS.ON_HOLD,
+    );
+  });
+});
+
+// ── status route entitlement semantics ──────────────────────────────────────
+
+describe('status route — entitlement for new states', () => {
+  let store: InMemorySubscriptionStore;
+  let server: TestServer;
+
+  beforeEach(() => {
+    const built = buildStatusServer();
+    store = built.store;
+    server = built.server;
+  });
+
+  it('grace_period → active: true (entitlement still valid)', async () => {
+    await store.save(sampleSub({ userId: 'u_grace', status: 'grace_period' }));
+    const resp = await server.request('GET', '/onesub/status?userId=u_grace');
+    expect(resp.status).toBe(200);
+    expect((resp.body as { active: boolean }).active).toBe(true);
+  });
+
+  it('on_hold → active: false (entitlement revoked)', async () => {
+    await store.save(sampleSub({ userId: 'u_hold', status: 'on_hold' }));
+    const resp = await server.request('GET', '/onesub/status?userId=u_hold');
+    expect(resp.status).toBe(200);
+    expect((resp.body as { active: boolean }).active).toBe(false);
+  });
+
+  it('expired → active: false', async () => {
+    await store.save(sampleSub({ userId: 'u_exp', status: 'expired' }));
+    const resp = await server.request('GET', '/onesub/status?userId=u_exp');
+    expect((resp.body as { active: boolean }).active).toBe(false);
+  });
+});
+
+// ── CONSUMPTION_REQUEST → consumptionInfoProvider → Apple PUT ───────────────
+
+describe('Apple webhook — CONSUMPTION_REQUEST', () => {
+  let testEcKey: string;
+
+  beforeAll(() => {
+    // Generate a real EC P-256 key for the JWT signing path.
+    const { privateKey } = generateKeyPairSync('ec', { namedCurve: 'P-256' });
+    testEcKey = privateKey.export({ type: 'pkcs8', format: 'pem' }) as string;
+  });
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('invokes consumptionInfoProvider with context, then PUTs body to Apple consumption endpoint', async () => {
+    const originalFetch = global.fetch;
+    const fetchCalls: { url: string; method?: string; body?: unknown; headers?: Record<string, string> }[] = [];
+    vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+      const urlStr = String(url);
+      // Pass-through localhost — that's our own test server.
+      if (urlStr.startsWith('http://127.0.0.1') || urlStr.startsWith('http://localhost')) {
+        return originalFetch(url, init);
+      }
+      fetchCalls.push({
+        url: urlStr,
+        method: init?.method,
+        body: init?.body,
+        headers: init?.headers as Record<string, string>,
+      });
+      return { ok: true, json: async () => ({}), text: async () => '' } as Response;
+    });
+
+    const provider = vi.fn(async () => ({
+      customerConsented: true,
+      consumptionStatus: 3 as const,
+      deliveryStatus: 1 as const,
+      refundPreference: 2 as const,
+    }));
+
+    const config: OneSubServerConfig = {
+      apple: {
+        bundleId: 'com.example.app',
+        skipJwsVerification: true,
+        keyId: 'TESTKEY1',
+        issuerId: '12345678-1234-1234-1234-123456789012',
+        privateKey: testEcKey,
+        consumptionInfoProvider: provider,
+      },
+      database: { url: '' },
+    };
+    const { server } = buildAppleWebhookServer(config);
+
+    const signedTransactionInfo = makeJws({
+      bundleId: 'com.example.app',
+      type: 'Consumable',
+      productId: 'credits_100',
+      transactionId: 'tx_consume_refund',
+      originalTransactionId: 'orig_consume_refund',
+      purchaseDate: Date.now(),
+      environment: 'Production',
+    });
+    const signedPayload = makeJws({
+      notificationType: 'CONSUMPTION_REQUEST',
+      data: { signedTransactionInfo, signedRenewalInfo: makeJws({}) },
+    });
+
+    const resp = await server.request('POST', '/onesub/webhook/apple', { signedPayload });
+    expect(resp.status).toBe(200);
+
+    // Provider runs in fire-and-forget — give the microtask queue a tick.
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(provider).toHaveBeenCalledWith({
+      transactionId: 'tx_consume_refund',
+      originalTransactionId: 'orig_consume_refund',
+      productId: 'credits_100',
+      bundleId: 'com.example.app',
+      environment: 'Production',
+    });
+
+    const putCall = fetchCalls.find((c) => c.method === 'PUT');
+    expect(putCall).toBeDefined();
+    expect(putCall?.url).toContain('api.storekit.itunes.apple.com');
+    expect(putCall?.url).toContain('/inApps/v1/transactions/consumption/tx_consume_refund');
+    expect(putCall?.headers?.Authorization).toMatch(/^Bearer /);
+    expect(JSON.parse(String(putCall?.body))).toMatchObject({
+      customerConsented: true,
+      consumptionStatus: 3,
+      deliveryStatus: 1,
+      refundPreference: 2,
+    });
+  });
+
+  it('routes Sandbox-environment notifications to the sandbox host', async () => {
+    const originalFetch = global.fetch;
+    const fetchCalls: { url: string; method?: string }[] = [];
+    vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+      const urlStr = String(url);
+      if (urlStr.startsWith('http://127.0.0.1') || urlStr.startsWith('http://localhost')) {
+        return originalFetch(url, init);
+      }
+      fetchCalls.push({ url: urlStr, method: init?.method });
+      return { ok: true, json: async () => ({}), text: async () => '' } as Response;
+    });
+
+    const config: OneSubServerConfig = {
+      apple: {
+        bundleId: 'com.example.app',
+        skipJwsVerification: true,
+        keyId: 'TESTKEY1',
+        issuerId: '12345678-1234-1234-1234-123456789012',
+        privateKey: testEcKey,
+        consumptionInfoProvider: async () => ({
+          customerConsented: true,
+          consumptionStatus: 1,
+          deliveryStatus: 1,
+        }),
+      },
+      database: { url: '' },
+    };
+    const { server } = buildAppleWebhookServer(config);
+
+    const signedTransactionInfo = makeJws({
+      bundleId: 'com.example.app',
+      type: 'Consumable',
+      productId: 'credits_100',
+      transactionId: 'tx_sandbox',
+      originalTransactionId: 'orig_sandbox',
+      purchaseDate: Date.now(),
+      environment: 'Sandbox',
+    });
+    const signedPayload = makeJws({
+      notificationType: 'CONSUMPTION_REQUEST',
+      data: { signedTransactionInfo, signedRenewalInfo: makeJws({}), environment: 'Sandbox' },
+    });
+
+    await server.request('POST', '/onesub/webhook/apple', { signedPayload });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const putCall = fetchCalls.find((c) => c.method === 'PUT');
+    expect(putCall?.url).toContain('api.storekit-sandbox.itunes.apple.com');
+  });
+
+  it('returns null from provider → no Apple PUT', async () => {
+    const originalFetch = global.fetch;
+    const fetchCalls: { url: string; method?: string }[] = [];
+    vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+      const urlStr = String(url);
+      if (urlStr.startsWith('http://127.0.0.1') || urlStr.startsWith('http://localhost')) {
+        return originalFetch(url, init);
+      }
+      fetchCalls.push({ url: urlStr, method: init?.method });
+      return { ok: true, json: async () => ({}), text: async () => '' } as Response;
+    });
+
+    const config: OneSubServerConfig = {
+      apple: {
+        bundleId: 'com.example.app',
+        skipJwsVerification: true,
+        keyId: 'TESTKEY1',
+        issuerId: 'X',
+        privateKey: testEcKey,
+        consumptionInfoProvider: async () => null,
+      },
+      database: { url: '' },
+    };
+    const { server } = buildAppleWebhookServer(config);
+
+    const signedTransactionInfo = makeJws({
+      bundleId: 'com.example.app',
+      type: 'Consumable',
+      productId: 'credits_100',
+      transactionId: 'tx_skip',
+      originalTransactionId: 'orig_skip',
+      purchaseDate: Date.now(),
+    });
+    const signedPayload = makeJws({
+      notificationType: 'CONSUMPTION_REQUEST',
+      data: { signedTransactionInfo, signedRenewalInfo: makeJws({}) },
+    });
+
+    await server.request('POST', '/onesub/webhook/apple', { signedPayload });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(fetchCalls.find((c) => c.method === 'PUT')).toBeUndefined();
+  });
+
+  it('skips silently when consumptionInfoProvider is not configured', async () => {
+    const originalFetch = global.fetch;
+    const outboundCalls: { url: string }[] = [];
+    vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+      const urlStr = String(url);
+      if (urlStr.startsWith('http://127.0.0.1') || urlStr.startsWith('http://localhost')) {
+        return originalFetch(url, init);
+      }
+      outboundCalls.push({ url: urlStr });
+      return { ok: true, json: async () => ({}), text: async () => '' } as Response;
+    });
+
+    const config: OneSubServerConfig = {
+      apple: { bundleId: 'com.example.app', skipJwsVerification: true },
+      database: { url: '' },
+    };
+    const { server } = buildAppleWebhookServer(config);
+
+    const signedTransactionInfo = makeJws({
+      bundleId: 'com.example.app',
+      type: 'Consumable',
+      productId: 'credits_100',
+      transactionId: 'tx_no_provider',
+      originalTransactionId: 'orig_no_provider',
+      purchaseDate: Date.now(),
+    });
+    const signedPayload = makeJws({
+      notificationType: 'CONSUMPTION_REQUEST',
+      data: { signedTransactionInfo, signedRenewalInfo: makeJws({}) },
+    });
+
+    const resp = await server.request('POST', '/onesub/webhook/apple', { signedPayload });
+    expect(resp.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(outboundCalls).toHaveLength(0);
+  });
+});

--- a/packages/server/src/providers/apple.ts
+++ b/packages/server/src/providers/apple.ts
@@ -1,6 +1,11 @@
-import { decodeJwt, decodeProtectedHeader, importX509, jwtVerify } from 'jose';
+import { decodeJwt, decodeProtectedHeader, importPKCS8, importX509, jwtVerify, SignJWT } from 'jose';
 import { X509Certificate } from 'node:crypto';
-import type { SubscriptionInfo, AppleNotificationPayload, OneSubServerConfig } from '@onesub/shared';
+import type {
+  SubscriptionInfo,
+  AppleNotificationPayload,
+  AppleConsumptionRequest,
+  OneSubServerConfig,
+} from '@onesub/shared';
 import { SUBSCRIPTION_STATUS } from '@onesub/shared';
 import { APPLE_ROOT_CA_PEMS } from './apple-root-ca.js';
 import { log } from '../logger.js';
@@ -340,6 +345,9 @@ export async function decodeAppleNotification(
   /** 'Auto-Renewable Subscription' | 'Consumable' | 'Non-Consumable' | 'Non-Renewing Subscription' */
   type: string | null;
   productId: string | null;
+  bundleId: string | null;
+  /** 'Production' | 'Sandbox' — drives which Apple API host to call back. */
+  environment: 'Production' | 'Sandbox';
   status: SubscriptionInfo['status'];
   willRenew: boolean;
   /** May be null for non-subscription notifications (consumable refund). */
@@ -369,13 +377,97 @@ export async function decodeAppleNotification(
   const status = deriveStatus(tx, renewal);
   const willRenew = renewal?.autoRenewStatus === 1;
 
+  // environment is on the notification data envelope but Apple also includes
+  // it inside the signed transaction payload. Prefer the JWS-protected one.
+  const txEnv = (tx as { environment?: string }).environment;
+  const dataEnv = payload.data.environment;
+  const environment: 'Production' | 'Sandbox' =
+    txEnv === 'Sandbox' || dataEnv === 'Sandbox' ? 'Sandbox' : 'Production';
+
   return {
     originalTransactionId: tx.originalTransactionId,
     transactionId: tx.transactionId ?? null,
     type: tx.type ?? null,
     productId: tx.productId ?? null,
+    bundleId: tx.bundleId ?? payload.data.bundleId ?? null,
+    environment,
     status,
     willRenew,
     expiresAt: tx.expiresDate ? new Date(tx.expiresDate).toISOString() : null,
   };
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// App Store Server API — outbound calls (consumption response, etc.)
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Mint a JWT for the App Store Server API (audience `appstoreconnect-v1`).
+ * Requires keyId, issuerId, and privateKey (PKCS8 ES256 from App Store Connect).
+ * Token TTL is capped at 20 minutes per Apple's spec.
+ */
+async function makeAppleApiJwt(config: AppleConfig): Promise<string> {
+  const { issuerId, keyId, privateKey, bundleId } = config;
+  if (!issuerId || !keyId || !privateKey) {
+    throw new Error('[onesub/apple] App Store Server API requires issuerId, keyId, and privateKey');
+  }
+  const key = await importPKCS8(privateKey, 'ES256');
+  return await new SignJWT({ bid: bundleId })
+    .setProtectedHeader({ alg: 'ES256', kid: keyId, typ: 'JWT' })
+    .setIssuer(issuerId)
+    .setAudience('appstoreconnect-v1')
+    .setIssuedAt()
+    .setExpirationTime('20m')
+    .sign(key);
+}
+
+/**
+ * PUT a ConsumptionRequest to Apple's
+ * /inApps/v1/transactions/consumption/{transactionId} endpoint.
+ *
+ * Apple sends CONSUMPTION_REQUEST notifications when a customer asks for a
+ * refund on a consumable. Without a response Apple has no usage signal and
+ * tends to grant the refund. This call provides the data Apple uses to weigh
+ * the refund decision.
+ *
+ * Fire-and-forget: failures are logged, never thrown — the webhook should
+ * still 200 to Apple even if our outbound call fails.
+ */
+export async function sendAppleConsumptionResponse(
+  transactionId: string,
+  body: AppleConsumptionRequest,
+  config: AppleConfig,
+  options?: { sandbox?: boolean },
+): Promise<void> {
+  if (config.mockMode) return;
+
+  let jwt: string;
+  try {
+    jwt = await makeAppleApiJwt(config);
+  } catch (err) {
+    log.warn('[onesub/apple] Cannot send consumption response — JWT mint failed:', err);
+    return;
+  }
+
+  const host = options?.sandbox
+    ? 'api.storekit-sandbox.itunes.apple.com'
+    : 'api.storekit.itunes.apple.com';
+  const url = `https://${host}/inApps/v1/transactions/consumption/${encodeURIComponent(transactionId)}`;
+
+  try {
+    const resp = await fetch(url, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    if (!resp.ok) {
+      const text = await resp.text();
+      log.warn(`[onesub/apple] Consumption response API error ${resp.status}: ${text}`);
+    }
+  } catch (err) {
+    log.warn('[onesub/apple] Consumption response network error:', err);
+  }
 }

--- a/packages/server/src/providers/google.ts
+++ b/packages/server/src/providers/google.ts
@@ -584,15 +584,15 @@ export function decodeGoogleVoidedNotification(
 }
 
 /**
- * Determine if a Google RTDN notification type represents an active subscription.
+ * Determine if a Google RTDN notification type represents an active subscription
+ * inside the paid window (excludes grace period — that's a separate state now).
  */
 export function isGoogleActiveNotification(notificationType: GoogleNotificationType): boolean {
   return (
     notificationType === GOOGLE_NOTIFICATION_TYPE.SUBSCRIPTION_PURCHASED ||
     notificationType === GOOGLE_NOTIFICATION_TYPE.SUBSCRIPTION_RENEWED ||
     notificationType === GOOGLE_NOTIFICATION_TYPE.SUBSCRIPTION_RECOVERED ||
-    notificationType === GOOGLE_NOTIFICATION_TYPE.SUBSCRIPTION_RESTARTED ||
-    notificationType === GOOGLE_NOTIFICATION_TYPE.SUBSCRIPTION_IN_GRACE_PERIOD
+    notificationType === GOOGLE_NOTIFICATION_TYPE.SUBSCRIPTION_RESTARTED
   );
 }
 
@@ -605,4 +605,20 @@ export function isGoogleCanceledNotification(notificationType: GoogleNotificatio
 
 export function isGoogleExpiredNotification(notificationType: GoogleNotificationType): boolean {
   return notificationType === GOOGLE_NOTIFICATION_TYPE.SUBSCRIPTION_EXPIRED;
+}
+
+/**
+ * Subscription is in the store-granted grace period — payment failed but the
+ * user retains access while Google retries. Maps to SUBSCRIPTION_STATUS.GRACE_PERIOD.
+ */
+export function isGoogleGracePeriodNotification(notificationType: GoogleNotificationType): boolean {
+  return notificationType === GOOGLE_NOTIFICATION_TYPE.SUBSCRIPTION_IN_GRACE_PERIOD;
+}
+
+/**
+ * Subscription is on hold — grace period ended, retry continuing, entitlement
+ * REVOKED. Maps to SUBSCRIPTION_STATUS.ON_HOLD.
+ */
+export function isGoogleOnHoldNotification(notificationType: GoogleNotificationType): boolean {
+  return notificationType === GOOGLE_NOTIFICATION_TYPE.SUBSCRIPTION_ON_HOLD;
 }

--- a/packages/server/src/routes/status.ts
+++ b/packages/server/src/routes/status.ts
@@ -39,7 +39,12 @@ export function createStatusRouter(store: SubscriptionStore): Router {
         return;
       }
 
-      const active = sub.status === SUBSCRIPTION_STATUS.ACTIVE;
+      // Entitlement is valid during the store-granted grace period (Apple
+      // GRACE_PERIOD subtype, Google IN_GRACE_PERIOD). on_hold is excluded —
+      // the user must fix payment before they regain access.
+      const active =
+        sub.status === SUBSCRIPTION_STATUS.ACTIVE ||
+        sub.status === SUBSCRIPTION_STATUS.GRACE_PERIOD;
       const response: StatusResponse = { active, subscription: sub };
       res.status(200).json(response);
     } catch (err) {

--- a/packages/server/src/routes/webhook.ts
+++ b/packages/server/src/routes/webhook.ts
@@ -9,7 +9,7 @@ import type {
 } from '@onesub/shared';
 import { ROUTES, SUBSCRIPTION_STATUS, ONESUB_ERROR_CODE } from '@onesub/shared';
 import type { SubscriptionStore, PurchaseStore } from '../store.js';
-import { decodeAppleNotification, decodeJws } from '../providers/apple.js';
+import { decodeAppleNotification, decodeJws, sendAppleConsumptionResponse } from '../providers/apple.js';
 import {
   decodeGoogleNotification,
   decodeGoogleVoidedNotification,
@@ -17,6 +17,8 @@ import {
   isGoogleActiveNotification,
   isGoogleCanceledNotification,
   isGoogleExpiredNotification,
+  isGoogleGracePeriodNotification,
+  isGoogleOnHoldNotification,
 } from '../providers/google.js';
 import { log } from '../logger.js';
 import { sendError } from '../errors.js';
@@ -79,11 +81,42 @@ const APPLE_CANCELED_TYPES = new Set([
 
 /**
  * Apple V2 notification types that indicate expiry.
+ * Pure EXPIRED only — GRACE_PERIOD_EXPIRED is handled separately as on_hold
+ * because billing retry continues after the grace window ends.
  */
 const APPLE_EXPIRED_TYPES = new Set([
   'EXPIRED',
-  'GRACE_PERIOD_EXPIRED',
 ]);
+
+/**
+ * Map an Apple notification (notificationType + optional subtype) to a
+ * lifecycle state. Returns null if the notification doesn't carry an explicit
+ * lifecycle signal (in which case the caller falls back to the JWS-derived status).
+ *
+ * Apple references:
+ *   DID_FAIL_TO_RENEW + subtype GRACE_PERIOD  → GRACE_PERIOD
+ *   DID_FAIL_TO_RENEW (no subtype)            → ON_HOLD (billing retry, no grace)
+ *   GRACE_PERIOD_EXPIRED                      → ON_HOLD (grace ended, retry continues)
+ *   EXPIRED                                   → EXPIRED (terminal, no further retries)
+ *   SUBSCRIBED / DID_RENEW / DID_RECOVER /
+ *     OFFER_REDEEMED                          → ACTIVE
+ *   REVOKE / REFUND / CONSUMPTION_REQUEST     → CANCELED
+ */
+function mapAppleNotificationStatus(
+  notificationType: string,
+  subtype: string | undefined,
+): SubscriptionInfo['status'] | null {
+  if (notificationType === 'DID_FAIL_TO_RENEW') {
+    return subtype === 'GRACE_PERIOD'
+      ? SUBSCRIPTION_STATUS.GRACE_PERIOD
+      : SUBSCRIPTION_STATUS.ON_HOLD;
+  }
+  if (notificationType === 'GRACE_PERIOD_EXPIRED') return SUBSCRIPTION_STATUS.ON_HOLD;
+  if (APPLE_CANCELED_TYPES.has(notificationType)) return SUBSCRIPTION_STATUS.CANCELED;
+  if (APPLE_EXPIRED_TYPES.has(notificationType)) return SUBSCRIPTION_STATUS.EXPIRED;
+  if (APPLE_ACTIVE_TYPES.has(notificationType)) return SUBSCRIPTION_STATUS.ACTIVE;
+  return null;
+}
 
 /**
  * Retry / durability semantics.
@@ -150,15 +183,55 @@ export function createWebhookRouter(
       return;
     }
 
-    const { originalTransactionId, transactionId, type, status, willRenew, expiresAt } = decoded;
+    const {
+      originalTransactionId,
+      transactionId,
+      type,
+      productId,
+      bundleId,
+      environment,
+      status,
+      willRenew,
+      expiresAt,
+    } = decoded;
     const notificationType = payload.notificationType;
+    const subtype = payload.subtype;
 
-    // Derive final status from the notification type (overrides the JWS-derived status
-    // when there is an explicit signal like REVOKE or EXPIRED).
-    let finalStatus: SubscriptionInfo['status'] = status;
-    if (APPLE_CANCELED_TYPES.has(notificationType)) finalStatus = SUBSCRIPTION_STATUS.CANCELED;
-    else if (APPLE_EXPIRED_TYPES.has(notificationType)) finalStatus = SUBSCRIPTION_STATUS.EXPIRED;
-    else if (APPLE_ACTIVE_TYPES.has(notificationType)) finalStatus = SUBSCRIPTION_STATUS.ACTIVE;
+    // Derive final status from the notification type + subtype (overrides the
+    // JWS-derived status when there is an explicit lifecycle signal).
+    const mapped = mapAppleNotificationStatus(notificationType, subtype);
+    const finalStatus: SubscriptionInfo['status'] = mapped ?? status;
+
+    // CONSUMPTION_REQUEST — Apple is asking whether to grant a consumable
+    // refund. If the host app provided a consumptionInfoProvider, call it and
+    // PUT the response. Failures are logged; the webhook still 200s.
+    if (
+      notificationType === 'CONSUMPTION_REQUEST' &&
+      config.apple?.consumptionInfoProvider &&
+      transactionId &&
+      productId
+    ) {
+      const provider = config.apple.consumptionInfoProvider;
+      const appleConfig = config.apple;
+      void (async () => {
+        try {
+          const info = await provider({
+            transactionId,
+            originalTransactionId,
+            productId,
+            bundleId: bundleId ?? appleConfig.bundleId,
+            environment,
+          });
+          if (info) {
+            await sendAppleConsumptionResponse(transactionId, info, appleConfig, {
+              sandbox: environment === 'Sandbox',
+            });
+          }
+        } catch (err) {
+          log.warn('[onesub/webhook/apple] consumptionInfoProvider failed:', err);
+        }
+      })();
+    }
 
     // IAP refund / revoke for one-time purchases (consumable / non-consumable).
     // Apple sends REFUND notifications for both subscriptions and IAP — the
@@ -310,6 +383,10 @@ export function createWebhookRouter(
       let finalStatus: SubscriptionInfo['status'];
       if (isGoogleActiveNotification(notificationType)) {
         finalStatus = SUBSCRIPTION_STATUS.ACTIVE;
+      } else if (isGoogleGracePeriodNotification(notificationType)) {
+        finalStatus = SUBSCRIPTION_STATUS.GRACE_PERIOD;
+      } else if (isGoogleOnHoldNotification(notificationType)) {
+        finalStatus = SUBSCRIPTION_STATUS.ON_HOLD;
       } else if (isGoogleCanceledNotification(notificationType)) {
         finalStatus = SUBSCRIPTION_STATUS.CANCELED;
       } else if (isGoogleExpiredNotification(notificationType)) {
@@ -326,9 +403,16 @@ export function createWebhookRouter(
         if (config.google?.serviceAccountKey) {
           const fresh = await validateGoogleReceipt(purchaseToken, subscriptionId, config.google);
           if (fresh) {
+            // Notification-derived grace_period/on_hold are authoritative — the
+            // expiry-based deriveStatus() in the provider can't observe these
+            // states (paymentState heuristics are unreliable), so trust the
+            // RTDN signal over the API-derived status for those two cases.
+            const preserveNotificationStatus =
+              finalStatus === SUBSCRIPTION_STATUS.GRACE_PERIOD ||
+              finalStatus === SUBSCRIPTION_STATUS.ON_HOLD;
             updated = {
               ...existing,
-              status: fresh.status,
+              status: preserveNotificationStatus ? finalStatus : fresh.status,
               expiresAt: fresh.expiresAt,
               willRenew: fresh.willRenew,
             };

--- a/packages/shared/src/__tests__/constants.test.ts
+++ b/packages/shared/src/__tests__/constants.test.ts
@@ -31,6 +31,14 @@ describe('shared constants', () => {
       expect(SUBSCRIPTION_STATUS.ACTIVE).toBe('active');
     });
 
+    it('GRACE_PERIOD equals "grace_period"', () => {
+      expect(SUBSCRIPTION_STATUS.GRACE_PERIOD).toBe('grace_period');
+    });
+
+    it('ON_HOLD equals "on_hold"', () => {
+      expect(SUBSCRIPTION_STATUS.ON_HOLD).toBe('on_hold');
+    });
+
     it('EXPIRED equals "expired"', () => {
       expect(SUBSCRIPTION_STATUS.EXPIRED).toBe('expired');
     });

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -14,6 +14,10 @@ export const DEFAULT_PORT = 4100;
 /** Subscription status values */
 export const SUBSCRIPTION_STATUS = {
   ACTIVE: 'active',
+  /** Payment failed but the store still grants access while retrying. Treat as entitled. */
+  GRACE_PERIOD: 'grace_period',
+  /** Payment failed; retry/grace window expired; entitlement REVOKED until user fixes payment. */
+  ON_HOLD: 'on_hold',
   EXPIRED: 'expired',
   CANCELED: 'canceled',
   NONE: 'none',

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,7 +1,25 @@
 import type { OneSubErrorCode } from './constants.js';
 
-/** Subscription status */
-export type SubscriptionStatus = 'active' | 'expired' | 'canceled' | 'none';
+/** Subscription status.
+ *
+ * Lifecycle states:
+ *   - active        — paid period, entitlement valid
+ *   - grace_period  — payment failed but Apple/Google grants temporary access
+ *                     while retrying. Treat as entitled.
+ *   - on_hold       — payment failed, retry window expired or grace ended.
+ *                     Entitlement REVOKED until the user fixes payment.
+ *                     (Apple "billing retry"; Google "on hold".)
+ *   - expired       — subscription ended without renewal
+ *   - canceled      — refunded or revoked by store
+ *   - none          — no record
+ */
+export type SubscriptionStatus =
+  | 'active'
+  | 'grace_period'
+  | 'on_hold'
+  | 'expired'
+  | 'canceled'
+  | 'none';
 
 /** Store platform */
 export type Platform = 'apple' | 'google';
@@ -51,7 +69,51 @@ export interface AppleNotificationPayload {
   data: {
     signedTransactionInfo: string;
     signedRenewalInfo: string;
+    environment?: string;  // 'Production' | 'Sandbox'
+    bundleId?: string;
   };
+}
+
+/**
+ * Apple App Store Server API ConsumptionRequest body — the response Apple
+ * expects when it sends a CONSUMPTION_REQUEST notification asking whether to
+ * grant or decline a consumable refund.
+ *
+ * https://developer.apple.com/documentation/appstoreserverapi/consumptionrequest
+ */
+export interface AppleConsumptionRequest {
+  /** REQUIRED — must be true; if false, Apple ignores the response. */
+  customerConsented: boolean;
+  /** 0 = undeclared, 1 = not consumed, 2 = partially consumed, 3 = fully consumed */
+  consumptionStatus: 0 | 1 | 2 | 3;
+  /** 0 = undeclared, 1 = delivered & working, 2 = quality issue, 3 = wrong item, 4 = server outage, 5 = currency change */
+  deliveryStatus: 0 | 1 | 2 | 3 | 4 | 5;
+  /** 0 = undeclared, 1 = grant refund, 2 = decline, 3 = no preference */
+  refundPreference?: 0 | 1 | 2 | 3;
+  /** 0 = undeclared, 1 = active, 2 = suspended, 3 = terminated, 4 = limited */
+  userStatus?: 0 | 1 | 2 | 3 | 4;
+  /** 0 = undeclared, 1 = <3 days, 2 = 3-10d, 3 = 10-30d, 4 = 30-90d, 5 = >90d */
+  accountTenure?: 0 | 1 | 2 | 3 | 4 | 5;
+  /** 0 = undeclared, 1 = <5min, 2 = 5-60min, 3 = 1-6h, 4 = 6-24h, 5 = 1-4d, 6 = >4d */
+  playTime?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  /** 0 = undeclared, 1 = $0, 2 = $0.01-$49.99, ... 7 = >$1999.99 */
+  lifetimeDollarsPurchased?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
+  /** Same buckets as lifetimeDollarsPurchased */
+  lifetimeDollarsRefunded?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
+  /** 0 = undeclared, 1 = Apple, 2 = Non-Apple */
+  platform?: 0 | 1 | 2;
+  sampleContentProvided?: boolean;
+  /** UUID — same value the client passed via setAppAccountToken */
+  appAccountToken?: string;
+}
+
+/** Context passed to the consumptionInfoProvider hook for a CONSUMPTION_REQUEST notification. */
+export interface AppleConsumptionContext {
+  transactionId: string;
+  originalTransactionId: string;
+  productId: string;
+  bundleId: string;
+  environment: 'Production' | 'Sandbox';
 }
 
 /** Google RTDN (Real-Time Developer Notification) */
@@ -93,6 +155,21 @@ export interface OneSubServerConfig {
      * real App Store Connect credentials. **NEVER enable in production.**
      */
     mockMode?: boolean;
+    /**
+     * Hook to provide consumption info when Apple sends a CONSUMPTION_REQUEST
+     * notification (consumable refund review).
+     *
+     * If set, the webhook handler calls this with the refunded transaction's
+     * context and PUTs the returned ConsumptionRequest to Apple's
+     * /inApps/v1/transactions/consumption/{txId} endpoint. Without this hook,
+     * Apple has no usage signal and tends to grant the refund.
+     *
+     * Requires keyId, issuerId, and privateKey to be configured (the API call
+     * is JWT-authenticated). Return null to skip this particular request.
+     */
+    consumptionInfoProvider?: (
+      ctx: AppleConsumptionContext,
+    ) => Promise<AppleConsumptionRequest | null>;
   };
   google?: {
     packageName: string;


### PR DESCRIPTION
## Summary

- `SubscriptionStatus`에 `grace_period`, `on_hold` 추가 — 그동안 active/expired/canceled 4개 상태로는 표현 못 했던 결제 실패 라이프사이클을 1급 시민으로
- Apple `DID_FAIL_TO_RENEW` (subtype 분기) + `GRACE_PERIOD_EXPIRED` 매핑 정교화 — billing retry 진입을 정확히 감지
- Google `SUBSCRIPTION_IN_GRACE_PERIOD`(6) / `SUBSCRIPTION_ON_HOLD`(5) 매핑 추가 — 이전엔 grace를 active로 잘못 분류했고 hold는 무처리였음
- Apple `CONSUMPTION_REQUEST` 응답 API (`PUT /inApps/v1/transactions/consumption/{txId}`) 구현 — 호스트 앱이 `consumptionInfoProvider` 콜백 제공 시 자동 호출, 미제공 시 안전하게 skip (옵트인)

## 상태 매핑 표

| 알림 | → 상태 | active 여부 |
|------|-------|------------|
| Apple `DID_FAIL_TO_RENEW` + subtype `GRACE_PERIOD` | `grace_period` | ✅ true |
| Apple `DID_FAIL_TO_RENEW` (no subtype) | `on_hold` | ❌ false |
| Apple `GRACE_PERIOD_EXPIRED` | `on_hold` | ❌ false |
| Apple `EXPIRED` | `expired` | ❌ false |
| Google `IN_GRACE_PERIOD` (6) | `grace_period` | ✅ true |
| Google `ON_HOLD` (5) | `on_hold` | ❌ false |

`status` 라우트의 `active`는 `active || grace_period`. `on_hold`는 entitlement 회수 (사용자가 결제 수정 전까지).

## 주요 파일

- `packages/shared/src/types.ts` — `SubscriptionStatus` 타입, `AppleConsumptionRequest`/`AppleConsumptionContext` 타입, `OneSubServerConfig.apple.consumptionInfoProvider` hook
- `packages/shared/src/constants.ts` — `SUBSCRIPTION_STATUS.GRACE_PERIOD`, `ON_HOLD` 상수
- `packages/server/src/providers/apple.ts` — `mapAppleNotificationStatus` (간접: webhook), `makeAppleApiJwt`, `sendAppleConsumptionResponse`; `decodeAppleNotification`이 `bundleId`/`environment` 추가 노출
- `packages/server/src/providers/google.ts` — `isGoogleGracePeriodNotification`, `isGoogleOnHoldNotification`
- `packages/server/src/routes/webhook.ts` — Apple/Google 분기 + CONSUMPTION_REQUEST → provider 호출 + Apple PUT
- `packages/server/src/routes/status.ts` — `active = active || grace_period`

## Test plan

- [x] `npm run build` (모든 패키지)
- [x] `npm test` — 208/208 (lifecycle-states.test.ts 13개 신규)
- [ ] (수동) 실제 sandbox에서 결제 실패 → grace 진입 → on_hold 흐름 확인
- [ ] (수동) sandbox에서 환불 요청 → CONSUMPTION_REQUEST → provider 호출 + Apple PUT 200 확인

## Breaking changes

- `SubscriptionStatus` 타입에 멤버 추가. 호스트 앱이 `switch (status)` exhaustive로 다루고 있다면 새 case 추가 필요.
- `decodeAppleNotification` 반환 shape 확장 — onesub 내부 사용만, public export 아님.

## 참고

이 PR은 `feat(server): IAP 환불 처리 + Google ack 자동 호출` (commit 6ff50e2, master에 직접 commit) 위에 stack됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)