### PR TITLE
test: CodeQL 경고 3건 해결 (RSA 2048 + URL hostname 매칭)

### DIFF
--- a/packages/server/src/__tests__/apple-status-api.test.ts
+++ b/packages/server/src/__tests__/apple-status-api.test.ts
@@ -19,6 +19,7 @@ import { SUBSCRIPTION_STATUS } from '@onesub/shared';
 import { fetchAppleSubscriptionStatus } from '../providers/apple.js';
 import { createWebhookRouter } from '../routes/webhook.js';
 import { InMemorySubscriptionStore, InMemoryPurchaseStore } from '../store.js';
+import { isLocalhostUrl } from './test-utils.js';
 
 // ── helpers ─────────────────────────────────────────────────────────────────
 
@@ -59,10 +60,10 @@ function mockAppleStatusFetch(responseBody: unknown, opts?: { status?: number })
   const originalFetch = global.fetch;
   const calls: { url: string; method?: string; headers?: Record<string, string> }[] = [];
   vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
-    const urlStr = String(url);
-    if (urlStr.startsWith('http://127.0.0.1') || urlStr.startsWith('http://localhost')) {
+    if (isLocalhostUrl(url)) {
       return originalFetch(url, init);
     }
+    const urlStr = String(url);
     calls.push({
       url: urlStr,
       method: init?.method,
@@ -345,11 +346,10 @@ describe('Apple webhook — unknown originalTransactionId fallback', () => {
     const originalFetch = global.fetch;
     const outboundCalls: { url: string }[] = [];
     vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
-      const urlStr = String(url);
-      if (urlStr.startsWith('http://127.0.0.1') || urlStr.startsWith('http://localhost')) {
+      if (isLocalhostUrl(url)) {
         return originalFetch(url, init);
       }
-      outboundCalls.push({ url: urlStr });
+      outboundCalls.push({ url: String(url) });
       return { ok: true, status: 200, json: async () => ({}), text: async () => '' } as Response;
     });
 
@@ -369,11 +369,10 @@ describe('Apple webhook — unknown originalTransactionId fallback', () => {
     const originalFetch = global.fetch;
     const outboundCalls: { url: string }[] = [];
     vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
-      const urlStr = String(url);
-      if (urlStr.startsWith('http://127.0.0.1') || urlStr.startsWith('http://localhost')) {
+      if (isLocalhostUrl(url)) {
         return originalFetch(url, init);
       }
-      outboundCalls.push({ url: urlStr });
+      outboundCalls.push({ url: String(url) });
       return { ok: true, status: 200, json: async () => ({}), text: async () => '' } as Response;
     });
 

--- a/packages/server/src/__tests__/google-subscriptions-v2.test.ts
+++ b/packages/server/src/__tests__/google-subscriptions-v2.test.ts
@@ -14,13 +14,14 @@ import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
 import { generateKeyPairSync } from 'crypto';
 import { validateGoogleReceipt } from '../providers/google.js';
 import { SUBSCRIPTION_STATUS } from '@onesub/shared';
+import { urlHost } from './test-utils.js';
 
 // ── helpers ─────────────────────────────────────────────────────────────────
 
 let testPrivateKey: string;
 
 beforeAll(() => {
-  const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 1024 });
+  const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
   testPrivateKey = privateKey.export({ type: 'pkcs8', format: 'pem' }) as string;
 });
 
@@ -55,15 +56,14 @@ interface V2Response {
 function mockV2Fetch(responseBody: V2Response, opts?: { status?: number }) {
   const calls: { url: string }[] = [];
   vi.spyOn(global, 'fetch').mockImplementation(async (url) => {
-    const urlStr = String(url);
-    if (urlStr.includes('oauth2.googleapis.com')) {
+    if (urlHost(url) === 'oauth2.googleapis.com') {
       return {
         ok: true,
         json: async () => ({ access_token: 'tok', expires_in: 3600 }),
         text: async () => '',
       } as Response;
     }
-    calls.push({ url: urlStr });
+    calls.push({ url: String(url) });
     return {
       ok: (opts?.status ?? 200) < 400,
       status: opts?.status ?? 200,
@@ -96,7 +96,7 @@ describe('validateGoogleReceipt — v2 endpoint', () => {
 
     await validateGoogleReceipt('purchase_token_xyz', 'pro_monthly', makeGoogleConfig());
 
-    const apiCall = calls.find((c) => c.url.includes('androidpublisher.googleapis.com'));
+    const apiCall = calls.find((c) => urlHost(c.url) === 'androidpublisher.googleapis.com');
     expect(apiCall).toBeDefined();
     expect(apiCall?.url).toContain('/purchases/subscriptionsv2/tokens/purchase_token_xyz');
     expect(apiCall?.url).not.toContain('/purchases/subscriptions/');

--- a/packages/server/src/__tests__/lifecycle-states.test.ts
+++ b/packages/server/src/__tests__/lifecycle-states.test.ts
@@ -17,6 +17,7 @@ import { SUBSCRIPTION_STATUS } from '@onesub/shared';
 import { createWebhookRouter } from '../routes/webhook.js';
 import { createStatusRouter } from '../routes/status.js';
 import { InMemorySubscriptionStore, InMemoryPurchaseStore } from '../store.js';
+import { isLocalhostUrl } from './test-utils.js';
 
 // ── helpers ─────────────────────────────────────────────────────────────────
 
@@ -288,13 +289,12 @@ describe('Apple webhook — CONSUMPTION_REQUEST', () => {
     const originalFetch = global.fetch;
     const fetchCalls: { url: string; method?: string; body?: unknown; headers?: Record<string, string> }[] = [];
     vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
-      const urlStr = String(url);
       // Pass-through localhost — that's our own test server.
-      if (urlStr.startsWith('http://127.0.0.1') || urlStr.startsWith('http://localhost')) {
+      if (isLocalhostUrl(url)) {
         return originalFetch(url, init);
       }
       fetchCalls.push({
-        url: urlStr,
+        url: String(url),
         method: init?.method,
         body: init?.body,
         headers: init?.headers as Record<string, string>,
@@ -367,10 +367,10 @@ describe('Apple webhook — CONSUMPTION_REQUEST', () => {
     const originalFetch = global.fetch;
     const fetchCalls: { url: string; method?: string }[] = [];
     vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
-      const urlStr = String(url);
-      if (urlStr.startsWith('http://127.0.0.1') || urlStr.startsWith('http://localhost')) {
+      if (isLocalhostUrl(url)) {
         return originalFetch(url, init);
       }
+      const urlStr = String(url);
       fetchCalls.push({ url: urlStr, method: init?.method });
       return { ok: true, json: async () => ({}), text: async () => '' } as Response;
     });
@@ -417,10 +417,10 @@ describe('Apple webhook — CONSUMPTION_REQUEST', () => {
     const originalFetch = global.fetch;
     const fetchCalls: { url: string; method?: string }[] = [];
     vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
-      const urlStr = String(url);
-      if (urlStr.startsWith('http://127.0.0.1') || urlStr.startsWith('http://localhost')) {
+      if (isLocalhostUrl(url)) {
         return originalFetch(url, init);
       }
+      const urlStr = String(url);
       fetchCalls.push({ url: urlStr, method: init?.method });
       return { ok: true, json: async () => ({}), text: async () => '' } as Response;
     });
@@ -461,10 +461,10 @@ describe('Apple webhook — CONSUMPTION_REQUEST', () => {
     const originalFetch = global.fetch;
     const outboundCalls: { url: string }[] = [];
     vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
-      const urlStr = String(url);
-      if (urlStr.startsWith('http://127.0.0.1') || urlStr.startsWith('http://localhost')) {
+      if (isLocalhostUrl(url)) {
         return originalFetch(url, init);
       }
+      const urlStr = String(url);
       outboundCalls.push({ url: urlStr });
       return { ok: true, json: async () => ({}), text: async () => '' } as Response;
     });

--- a/packages/server/src/__tests__/providers.test.ts
+++ b/packages/server/src/__tests__/providers.test.ts
@@ -11,6 +11,7 @@ import {
   acknowledgeGoogleSubscription,
   acknowledgeGoogleProduct,
 } from '../providers/google.js';
+import { urlHost } from './test-utils.js';
 
 // ── Apple helpers ──────────────────────────────────────────────────────────
 
@@ -44,8 +45,8 @@ let testPrivateKey: string;
 
 beforeAll(() => {
   // Generate a real RSA key pair once — needed for the JWT assertion in getAccessToken().
-  // 1024-bit is sufficient for tests (not production).
-  const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 1024 });
+  // 2048-bit (CodeQL minimum); generated once per suite so test-time cost is negligible.
+  const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
   testPrivateKey = privateKey.export({ type: 'pkcs8', format: 'pem' }) as string;
 });
 
@@ -83,22 +84,22 @@ type MockProductPurchase = {
  */
 function mockGoogleFetch(productPurchase: MockProductPurchase) {
   vi.spyOn(global, 'fetch').mockImplementation(async (url) => {
-    const urlStr = String(url);
-    if (urlStr.includes('oauth2.googleapis.com')) {
+    const host = urlHost(url);
+    if (host === 'oauth2.googleapis.com') {
       return {
         ok: true,
         json: async () => ({ access_token: 'test_access_token', expires_in: 3600 }),
         text: async () => '',
       } as Response;
     }
-    if (urlStr.includes('androidpublisher.googleapis.com')) {
+    if (host === 'androidpublisher.googleapis.com') {
       return {
         ok: true,
         json: async () => productPurchase,
         text: async () => JSON.stringify(productPurchase),
       } as Response;
     }
-    throw new Error(`[test] Unexpected fetch URL: ${urlStr}`);
+    throw new Error(`[test] Unexpected fetch URL: ${String(url)}`);
   });
 }
 
@@ -332,8 +333,7 @@ describe('validateGoogleProductReceipt', () => {
 
   it('returns null when Play API returns an error response', async () => {
     vi.spyOn(global, 'fetch').mockImplementation(async (url) => {
-      const urlStr = String(url);
-      if (urlStr.includes('oauth2.googleapis.com')) {
+      if (urlHost(url) === 'oauth2.googleapis.com') {
         return {
           ok: true,
           json: async () => ({ access_token: 'tok', expires_in: 3600 }),
@@ -361,8 +361,7 @@ describe('acknowledgeGoogleSubscription', () => {
     const calls: { url: string; method?: string; body?: unknown }[] = [];
     vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
       calls.push({ url: String(url), method: init?.method, body: init?.body });
-      const urlStr = String(url);
-      if (urlStr.includes('oauth2.googleapis.com')) {
+      if (urlHost(url) === 'oauth2.googleapis.com') {
         return { ok: true, json: async () => ({ access_token: 'tok', expires_in: 3600 }), text: async () => '' } as Response;
       }
       return { ok: true, json: async () => ({}), text: async () => '' } as Response;
@@ -379,8 +378,7 @@ describe('acknowledgeGoogleSubscription', () => {
 
   it('does not throw when Play API returns an error (fire-and-forget)', async () => {
     vi.spyOn(global, 'fetch').mockImplementation(async (url) => {
-      const urlStr = String(url);
-      if (urlStr.includes('oauth2.googleapis.com')) {
+      if (urlHost(url) === 'oauth2.googleapis.com') {
         return { ok: true, json: async () => ({ access_token: 'tok', expires_in: 3600 }), text: async () => '' } as Response;
       }
       return { ok: false, status: 500, json: async () => ({}), text: async () => 'oops' } as Response;
@@ -409,8 +407,7 @@ describe('acknowledgeGoogleProduct', () => {
     const calls: { url: string }[] = [];
     vi.spyOn(global, 'fetch').mockImplementation(async (url) => {
       calls.push({ url: String(url) });
-      const urlStr = String(url);
-      if (urlStr.includes('oauth2.googleapis.com')) {
+      if (urlHost(url) === 'oauth2.googleapis.com') {
         return { ok: true, json: async () => ({ access_token: 'tok', expires_in: 3600 }), text: async () => '' } as Response;
       }
       return { ok: true, json: async () => ({}), text: async () => '' } as Response;

--- a/packages/server/src/__tests__/test-utils.ts
+++ b/packages/server/src/__tests__/test-utils.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared test helpers — kept here so unit tests don't reinvent the wheel
+ * (and don't trip CodeQL with substring URL matching, which is unsafe in
+ * production code and inconsistent across files).
+ */
+
+/**
+ * Extract the hostname from a fetch input (string | URL | Request).
+ * Returns null when the input isn't a parseable absolute URL.
+ *
+ * Use this instead of `urlStr.includes('host.com')` — substring matching
+ * matches `https://attacker.example/?q=host.com` too, which CodeQL flags.
+ */
+export function urlHost(input: unknown): string | null {
+  try {
+    return new URL(String(input)).hostname;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True for fetch URLs targeting the in-process test HTTP server. Used by
+ * fetch mocks that need to pass-through the test runner's own requests
+ * while intercepting outbound API calls.
+ */
+export function isLocalhostUrl(input: unknown): boolean {
+  const host = urlHost(input);
+  return host === '127.0.0.1' || host === 'localhost';
+}


### PR DESCRIPTION
## Summary

PR #26에서 CodeQL이 잡은 경고 3건을 해결. 모두 **테스트 코드 위생** 이슈로 프로덕션 코드 영향 없음. 동일 패턴이 4개 테스트 파일에 흩어져 있어서 공통 헬퍼로 통합.

## CodeQL 경고

| # | 알림 | 파일 | 처리 |
|---|------|------|------|
| 1 | Use of a weak cryptographic key (RSA 1024) | `providers.test.ts`, `google-subscriptions-v2.test.ts` | 2048로 변경 |
| 2 | Incomplete URL substring sanitization (`oauth2.googleapis.com`) | `providers.test.ts`, `google-subscriptions-v2.test.ts` | `urlHost(url) === '...'` 정확 매칭 |
| 3 | Incomplete URL substring sanitization (`androidpublisher.googleapis.com`) | `providers.test.ts`, `google-subscriptions-v2.test.ts` | 위와 동일 |

추가로 같은 패턴이라 함께 처리:

| 파일 | 처리 |
|------|------|
| `apple-status-api.test.ts` | `urlStr.startsWith('http://127.0.0.1')` localhost passthrough → `isLocalhostUrl(url)` |
| `lifecycle-states.test.ts` | 위와 동일 |

## 신규 파일

`packages/server/src/__tests__/test-utils.ts`:

```ts
export function urlHost(input: unknown): string | null { ... }
export function isLocalhostUrl(input: unknown): boolean { ... }
```

`URL().hostname` 기반 정확 매칭. 파싱 실패 시 null.

## Test plan

- [x] `npm run build` 통과
- [x] `npm test` — 246/246 통과 (테스트 동작 변경 없음)
- [ ] (자동) CodeQL 재스캔 후 경고 3건 자동 닫힘 확인

## Breaking changes

없음. 테스트 코드만.

🤖 Generated with [Claude Code](https://claude.com/claude-code)