### PR TITLE
Apple Subscription Status API 직접 조회 + webhook 유실 복구

### DIFF
--- a/packages/server/src/__tests__/apple-status-api.test.ts
+++ b/packages/server/src/__tests__/apple-status-api.test.ts
@@ -1,0 +1,406 @@
+/**
+ * Tests for fetchAppleSubscriptionStatus + the Apple webhook unknown-tx fallback.
+ *
+ * Covers:
+ *   - status code 1..5 → SubscriptionStatus mapping
+ *   - sandbox vs production host routing
+ *   - missing API credentials → returns null (no throw)
+ *   - HTTP error / empty data → returns null
+ *   - webhook receives notification for unknown originalTransactionId →
+ *     calls Status API + saves the returned record
+ *   - webhook unknown tx without API creds → no fetch, just logs
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+import express from 'express';
+import { generateKeyPairSync } from 'crypto';
+import type { OneSubServerConfig, SubscriptionInfo } from '@onesub/shared';
+import { SUBSCRIPTION_STATUS } from '@onesub/shared';
+import { fetchAppleSubscriptionStatus } from '../providers/apple.js';
+import { createWebhookRouter } from '../routes/webhook.js';
+import { InMemorySubscriptionStore, InMemoryPurchaseStore } from '../store.js';
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+function makeJws(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'ES256' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.fakesig`;
+}
+
+let testEcKey: string;
+
+beforeAll(() => {
+  const { privateKey } = generateKeyPairSync('ec', { namedCurve: 'P-256' });
+  testEcKey = privateKey.export({ type: 'pkcs8', format: 'pem' }) as string;
+});
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+function appleConfigWithApi(overrides?: Partial<OneSubServerConfig['apple']>): NonNullable<OneSubServerConfig['apple']> {
+  return {
+    bundleId: 'com.example.app',
+    skipJwsVerification: true,
+    keyId: 'TESTKEY1',
+    issuerId: '12345678-1234-1234-1234-123456789012',
+    privateKey: testEcKey,
+    ...overrides,
+  };
+}
+
+/**
+ * Mock global fetch with localhost pass-through. Apple Status API requests
+ * resolve to the provided body; localhost (our test http server) is forwarded
+ * to the real fetch implementation.
+ */
+function mockAppleStatusFetch(responseBody: unknown, opts?: { status?: number }) {
+  const originalFetch = global.fetch;
+  const calls: { url: string; method?: string; headers?: Record<string, string> }[] = [];
+  vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+    const urlStr = String(url);
+    if (urlStr.startsWith('http://127.0.0.1') || urlStr.startsWith('http://localhost')) {
+      return originalFetch(url, init);
+    }
+    calls.push({
+      url: urlStr,
+      method: init?.method,
+      headers: init?.headers as Record<string, string>,
+    });
+    return {
+      ok: (opts?.status ?? 200) < 400,
+      status: opts?.status ?? 200,
+      json: async () => responseBody,
+      text: async () => JSON.stringify(responseBody),
+    } as Response;
+  });
+  return calls;
+}
+
+function makeStatusResponse(opts: {
+  originalTransactionId: string;
+  status: 1 | 2 | 3 | 4 | 5;
+  productId?: string;
+  expiresDate?: number;
+  autoRenewStatus?: 0 | 1;
+}) {
+  const tx = makeJws({
+    bundleId: 'com.example.app',
+    type: 'Auto-Renewable Subscription',
+    productId: opts.productId ?? 'pro_monthly',
+    transactionId: 'tx_inner',
+    originalTransactionId: opts.originalTransactionId,
+    purchaseDate: Date.now() - 30 * 86400000,
+    originalPurchaseDate: Date.now() - 30 * 86400000,
+    expiresDate: opts.expiresDate ?? Date.now() + 86400000,
+  });
+  const renewal = makeJws({ autoRenewStatus: opts.autoRenewStatus ?? 1 });
+  return {
+    bundleId: 'com.example.app',
+    environment: 'Production',
+    data: [{
+      subscriptionGroupIdentifier: 'group_a',
+      lastTransactions: [{
+        originalTransactionId: opts.originalTransactionId,
+        status: opts.status,
+        signedTransactionInfo: tx,
+        signedRenewalInfo: renewal,
+      }],
+    }],
+  };
+}
+
+// ── fetchAppleSubscriptionStatus unit tests ─────────────────────────────────
+
+describe('fetchAppleSubscriptionStatus', () => {
+  it('returns null when API credentials are missing', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch');
+    const result = await fetchAppleSubscriptionStatus('orig_xyz', {
+      bundleId: 'com.example.app',
+      skipJwsVerification: true,
+    });
+    expect(result).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns null when mockMode is enabled', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch');
+    const result = await fetchAppleSubscriptionStatus('orig_xyz', appleConfigWithApi({ mockMode: true }));
+    expect(result).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('GET .../inApps/v1/subscriptions/<id> with Bearer JWT', async () => {
+    const calls = mockAppleStatusFetch(makeStatusResponse({
+      originalTransactionId: 'orig_active',
+      status: 1,
+    }));
+
+    await fetchAppleSubscriptionStatus('orig_active', appleConfigWithApi());
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toContain('api.storekit.itunes.apple.com');
+    expect(calls[0].url).toContain('/inApps/v1/subscriptions/orig_active');
+    expect(calls[0].headers?.Authorization).toMatch(/^Bearer /);
+  });
+
+  it('routes to sandbox host when options.sandbox is true', async () => {
+    const calls = mockAppleStatusFetch(makeStatusResponse({
+      originalTransactionId: 'orig_sb',
+      status: 1,
+    }));
+
+    await fetchAppleSubscriptionStatus('orig_sb', appleConfigWithApi(), { sandbox: true });
+
+    expect(calls[0].url).toContain('api.storekit-sandbox.itunes.apple.com');
+  });
+
+  it('maps status code 1 → active', async () => {
+    mockAppleStatusFetch(makeStatusResponse({ originalTransactionId: 'o1', status: 1 }));
+    const result = await fetchAppleSubscriptionStatus('o1', appleConfigWithApi());
+    expect(result?.status).toBe(SUBSCRIPTION_STATUS.ACTIVE);
+  });
+
+  it('maps status code 2 → expired', async () => {
+    mockAppleStatusFetch(makeStatusResponse({ originalTransactionId: 'o2', status: 2 }));
+    const result = await fetchAppleSubscriptionStatus('o2', appleConfigWithApi());
+    expect(result?.status).toBe(SUBSCRIPTION_STATUS.EXPIRED);
+  });
+
+  it('maps status code 3 → on_hold (billing retry)', async () => {
+    mockAppleStatusFetch(makeStatusResponse({ originalTransactionId: 'o3', status: 3 }));
+    const result = await fetchAppleSubscriptionStatus('o3', appleConfigWithApi());
+    expect(result?.status).toBe(SUBSCRIPTION_STATUS.ON_HOLD);
+  });
+
+  it('maps status code 4 → grace_period', async () => {
+    mockAppleStatusFetch(makeStatusResponse({ originalTransactionId: 'o4', status: 4 }));
+    const result = await fetchAppleSubscriptionStatus('o4', appleConfigWithApi());
+    expect(result?.status).toBe(SUBSCRIPTION_STATUS.GRACE_PERIOD);
+  });
+
+  it('maps status code 5 → canceled (revoked)', async () => {
+    mockAppleStatusFetch(makeStatusResponse({ originalTransactionId: 'o5', status: 5 }));
+    const result = await fetchAppleSubscriptionStatus('o5', appleConfigWithApi());
+    expect(result?.status).toBe(SUBSCRIPTION_STATUS.CANCELED);
+  });
+
+  it('reads autoRenewStatus from signedRenewalInfo for willRenew', async () => {
+    mockAppleStatusFetch(makeStatusResponse({
+      originalTransactionId: 'o_renew',
+      status: 1,
+      autoRenewStatus: 0,
+    }));
+    const result = await fetchAppleSubscriptionStatus('o_renew', appleConfigWithApi());
+    expect(result?.willRenew).toBe(false);
+  });
+
+  it('returns null on HTTP 404', async () => {
+    mockAppleStatusFetch({ errorCode: 4040010 }, { status: 404 });
+    const result = await fetchAppleSubscriptionStatus('not_found', appleConfigWithApi());
+    expect(result).toBeNull();
+  });
+
+  it('returns null when data array is empty', async () => {
+    mockAppleStatusFetch({ bundleId: 'com.example.app', environment: 'Production', data: [] });
+    const result = await fetchAppleSubscriptionStatus('orig_empty', appleConfigWithApi());
+    expect(result).toBeNull();
+  });
+
+  it('returns null when matching originalTransactionId not in lastTransactions', async () => {
+    mockAppleStatusFetch({
+      bundleId: 'com.example.app',
+      environment: 'Production',
+      data: [{
+        subscriptionGroupIdentifier: 'g',
+        lastTransactions: [{
+          originalTransactionId: 'different_id',
+          status: 1,
+          signedTransactionInfo: makeJws({ productId: 'p', expiresDate: Date.now() }),
+        }],
+      }],
+    });
+    const result = await fetchAppleSubscriptionStatus('expected_id', appleConfigWithApi());
+    expect(result).toBeNull();
+  });
+
+  it('preserves originalTransactionId from caller (not from inner JWS)', async () => {
+    mockAppleStatusFetch(makeStatusResponse({
+      originalTransactionId: 'orig_caller',
+      status: 1,
+    }));
+    const result = await fetchAppleSubscriptionStatus('orig_caller', appleConfigWithApi());
+    expect(result?.originalTransactionId).toBe('orig_caller');
+  });
+});
+
+// ── webhook unknown-transaction fallback ────────────────────────────────────
+
+interface TestServer {
+  request: (path: string, body: unknown) => Promise<{ status: number; body: unknown }>;
+}
+
+function buildAppleWebhookServer(config: OneSubServerConfig): {
+  store: InMemorySubscriptionStore;
+  server: TestServer;
+} {
+  const store = new InMemorySubscriptionStore();
+  const purchaseStore = new InMemoryPurchaseStore();
+  const app = express();
+  app.use(express.json());
+  app.use(createWebhookRouter(config, store, purchaseStore));
+  return {
+    store,
+    server: {
+      async request(path, body) {
+        const httpServer = app.listen(0);
+        const address = httpServer.address();
+        const port = typeof address === 'object' && address ? address.port : 0;
+        try {
+          const resp = await fetch(`http://127.0.0.1:${port}${path}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+          });
+          const text = await resp.text();
+          let parsed: unknown = text;
+          try { parsed = JSON.parse(text); } catch { /* keep as text */ }
+          return { status: resp.status, body: parsed };
+        } finally {
+          await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+        }
+      },
+    },
+  };
+}
+
+function buildUnknownTxNotification(originalTransactionId: string, opts?: { sandbox?: boolean }): unknown {
+  const signedTransactionInfo = makeJws({
+    bundleId: 'com.example.app',
+    type: 'Auto-Renewable Subscription',
+    productId: 'pro_monthly',
+    transactionId: 'tx_notify',
+    originalTransactionId,
+    purchaseDate: Date.now(),
+    expiresDate: Date.now() + 86400000,
+    environment: opts?.sandbox ? 'Sandbox' : 'Production',
+  });
+  return {
+    signedPayload: makeJws({
+      notificationType: 'DID_RENEW',
+      data: {
+        signedTransactionInfo,
+        signedRenewalInfo: makeJws({ autoRenewStatus: 1 }),
+      },
+    }),
+  };
+}
+
+describe('Apple webhook — unknown originalTransactionId fallback', () => {
+  it('fetches from Status API and saves a placeholder record when API creds present', async () => {
+    mockAppleStatusFetch(makeStatusResponse({
+      originalTransactionId: 'orig_unknown',
+      status: 1,
+    }));
+
+    const config: OneSubServerConfig = {
+      apple: appleConfigWithApi(),
+      database: { url: '' },
+    };
+    const { store, server } = buildAppleWebhookServer(config);
+
+    const resp = await server.request('/onesub/webhook/apple', buildUnknownTxNotification('orig_unknown'));
+    expect(resp.status).toBe(200);
+
+    const saved = await store.getByTransactionId('orig_unknown');
+    expect(saved).not.toBeNull();
+    expect(saved?.status).toBe(SUBSCRIPTION_STATUS.ACTIVE);
+    // userId is unknown at webhook time — placeholder is the originalTransactionId
+    expect(saved?.userId).toBe('orig_unknown');
+  });
+
+  it('routes to sandbox host when notification environment is Sandbox', async () => {
+    const calls = mockAppleStatusFetch(makeStatusResponse({
+      originalTransactionId: 'orig_sb_unknown',
+      status: 1,
+    }));
+
+    const config: OneSubServerConfig = {
+      apple: appleConfigWithApi(),
+      database: { url: '' },
+    };
+    const { server } = buildAppleWebhookServer(config);
+
+    await server.request(
+      '/onesub/webhook/apple',
+      buildUnknownTxNotification('orig_sb_unknown', { sandbox: true }),
+    );
+
+    const apiCall = calls.find((c) => c.url.includes('/inApps/v1/subscriptions/'));
+    expect(apiCall?.url).toContain('api.storekit-sandbox.itunes.apple.com');
+  });
+
+  it('does not call Status API when issuerId/keyId/privateKey are missing', async () => {
+    const originalFetch = global.fetch;
+    const outboundCalls: { url: string }[] = [];
+    vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+      const urlStr = String(url);
+      if (urlStr.startsWith('http://127.0.0.1') || urlStr.startsWith('http://localhost')) {
+        return originalFetch(url, init);
+      }
+      outboundCalls.push({ url: urlStr });
+      return { ok: true, status: 200, json: async () => ({}), text: async () => '' } as Response;
+    });
+
+    const config: OneSubServerConfig = {
+      apple: { bundleId: 'com.example.app', skipJwsVerification: true }, // no API creds
+      database: { url: '' },
+    };
+    const { store, server } = buildAppleWebhookServer(config);
+
+    const resp = await server.request('/onesub/webhook/apple', buildUnknownTxNotification('orig_no_creds'));
+    expect(resp.status).toBe(200);
+    expect(await store.getByTransactionId('orig_no_creds')).toBeNull();
+    expect(outboundCalls).toHaveLength(0);
+  });
+
+  it('does not overwrite an existing record (still the normal update path)', async () => {
+    const originalFetch = global.fetch;
+    const outboundCalls: { url: string }[] = [];
+    vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+      const urlStr = String(url);
+      if (urlStr.startsWith('http://127.0.0.1') || urlStr.startsWith('http://localhost')) {
+        return originalFetch(url, init);
+      }
+      outboundCalls.push({ url: urlStr });
+      return { ok: true, status: 200, json: async () => ({}), text: async () => '' } as Response;
+    });
+
+    const config: OneSubServerConfig = {
+      apple: appleConfigWithApi(),
+      database: { url: '' },
+    };
+    const { store, server } = buildAppleWebhookServer(config);
+
+    const existing: SubscriptionInfo = {
+      userId: 'real_user',
+      productId: 'pro_monthly',
+      platform: 'apple',
+      status: SUBSCRIPTION_STATUS.ACTIVE,
+      expiresAt: '2027-01-01T00:00:00.000Z',
+      originalTransactionId: 'orig_known',
+      purchasedAt: '2026-01-01T00:00:00.000Z',
+      willRenew: true,
+    };
+    await store.save(existing);
+
+    const resp = await server.request('/onesub/webhook/apple', buildUnknownTxNotification('orig_known'));
+    expect(resp.status).toBe(200);
+
+    // Existing record's userId preserved (not replaced with placeholder)
+    expect((await store.getByTransactionId('orig_known'))?.userId).toBe('real_user');
+    // No outbound Status API call since we already had the record
+    expect(outboundCalls.find((c) => c.url.includes('/inApps/v1/subscriptions/'))).toBeUndefined();
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -104,7 +104,7 @@ export type { SubscriptionStore, PurchaseStore } from './store.js';
 export { PostgresSubscriptionStore, PostgresPurchaseStore } from './stores/postgres.js';
 
 // Provider functions for direct (non-HTTP) usage
-export { validateAppleReceipt } from './providers/apple.js';
+export { validateAppleReceipt, fetchAppleSubscriptionStatus } from './providers/apple.js';
 export { validateGoogleReceipt } from './providers/google.js';
 
 // Logger plumbing — expose so non-middleware callers (direct provider use)

--- a/packages/server/src/providers/apple.ts
+++ b/packages/server/src/providers/apple.ts
@@ -471,3 +471,149 @@ export async function sendAppleConsumptionResponse(
     log.warn('[onesub/apple] Consumption response network error:', err);
   }
 }
+
+/**
+ * Apple's status code in the GET /inApps/v1/subscriptions/{originalTxId} response.
+ * https://developer.apple.com/documentation/appstoreserverapi/status
+ */
+const APPLE_SUBSCRIPTION_STATUS_CODE = {
+  ACTIVE: 1,
+  EXPIRED: 2,
+  BILLING_RETRY: 3,
+  GRACE_PERIOD: 4,
+  REVOKED: 5,
+} as const;
+
+function mapAppleStatusCode(code: number): SubscriptionInfo['status'] {
+  switch (code) {
+    case APPLE_SUBSCRIPTION_STATUS_CODE.ACTIVE:
+      return SUBSCRIPTION_STATUS.ACTIVE;
+    case APPLE_SUBSCRIPTION_STATUS_CODE.GRACE_PERIOD:
+      return SUBSCRIPTION_STATUS.GRACE_PERIOD;
+    case APPLE_SUBSCRIPTION_STATUS_CODE.BILLING_RETRY:
+      return SUBSCRIPTION_STATUS.ON_HOLD;
+    case APPLE_SUBSCRIPTION_STATUS_CODE.REVOKED:
+      return SUBSCRIPTION_STATUS.CANCELED;
+    case APPLE_SUBSCRIPTION_STATUS_CODE.EXPIRED:
+    default:
+      return SUBSCRIPTION_STATUS.EXPIRED;
+  }
+}
+
+/**
+ * Shape of the GET /inApps/v1/subscriptions/{originalTransactionId} response.
+ * Only the fields we read.
+ */
+interface AppleSubscriptionStatusResponse {
+  data?: Array<{
+    subscriptionGroupIdentifier?: string;
+    lastTransactions?: Array<{
+      originalTransactionId?: string;
+      status?: number;
+      signedTransactionInfo?: string;
+      signedRenewalInfo?: string;
+    }>;
+  }>;
+  bundleId?: string;
+  environment?: 'Production' | 'Sandbox';
+}
+
+/**
+ * Fetch the current state of a subscription directly from Apple's App Store
+ * Server API — the canonical source of truth when webhooks have been missed,
+ * delivered out of order, or the local store has no record at all.
+ *
+ * GET /inApps/v1/subscriptions/{originalTransactionId}
+ * https://developer.apple.com/documentation/appstoreserverapi/get_all_subscription_statuses
+ *
+ * Returns null on:
+ *   - Missing API credentials (issuerId/keyId/privateKey)
+ *   - Network or auth failure
+ *   - Empty response (transaction not found)
+ *
+ * Hosts can call this directly (e.g. from a reconciliation cron) or it runs
+ * automatically as the unknown-transaction fallback inside the Apple webhook.
+ */
+export async function fetchAppleSubscriptionStatus(
+  originalTransactionId: string,
+  config: AppleConfig,
+  options?: { sandbox?: boolean },
+): Promise<SubscriptionInfo | null> {
+  if (config.mockMode) return null;
+
+  let jwt: string;
+  try {
+    jwt = await makeAppleApiJwt(config);
+  } catch (err) {
+    log.warn('[onesub/apple] Cannot fetch subscription status — JWT mint failed:', err);
+    return null;
+  }
+
+  const host = options?.sandbox
+    ? 'api.storekit-sandbox.itunes.apple.com'
+    : 'api.storekit.itunes.apple.com';
+  const url = `https://${host}/inApps/v1/subscriptions/${encodeURIComponent(originalTransactionId)}`;
+
+  let body: AppleSubscriptionStatusResponse;
+  try {
+    const resp = await fetch(url, {
+      headers: { Authorization: `Bearer ${jwt}` },
+    });
+    if (!resp.ok) {
+      const text = await resp.text();
+      log.warn(`[onesub/apple] Status API error ${resp.status}: ${text}`);
+      return null;
+    }
+    body = (await resp.json()) as AppleSubscriptionStatusResponse;
+  } catch (err) {
+    log.warn('[onesub/apple] Status API network error:', err);
+    return null;
+  }
+
+  // Find the lastTransactions entry matching the requested originalTransactionId.
+  // Apple groups by subscriptionGroupIdentifier; one originalTxId is in exactly one group.
+  const entry = body.data
+    ?.flatMap((g) => g.lastTransactions ?? [])
+    .find((t) => t.originalTransactionId === originalTransactionId);
+
+  if (!entry || entry.status == null || !entry.signedTransactionInfo) {
+    log.warn('[onesub/apple] Status API returned no matching transaction for', originalTransactionId);
+    return null;
+  }
+
+  let tx: AppleTransactionPayload;
+  try {
+    tx = await decodeJws<AppleTransactionPayload>(entry.signedTransactionInfo, config.skipJwsVerification);
+  } catch (err) {
+    log.warn('[onesub/apple] Failed to decode signedTransactionInfo from Status API:', err);
+    return null;
+  }
+
+  let renewal: AppleRenewalPayload | null = null;
+  if (entry.signedRenewalInfo) {
+    try {
+      renewal = await decodeJws<AppleRenewalPayload>(entry.signedRenewalInfo, config.skipJwsVerification);
+    } catch {
+      // renewal info is optional
+    }
+  }
+
+  if (!tx.productId || !tx.expiresDate) {
+    log.warn('[onesub/apple] Status API transaction missing productId or expiresDate');
+    return null;
+  }
+
+  const status = mapAppleStatusCode(entry.status);
+  const purchasedAt = tx.originalPurchaseDate ?? tx.purchaseDate ?? Date.now();
+
+  return {
+    userId: '',  // caller fills this in
+    productId: tx.productId,
+    platform: 'apple',
+    status,
+    expiresAt: new Date(tx.expiresDate).toISOString(),
+    originalTransactionId,
+    purchasedAt: new Date(purchasedAt).toISOString(),
+    willRenew: renewal?.autoRenewStatus === 1,
+  };
+}

--- a/packages/server/src/routes/webhook.ts
+++ b/packages/server/src/routes/webhook.ts
@@ -9,7 +9,12 @@ import type {
 } from '@onesub/shared';
 import { ROUTES, SUBSCRIPTION_STATUS, ONESUB_ERROR_CODE } from '@onesub/shared';
 import type { SubscriptionStore, PurchaseStore } from '../store.js';
-import { decodeAppleNotification, decodeJws, sendAppleConsumptionResponse } from '../providers/apple.js';
+import {
+  decodeAppleNotification,
+  decodeJws,
+  sendAppleConsumptionResponse,
+  fetchAppleSubscriptionStatus,
+} from '../providers/apple.js';
 import {
   decodeGoogleNotification,
   decodeGoogleVoidedNotification,
@@ -268,11 +273,29 @@ export function createWebhookRouter(
           expiresAt: expiresAt ?? existing.expiresAt,
         };
         await store.save(updated);
+      } else if (config.apple?.issuerId && config.apple?.keyId && config.apple?.privateKey) {
+        // No local record but App Store Server API credentials are present —
+        // fetch the canonical state from Apple. This recovers from missed
+        // webhooks (server downtime, queue truncation) and bootstraps
+        // subscriptions purchased before this server existed.
+        // userId is unknown at webhook time — store under originalTransactionId
+        // as placeholder so a later /onesub/validate call can claim ownership.
+        const fresh = await fetchAppleSubscriptionStatus(originalTransactionId, config.apple, {
+          sandbox: environment === 'Sandbox',
+        });
+        if (fresh) {
+          fresh.userId = originalTransactionId;
+          await store.save(fresh);
+        } else {
+          log.warn(
+            '[onesub/webhook/apple] Unknown transaction and Status API returned no record:',
+            originalTransactionId,
+          );
+        }
       } else {
-        // We have no record of this transaction — log and acknowledge.
-        // This can happen for purchases made before the server started.
+        // No local record and no API credentials to re-fetch — log and ack.
         log.warn(
-          '[onesub/webhook/apple] Received notification for unknown transaction:',
+          '[onesub/webhook/apple] Received notification for unknown transaction (no API creds to recover):',
           originalTransactionId
         );
       }


### PR DESCRIPTION
## Summary

- Apple App Store Server API의 `GET /inApps/v1/subscriptions/{originalTransactionId}` 호출 함수 `fetchAppleSubscriptionStatus` 추가
- Apple webhook이 모르는 `originalTransactionId` 받았을 때 자동 fallback fetch — webhook 유실/순서 꼬임 복구
- Apple status code 1~5를 PR #24에서 만든 새 lifecycle 상태로 매핑

## 왜 필요한가

지금까지는 webhook이 truth source였는데, webhook이 유실되면(서버 다운, 큐 만료, 신규 환경) 영구적으로 데이터 불일치. 이 PR로 Apple 자체에 직접 조회해서 복구 가능.

## status code 매핑

| Apple status | onesub status |
|--------------|---------------|
| 1 (Active) | `active` |
| 2 (Expired) | `expired` |
| 3 (Billing Retry) | `on_hold` |
| 4 (Grace Period) | `grace_period` |
| 5 (Revoked) | `canceled` |

## 사용처

1. **자동**: webhook이 unknown `originalTransactionId` 알림 받으면 (API 자격증명 있을 때) 자동으로 fetch → SubscriptionStore 저장. userId는 placeholder로 두고 추후 `/onesub/validate` 호출 시 claim.
2. **수동**: `fetchAppleSubscriptionStatus` 함수 export — 호스트가 cron, 관리자 동기화 등에서 직접 호출 가능.

## 주요 파일

- `packages/server/src/providers/apple.ts` — `fetchAppleSubscriptionStatus`, `mapAppleStatusCode`, `APPLE_SUBSCRIPTION_STATUS_CODE`
- `packages/server/src/routes/webhook.ts` — unknown-tx 분기에 `fetchAppleSubscriptionStatus` fallback
- `packages/server/src/index.ts` — public export

## Test plan

- [x] `npm run build` 전체 패키지
- [x] `npm test` — 226/226 (apple-status-api.test.ts 18개 신규)
- [x] status code 1~5 매핑 단위 테스트
- [x] sandbox vs production host 라우팅
- [x] 자격증명 누락 시 null 반환 (no throw)
- [x] HTTP 4xx / 빈 data → null
- [x] webhook unknown tx + 자격증명 있음 → fetch + 저장
- [x] webhook unknown tx + 자격증명 없음 → fetch 안 함, 기존 동작
- [x] webhook 기존 record 있음 → fetch 안 함 (덮어쓰기 방지)

## Breaking changes

없음. 추가 기능만.

🤖 Generated with [Claude Code](https://claude.com/claude-code)