### PR TITLE
Google Play subscriptions v1 → subscriptionsv2 마이그레이션

### DIFF
--- a/packages/server/src/__tests__/google-subscriptions-v2.test.ts
+++ b/packages/server/src/__tests__/google-subscriptions-v2.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Tests for the validateGoogleReceipt v1 → v2 migration.
+ *
+ * Covers:
+ *   - Calls purchases.subscriptionsv2 endpoint (no productId in URL)
+ *   - subscriptionState string enum → onesub SubscriptionStatus mapping
+ *   - lineItems productId match (success / mismatch)
+ *   - autoRenewingPlan.autoRenewEnabled → willRenew
+ *   - latestOrderId → originalTransactionId
+ *   - PENDING / UNSPECIFIED states rejected (return null)
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+import { generateKeyPairSync } from 'crypto';
+import { validateGoogleReceipt } from '../providers/google.js';
+import { SUBSCRIPTION_STATUS } from '@onesub/shared';
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+let testPrivateKey: string;
+
+beforeAll(() => {
+  const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 1024 });
+  testPrivateKey = privateKey.export({ type: 'pkcs8', format: 'pem' }) as string;
+});
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeGoogleConfig() {
+  return {
+    packageName: 'com.example.app',
+    serviceAccountKey: JSON.stringify({
+      client_email: `test-${Math.random()}@test.iam.gserviceaccount.com`,
+      private_key: testPrivateKey,
+      token_uri: 'https://oauth2.googleapis.com/token',
+    }),
+  };
+}
+
+interface V2Response {
+  startTime?: string;
+  subscriptionState?: string;
+  latestOrderId?: string;
+  linkedPurchaseToken?: string;
+  acknowledgementState?: string;
+  lineItems?: Array<{
+    productId?: string;
+    expiryTime?: string;
+    autoRenewingPlan?: { autoRenewEnabled?: boolean };
+  }>;
+}
+
+function mockV2Fetch(responseBody: V2Response, opts?: { status?: number }) {
+  const calls: { url: string }[] = [];
+  vi.spyOn(global, 'fetch').mockImplementation(async (url) => {
+    const urlStr = String(url);
+    if (urlStr.includes('oauth2.googleapis.com')) {
+      return {
+        ok: true,
+        json: async () => ({ access_token: 'tok', expires_in: 3600 }),
+        text: async () => '',
+      } as Response;
+    }
+    calls.push({ url: urlStr });
+    return {
+      ok: (opts?.status ?? 200) < 400,
+      status: opts?.status ?? 200,
+      json: async () => responseBody,
+      text: async () => JSON.stringify(responseBody),
+    } as Response;
+  });
+  return calls;
+}
+
+function v2Active(productId = 'pro_monthly'): V2Response {
+  return {
+    startTime: '2026-01-01T00:00:00Z',
+    subscriptionState: 'SUBSCRIPTION_STATE_ACTIVE',
+    latestOrderId: 'GPA.1234-5678-9012-12345',
+    acknowledgementState: 'ACKNOWLEDGEMENT_STATE_ACKNOWLEDGED',
+    lineItems: [{
+      productId,
+      expiryTime: '2027-01-01T00:00:00Z',
+      autoRenewingPlan: { autoRenewEnabled: true },
+    }],
+  };
+}
+
+// ── URL shape ───────────────────────────────────────────────────────────────
+
+describe('validateGoogleReceipt — v2 endpoint', () => {
+  it('calls purchases.subscriptionsv2 (token only, no productId in URL)', async () => {
+    const calls = mockV2Fetch(v2Active('pro_monthly'));
+
+    await validateGoogleReceipt('purchase_token_xyz', 'pro_monthly', makeGoogleConfig());
+
+    const apiCall = calls.find((c) => c.url.includes('androidpublisher.googleapis.com'));
+    expect(apiCall).toBeDefined();
+    expect(apiCall?.url).toContain('/purchases/subscriptionsv2/tokens/purchase_token_xyz');
+    expect(apiCall?.url).not.toContain('/purchases/subscriptions/');
+  });
+});
+
+// ── subscriptionState mapping ───────────────────────────────────────────────
+
+describe('validateGoogleReceipt — subscriptionState mapping', () => {
+  const cases: Array<[string, string]> = [
+    ['SUBSCRIPTION_STATE_ACTIVE', SUBSCRIPTION_STATUS.ACTIVE],
+    ['SUBSCRIPTION_STATE_IN_GRACE_PERIOD', SUBSCRIPTION_STATUS.GRACE_PERIOD],
+    ['SUBSCRIPTION_STATE_ON_HOLD', SUBSCRIPTION_STATUS.ON_HOLD],
+    ['SUBSCRIPTION_STATE_PAUSED', SUBSCRIPTION_STATUS.ON_HOLD],
+    ['SUBSCRIPTION_STATE_CANCELED', SUBSCRIPTION_STATUS.CANCELED],
+    ['SUBSCRIPTION_STATE_EXPIRED', SUBSCRIPTION_STATUS.EXPIRED],
+  ];
+
+  for (const [state, expected] of cases) {
+    it(`${state} → ${expected}`, async () => {
+      mockV2Fetch({ ...v2Active('pro_monthly'), subscriptionState: state });
+      const result = await validateGoogleReceipt('tok', 'pro_monthly', makeGoogleConfig());
+      expect(result?.status).toBe(expected);
+    });
+  }
+
+  it('SUBSCRIPTION_STATE_PENDING → null (entitlement not yet granted)', async () => {
+    mockV2Fetch({ ...v2Active('pro_monthly'), subscriptionState: 'SUBSCRIPTION_STATE_PENDING' });
+    const result = await validateGoogleReceipt('tok', 'pro_monthly', makeGoogleConfig());
+    expect(result).toBeNull();
+  });
+
+  it('SUBSCRIPTION_STATE_UNSPECIFIED → null', async () => {
+    mockV2Fetch({ ...v2Active('pro_monthly'), subscriptionState: 'SUBSCRIPTION_STATE_UNSPECIFIED' });
+    const result = await validateGoogleReceipt('tok', 'pro_monthly', makeGoogleConfig());
+    expect(result).toBeNull();
+  });
+
+  it('unknown state string → null', async () => {
+    mockV2Fetch({ ...v2Active('pro_monthly'), subscriptionState: 'SOMETHING_NEW_FROM_GOOGLE' });
+    const result = await validateGoogleReceipt('tok', 'pro_monthly', makeGoogleConfig());
+    expect(result).toBeNull();
+  });
+});
+
+// ── lineItems productId matching ────────────────────────────────────────────
+
+describe('validateGoogleReceipt — lineItems productId match', () => {
+  it('returns null when no lineItem matches the requested productId', async () => {
+    mockV2Fetch(v2Active('different_product'));
+    const result = await validateGoogleReceipt('tok', 'pro_monthly', makeGoogleConfig());
+    expect(result).toBeNull();
+  });
+
+  it('returns null when lineItems is empty', async () => {
+    mockV2Fetch({ ...v2Active(), lineItems: [] });
+    const result = await validateGoogleReceipt('tok', 'pro_monthly', makeGoogleConfig());
+    expect(result).toBeNull();
+  });
+
+  it('picks the matching lineItem when multiple are present (multi-product)', async () => {
+    mockV2Fetch({
+      ...v2Active(),
+      lineItems: [
+        { productId: 'addon_a', expiryTime: '2099-01-01T00:00:00Z', autoRenewingPlan: { autoRenewEnabled: true } },
+        { productId: 'pro_monthly', expiryTime: '2027-06-01T00:00:00Z', autoRenewingPlan: { autoRenewEnabled: true } },
+        { productId: 'addon_b', expiryTime: '2099-12-31T00:00:00Z', autoRenewingPlan: { autoRenewEnabled: false } },
+      ],
+    });
+    const result = await validateGoogleReceipt('tok', 'pro_monthly', makeGoogleConfig());
+    expect(result).not.toBeNull();
+    expect(result?.productId).toBe('pro_monthly');
+    expect(result?.expiresAt).toBe('2027-06-01T00:00:00Z');
+    expect(result?.willRenew).toBe(true);
+  });
+});
+
+// ── field mapping ───────────────────────────────────────────────────────────
+
+describe('validateGoogleReceipt — field mapping', () => {
+  it('uses latestOrderId as originalTransactionId', async () => {
+    mockV2Fetch({ ...v2Active('pro_monthly'), latestOrderId: 'GPA.canonical-order-id' });
+    const result = await validateGoogleReceipt('tok', 'pro_monthly', makeGoogleConfig());
+    expect(result?.originalTransactionId).toBe('GPA.canonical-order-id');
+  });
+
+  it('falls back to truncated purchaseToken when latestOrderId is absent', async () => {
+    const noOrder = v2Active('pro_monthly');
+    delete noOrder.latestOrderId;
+    mockV2Fetch(noOrder);
+    const result = await validateGoogleReceipt('a-very-very-long-token-' + 'x'.repeat(100), 'pro_monthly', makeGoogleConfig());
+    expect(result?.originalTransactionId).toBeDefined();
+    expect(result?.originalTransactionId.length).toBeLessThanOrEqual(64);
+  });
+
+  it('autoRenewEnabled false → willRenew false', async () => {
+    mockV2Fetch({
+      ...v2Active(),
+      lineItems: [{
+        productId: 'pro_monthly',
+        expiryTime: '2027-01-01T00:00:00Z',
+        autoRenewingPlan: { autoRenewEnabled: false },
+      }],
+    });
+    const result = await validateGoogleReceipt('tok', 'pro_monthly', makeGoogleConfig());
+    expect(result?.willRenew).toBe(false);
+  });
+
+  it('missing autoRenewingPlan → willRenew false', async () => {
+    mockV2Fetch({
+      ...v2Active(),
+      lineItems: [{ productId: 'pro_monthly', expiryTime: '2027-01-01T00:00:00Z' }],
+    });
+    const result = await validateGoogleReceipt('tok', 'pro_monthly', makeGoogleConfig());
+    expect(result?.willRenew).toBe(false);
+  });
+
+  it('uses lineItem.expiryTime for expiresAt and startTime for purchasedAt', async () => {
+    mockV2Fetch({
+      startTime: '2025-12-01T10:00:00Z',
+      subscriptionState: 'SUBSCRIPTION_STATE_ACTIVE',
+      latestOrderId: 'GPA.x',
+      lineItems: [{
+        productId: 'pro_monthly',
+        expiryTime: '2026-12-01T10:00:00Z',
+        autoRenewingPlan: { autoRenewEnabled: true },
+      }],
+    });
+    const result = await validateGoogleReceipt('tok', 'pro_monthly', makeGoogleConfig());
+    expect(result?.purchasedAt).toBe('2025-12-01T10:00:00Z');
+    expect(result?.expiresAt).toBe('2026-12-01T10:00:00Z');
+  });
+});
+
+// ── error paths ─────────────────────────────────────────────────────────────
+
+describe('validateGoogleReceipt — error paths', () => {
+  it('returns null on Play API error response', async () => {
+    mockV2Fetch({}, { status: 410 });
+    const result = await validateGoogleReceipt('tok', 'pro_monthly', makeGoogleConfig());
+    expect(result).toBeNull();
+  });
+
+  it('returns null when serviceAccountKey is missing', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch');
+    const result = await validateGoogleReceipt('tok', 'pro_monthly', { packageName: 'com.example.app' });
+    expect(result).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/providers/google.ts
+++ b/packages/server/src/providers/google.ts
@@ -9,23 +9,51 @@ import {
 type GoogleConfig = NonNullable<OneSubServerConfig['google']>;
 
 /**
- * Google Play Developer API v3 — SubscriptionPurchase resource (partial).
- * https://developers.google.com/android-publisher/api-ref/rest/v3/purchases.subscriptions
+ * Google Play Developer API v3 — SubscriptionPurchaseV2 resource (partial).
+ * https://developers.google.com/android-publisher/api-ref/rest/v3/purchases.subscriptionsv2/get
+ *
+ * V2 differences from the deprecated V1 (purchases.subscriptions):
+ *   - URL doesn't take productId — one token can map to multiple lineItems
+ *   - subscriptionState is a string enum (explicit grace/hold/paused) instead
+ *     of being inferred from expiryTime
+ *   - lineItems[] carries per-product productId + expiryTime + autoRenewingPlan
+ *   - linkedPurchaseToken first-class (upgrade/downgrade chain tracking)
+ *   - latestOrderId replaces orderId as the canonical transaction id
  */
-interface GoogleSubscriptionPurchase {
-  kind?: string;                   // 'androidpublisher#subscriptionPurchase'
-  startTimeMillis?: string;
-  expiryTimeMillis?: string;
-  autoRenewing?: boolean;
-  priceCurrencyCode?: string;
-  priceAmountMicros?: string;
-  cancelReason?: number;           // 0=User, 1=System, 2=Replaced, 3=Developer
-  paymentState?: number;           // 0=Pending, 1=Received, 2=Free trial, 3=Deferred
-  cancelSurveyResult?: unknown;
-  purchaseType?: number;           // 0=Test, 1=Promo
-  acknowledgementState?: number;   // 0=Yet to be acknowledged, 1=Acknowledged
-  orderId?: string;
+interface GoogleSubscriptionPurchaseV2 {
+  kind?: string;                   // 'androidpublisher#subscriptionPurchaseV2'
+  startTime?: string;              // RFC3339 (ISO 8601)
+  regionCode?: string;
+  lineItems?: Array<{
+    productId?: string;
+    expiryTime?: string;           // RFC3339
+    autoRenewingPlan?: {
+      autoRenewEnabled?: boolean;
+      priceChangeDetails?: unknown;
+    };
+    prepaidPlan?: {
+      allowExtendAfterTime?: string;
+    };
+    offerDetails?: unknown;
+  }>;
+  subscriptionState?:
+    | 'SUBSCRIPTION_STATE_UNSPECIFIED'
+    | 'SUBSCRIPTION_STATE_PENDING'
+    | 'SUBSCRIPTION_STATE_ACTIVE'
+    | 'SUBSCRIPTION_STATE_PAUSED'
+    | 'SUBSCRIPTION_STATE_IN_GRACE_PERIOD'
+    | 'SUBSCRIPTION_STATE_ON_HOLD'
+    | 'SUBSCRIPTION_STATE_CANCELED'
+    | 'SUBSCRIPTION_STATE_EXPIRED';
+  latestOrderId?: string;
   linkedPurchaseToken?: string;
+  acknowledgementState?:
+    | 'ACKNOWLEDGEMENT_STATE_UNSPECIFIED'
+    | 'ACKNOWLEDGEMENT_STATE_PENDING'
+    | 'ACKNOWLEDGEMENT_STATE_ACKNOWLEDGED';
+  pausedStateContext?: { autoResumeTime?: string };
+  canceledStateContext?: unknown;
+  testPurchase?: unknown;
   [key: string]: unknown;
 }
 
@@ -186,15 +214,20 @@ async function getAccessToken(serviceAccountKey: string): Promise<string> {
 }
 
 /**
- * Fetch a subscription purchase from the Google Play Developer API.
+ * Fetch a subscription purchase from the Google Play Developer API
+ * (purchases.subscriptionsv2.get). The v2 endpoint takes only the purchaseToken
+ * — the productId comes back in lineItems, which lets one token represent a
+ * multi-product subscription.
  */
-async function fetchSubscriptionPurchase(
+async function fetchSubscriptionPurchaseV2(
   packageName: string,
-  productId: string,
   purchaseToken: string,
-  accessToken: string
-): Promise<GoogleSubscriptionPurchase> {
-  const url = `https://androidpublisher.googleapis.com/androidpublisher/v3/applications/${encodeURIComponent(packageName)}/purchases/subscriptions/${encodeURIComponent(productId)}/tokens/${encodeURIComponent(purchaseToken)}`;
+  accessToken: string,
+): Promise<GoogleSubscriptionPurchaseV2> {
+  const url =
+    `https://androidpublisher.googleapis.com/androidpublisher/v3/applications/` +
+    `${encodeURIComponent(packageName)}/purchases/subscriptionsv2/tokens/` +
+    `${encodeURIComponent(purchaseToken)}`;
 
   const resp = await fetch(url, {
     headers: { Authorization: `Bearer ${accessToken}` },
@@ -202,10 +235,10 @@ async function fetchSubscriptionPurchase(
 
   if (!resp.ok) {
     const body = await resp.text();
-    throw new Error(`[onesub/google] Play API error ${resp.status}: ${body}`);
+    throw new Error(`[onesub/google] Play API v2 error ${resp.status}: ${body}`);
   }
 
-  return resp.json() as Promise<GoogleSubscriptionPurchase>;
+  return resp.json() as Promise<GoogleSubscriptionPurchaseV2>;
 }
 
 /**
@@ -367,28 +400,47 @@ export async function consumeGoogleProductReceipt(
 }
 
 /**
- * Derive a SubscriptionStatus from a Google Play purchase resource.
+ * Map a v2 subscriptionState string to onesub SubscriptionStatus.
+ *
+ * Returns null when the state is unrecognised or PENDING (initial purchase
+ * not yet settled — entitlement should not be granted yet).
+ *
+ * Note: SUBSCRIPTION_STATE_PAUSED currently maps to on_hold (entitlement
+ * revoked). When a dedicated `paused` lifecycle state lands, switch this case.
  */
-function deriveStatus(purchase: GoogleSubscriptionPurchase): SubscriptionInfo['status'] {
-  const now = Date.now();
-  const expiryMs = purchase.expiryTimeMillis ? parseInt(purchase.expiryTimeMillis, 10) : 0;
-
-  if (expiryMs > now) {
-    // paymentState 0 = pending (grace period treated as active)
-    return SUBSCRIPTION_STATUS.ACTIVE;
+function deriveStatusV2(
+  state: GoogleSubscriptionPurchaseV2['subscriptionState'],
+): SubscriptionInfo['status'] | null {
+  switch (state) {
+    case 'SUBSCRIPTION_STATE_ACTIVE':
+      return SUBSCRIPTION_STATUS.ACTIVE;
+    case 'SUBSCRIPTION_STATE_IN_GRACE_PERIOD':
+      return SUBSCRIPTION_STATUS.GRACE_PERIOD;
+    case 'SUBSCRIPTION_STATE_ON_HOLD':
+    case 'SUBSCRIPTION_STATE_PAUSED':
+      return SUBSCRIPTION_STATUS.ON_HOLD;
+    case 'SUBSCRIPTION_STATE_CANCELED':
+      return SUBSCRIPTION_STATUS.CANCELED;
+    case 'SUBSCRIPTION_STATE_EXPIRED':
+      return SUBSCRIPTION_STATUS.EXPIRED;
+    case 'SUBSCRIPTION_STATE_PENDING':
+    case 'SUBSCRIPTION_STATE_UNSPECIFIED':
+    default:
+      return null;
   }
-
-  if (purchase.cancelReason !== undefined) return SUBSCRIPTION_STATUS.CANCELED;
-
-  return SUBSCRIPTION_STATUS.EXPIRED;
 }
 
 /**
- * Validate a Google Play purchase token.
+ * Validate a Google Play purchase token via purchases.subscriptionsv2.get.
  *
- * @param receipt  - The purchaseToken from the client (Google Play Billing)
- * @param productId - The subscription product ID
- * @param config   - Google config with packageName and optional serviceAccountKey
+ * The productId argument is used to pick the matching `lineItems` entry. If
+ * the response has no lineItem with that productId, validation fails — the
+ * token does not entitle the caller to that product. (For multi-product
+ * subscriptions, callers can read other lineItems out of the API directly.)
+ *
+ * @param receipt    The purchaseToken from the client (Google Play Billing)
+ * @param productId  Expected subscription productId — must match a lineItem
+ * @param config     Google config with packageName + optional serviceAccountKey
  */
 export async function validateGoogleReceipt(
   receipt: string,
@@ -401,28 +453,51 @@ export async function validateGoogleReceipt(
     return null;
   }
 
-  let purchase: GoogleSubscriptionPurchase;
+  let purchase: GoogleSubscriptionPurchaseV2;
   try {
     const token = await getCachedAccessToken(config.serviceAccountKey);
-    purchase = await fetchSubscriptionPurchase(config.packageName, productId, receipt, token);
+    purchase = await fetchSubscriptionPurchaseV2(config.packageName, receipt, token);
   } catch (err) {
     log.error('[onesub/google] Receipt validation failed:', err);
     return null;
   }
 
-  const status = deriveStatus(purchase);
-  const expiryMs = purchase.expiryTimeMillis ? parseInt(purchase.expiryTimeMillis, 10) : Date.now();
-  const startMs = purchase.startTimeMillis ? parseInt(purchase.startTimeMillis, 10) : Date.now();
+  const status = deriveStatusV2(purchase.subscriptionState);
+  if (!status) {
+    log.warn(
+      '[onesub/google] Unrecognised or pending subscriptionState — rejecting:',
+      purchase.subscriptionState,
+    );
+    return null;
+  }
+
+  // Pick the lineItem matching the requested productId. v2 supports multi-product
+  // subscriptions so the same token can carry several lineItems; we only entitle
+  // the caller for the productId they explicitly asked about.
+  const lineItem = purchase.lineItems?.find((item) => item.productId === productId);
+  if (!lineItem) {
+    log.warn(
+      '[onesub/google] productId not found in subscription lineItems:',
+      productId,
+      'available:',
+      purchase.lineItems?.map((i) => i.productId).join(', ') ?? '(none)',
+    );
+    return null;
+  }
+
+  const expiresAt = lineItem.expiryTime ?? new Date().toISOString();
+  const purchasedAt = purchase.startTime ?? new Date().toISOString();
+  const willRenew = lineItem.autoRenewingPlan?.autoRenewEnabled ?? false;
 
   return {
     userId: '',  // caller fills this in
     productId,
     platform: 'google',
     status,
-    expiresAt: new Date(expiryMs).toISOString(),
-    originalTransactionId: purchase.orderId ?? receipt.slice(0, 64),
-    purchasedAt: new Date(startMs).toISOString(),
-    willRenew: purchase.autoRenewing ?? false,
+    expiresAt,
+    originalTransactionId: purchase.latestOrderId ?? receipt.slice(0, 64),
+    purchasedAt,
+    willRenew,
   };
 }
 


### PR DESCRIPTION
## Summary

Google Play Developer API의 deprecated된 `purchases.subscriptions.get` (v1) 호출을 `purchases.subscriptionsv2.get` (v2)로 교체. v2의 `subscriptionState` 문자열 enum이 PR #24의 grace_period/on_hold 라이프사이클 모델과 직접 일치하므로, 더 정확한 상태 결정이 가능.

## 왜 필요한가

기존 v1은 expiryTime/cancelReason 기반으로 상태를 **추정**했는데:
- `expiryTime > now`면 무조건 `active` → **grace_period 못 잡음**
- `cancelReason` 있으면 `canceled` → **on_hold 못 잡음**

PR #24에서 webhook 알림 기반 grace/hold 매핑은 추가했지만, validate 직접 호출 시(SDK가 receipt 검증)는 여전히 잘못된 상태 추정. v2는 Google이 직접 상태를 알려주므로 정확.

## 상태 매핑

| v2 subscriptionState | onesub status |
|---|---|
| `SUBSCRIPTION_STATE_ACTIVE` | `active` |
| `SUBSCRIPTION_STATE_IN_GRACE_PERIOD` | `grace_period` |
| `SUBSCRIPTION_STATE_ON_HOLD` | `on_hold` |
| `SUBSCRIPTION_STATE_PAUSED` | `on_hold` (별도 paused 상태 추가 시 그쪽으로) |
| `SUBSCRIPTION_STATE_CANCELED` | `canceled` |
| `SUBSCRIPTION_STATE_EXPIRED` | `expired` |
| `SUBSCRIPTION_STATE_PENDING` | `null` (entitlement 거부) |
| `SUBSCRIPTION_STATE_UNSPECIFIED` / unknown | `null` |

## API 변경

- URL: `/purchases/subscriptions/{productId}/tokens/{token}` → `/purchases/subscriptionsv2/tokens/{token}` (productId 제거)
- 응답 필드:
  - `expiryTimeMillis` → `lineItems[].expiryTime` (RFC3339)
  - `startTimeMillis` → `startTime`
  - `autoRenewing` → `lineItems[].autoRenewingPlan.autoRenewEnabled`
  - `orderId` → `latestOrderId`
- multi-product 구독 지원 — 한 token이 여러 lineItems 포함 가능, 호출자가 요청한 productId에 매칭되는 것만 entitle

## 시그니처 보존

```ts
validateGoogleReceipt(receipt, productId, config) → SubscriptionInfo | null
```

호출자(`/onesub/validate`, webhook fallback)는 변경 불필요. productId는 v2에서도 lineItems 매칭에 사용.

## 주요 파일

- `packages/server/src/providers/google.ts` — v1 코드 제거, v2로 교체

## Test plan

- [x] `npm run build` 전체 패키지 통과
- [x] `npm test` — 246/246 (google-subscriptions-v2.test.ts 20개 신규)
- [x] subscriptionState 6개 매핑 모두 검증 (active/grace/hold/paused/canceled/expired)
- [x] PENDING / UNSPECIFIED / unknown → null
- [x] lineItems productId 매칭 (단일/없음/multi-product)
- [x] autoRenewingPlan, latestOrderId, expiryTime, startTime 매핑
- [x] HTTP 410 (Gone, v1 deprecation 시 발생 가능) → null
- [x] serviceAccountKey 누락 → null
- [ ] (수동) 실제 sandbox 구독으로 v2 응답 받아 매핑 확인

## Breaking changes

**API 시그니처는 동일.** 하지만 동작 변경:
- 동일 token이라도 v1에선 active로 분류되던 grace_period가 이제 `grace_period`로 정확히 분류됨
- 호스트 앱이 `SubscriptionInfo.status`를 string switch로 다루면 새 값 노출 가능 (PR #24에서 이미 `grace_period`/`on_hold` 도입됨)
- v1 deprecation으로 Google이 410 Gone 반환 시작하면 기존 코드는 망가졌을 텐데 이번 PR로 사전 방지

## 참고

- v2 spec: https://developers.google.com/android-publisher/api-ref/rest/v3/purchases.subscriptionsv2/get
- v1 deprecation 공지: https://android-developers.googleblog.com/2023/02/announcing-google-play-developer-api-v3-deprecation.html (참조용 — 정확한 sunset 일정은 Google 콘솔 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)