### PR TITLE
환불 정책 분기 (refundPolicy: immediate | until_expiry) + status route stale-record 안전망

### DIFF
--- a/packages/server/src/__tests__/refund-policy.test.ts
+++ b/packages/server/src/__tests__/refund-policy.test.ts
@@ -1,0 +1,371 @@
+/**
+ * Tests for OneSubServerConfig.refundPolicy.
+ *
+ * Covers:
+ *   - Default ('immediate'): subscription REFUND/REVOKE/voided sets status=canceled
+ *   - 'until_expiry': keeps status + expiresAt, only flips willRenew=false
+ *   - IAP refund is unaffected by refundPolicy (always immediate)
+ *   - status route's stale-record check (active && expiresAt > now)
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import express from 'express';
+import type { OneSubServerConfig, SubscriptionInfo, PurchaseInfo } from '@onesub/shared';
+import { SUBSCRIPTION_STATUS } from '@onesub/shared';
+import { createWebhookRouter } from '../routes/webhook.js';
+import { createStatusRouter } from '../routes/status.js';
+import { InMemorySubscriptionStore, InMemoryPurchaseStore } from '../store.js';
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+function makeJws(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'ES256' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.fakesig`;
+}
+
+interface TestServer {
+  request: (method: 'POST' | 'GET', path: string, body?: unknown) => Promise<{ status: number; body: unknown }>;
+}
+
+function spinUp(handler: express.Express): TestServer {
+  return {
+    async request(method, path, body) {
+      const server = handler.listen(0);
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      try {
+        const url = `http://127.0.0.1:${port}${path}`;
+        const init: RequestInit = { method };
+        if (body !== undefined) {
+          init.headers = { 'Content-Type': 'application/json' };
+          init.body = JSON.stringify(body);
+        }
+        const resp = await fetch(url, init);
+        const text = await resp.text();
+        let parsed: unknown = text;
+        try { parsed = JSON.parse(text); } catch { /* keep as text */ }
+        return { status: resp.status, body: parsed };
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    },
+  };
+}
+
+function buildWebhookServer(config: OneSubServerConfig): {
+  store: InMemorySubscriptionStore;
+  purchaseStore: InMemoryPurchaseStore;
+  server: TestServer;
+} {
+  const store = new InMemorySubscriptionStore();
+  const purchaseStore = new InMemoryPurchaseStore();
+  const app = express();
+  app.use(express.json());
+  app.use(createWebhookRouter(config, store, purchaseStore));
+  return { store, purchaseStore, server: spinUp(app) };
+}
+
+function buildStatusServer(): { store: InMemorySubscriptionStore; server: TestServer } {
+  const store = new InMemorySubscriptionStore();
+  const app = express();
+  app.use(express.json());
+  app.use(createStatusRouter(store));
+  return { store, server: spinUp(app) };
+}
+
+const futureExpiry = '2099-01-01T00:00:00.000Z';
+const pastExpiry = '2024-01-01T00:00:00.000Z';
+
+const sampleSub = (overrides?: Partial<SubscriptionInfo>): SubscriptionInfo => ({
+  userId: 'user_x',
+  productId: 'pro_monthly',
+  platform: 'apple',
+  status: 'active',
+  expiresAt: futureExpiry,
+  originalTransactionId: 'orig_x',
+  purchasedAt: '2026-01-01T00:00:00.000Z',
+  willRenew: true,
+  ...overrides,
+});
+
+function appleSubRefundPayload(originalTransactionId: string): unknown {
+  const signedTransactionInfo = makeJws({
+    bundleId: 'com.example.app',
+    type: 'Auto-Renewable Subscription',
+    productId: 'pro_monthly',
+    transactionId: 'tx_refund',
+    originalTransactionId,
+    purchaseDate: Date.now() - 30 * 86400000,
+    expiresDate: Date.now() + 30 * 86400000,
+  });
+  return {
+    signedPayload: makeJws({
+      notificationType: 'REFUND',
+      data: { signedTransactionInfo, signedRenewalInfo: makeJws({}) },
+    }),
+  };
+}
+
+function appleConsumableRefundPayload(transactionId: string): unknown {
+  const signedTransactionInfo = makeJws({
+    bundleId: 'com.example.app',
+    type: 'Consumable',
+    productId: 'credits_100',
+    transactionId,
+    originalTransactionId: transactionId,
+    purchaseDate: Date.now(),
+  });
+  return {
+    signedPayload: makeJws({
+      notificationType: 'REFUND',
+      data: { signedTransactionInfo, signedRenewalInfo: makeJws({}) },
+    }),
+  };
+}
+
+function googleVoidedSubPayload(purchaseToken: string): unknown {
+  const json = JSON.stringify({
+    version: '1.0',
+    packageName: 'com.example.app',
+    eventTimeMillis: String(Date.now()),
+    voidedPurchaseNotification: {
+      purchaseToken,
+      orderId: 'GPA.refunded',
+      productType: 1,
+      refundType: 1,
+    },
+  });
+  return {
+    message: { data: Buffer.from(json).toString('base64'), messageId: '1' },
+    subscription: 's',
+  };
+}
+
+const appleConfig: NonNullable<OneSubServerConfig['apple']> = {
+  bundleId: 'com.example.app',
+  skipJwsVerification: true,
+};
+const googleConfig: NonNullable<OneSubServerConfig['google']> = {
+  packageName: 'com.example.app',
+};
+
+// ── refundPolicy default ('immediate') ──────────────────────────────────────
+
+describe('refundPolicy default (immediate) — Apple subscription REFUND', () => {
+  let store: InMemorySubscriptionStore;
+  let server: TestServer;
+
+  beforeEach(() => {
+    const built = buildWebhookServer({ apple: appleConfig, database: { url: '' } });
+    store = built.store;
+    server = built.server;
+  });
+
+  it('marks status=canceled on REFUND', async () => {
+    await store.save(sampleSub({ originalTransactionId: 'orig_immed' }));
+    const resp = await server.request('POST', '/onesub/webhook/apple', appleSubRefundPayload('orig_immed'));
+    expect(resp.status).toBe(200);
+    expect((await store.getByTransactionId('orig_immed'))?.status).toBe(SUBSCRIPTION_STATUS.CANCELED);
+  });
+});
+
+describe('refundPolicy default (immediate) — Google voided subscription', () => {
+  it('marks status=canceled on voidedPurchaseNotification productType=1', async () => {
+    const { store, server } = buildWebhookServer({ google: googleConfig, database: { url: '' } });
+    await store.save(sampleSub({ platform: 'google', originalTransactionId: 'tok_immed' }));
+
+    const resp = await server.request('POST', '/onesub/webhook/google', googleVoidedSubPayload('tok_immed'));
+    expect(resp.status).toBe(200);
+    expect((await store.getByTransactionId('tok_immed'))?.status).toBe(SUBSCRIPTION_STATUS.CANCELED);
+  });
+});
+
+// ── refundPolicy 'until_expiry' ─────────────────────────────────────────────
+
+describe("refundPolicy 'until_expiry' — Apple subscription REFUND", () => {
+  let store: InMemorySubscriptionStore;
+  let server: TestServer;
+
+  beforeEach(() => {
+    const built = buildWebhookServer({
+      apple: appleConfig,
+      database: { url: '' },
+      refundPolicy: 'until_expiry',
+    });
+    store = built.store;
+    server = built.server;
+  });
+
+  it('keeps status=active and expiresAt; only flips willRenew=false', async () => {
+    const original = sampleSub({
+      originalTransactionId: 'orig_keep',
+      status: 'active',
+      expiresAt: futureExpiry,
+      willRenew: true,
+    });
+    await store.save(original);
+
+    await server.request('POST', '/onesub/webhook/apple', appleSubRefundPayload('orig_keep'));
+
+    const updated = await store.getByTransactionId('orig_keep');
+    expect(updated?.status).toBe(SUBSCRIPTION_STATUS.ACTIVE);
+    expect(updated?.expiresAt).toBe(futureExpiry);
+    expect(updated?.willRenew).toBe(false);
+  });
+
+  it('still routes Apple REVOKE the same way (refund-class signal)', async () => {
+    await store.save(sampleSub({ originalTransactionId: 'orig_revoke' }));
+
+    const signedTransactionInfo = makeJws({
+      bundleId: 'com.example.app',
+      type: 'Auto-Renewable Subscription',
+      productId: 'pro_monthly',
+      transactionId: 'tx_revoke',
+      originalTransactionId: 'orig_revoke',
+      purchaseDate: Date.now(),
+      expiresDate: Date.now() + 86400000,
+    });
+    const signedPayload = makeJws({
+      notificationType: 'REVOKE',
+      data: { signedTransactionInfo, signedRenewalInfo: makeJws({}) },
+    });
+
+    await server.request('POST', '/onesub/webhook/apple', { signedPayload });
+
+    const updated = await store.getByTransactionId('orig_revoke');
+    expect(updated?.status).toBe(SUBSCRIPTION_STATUS.ACTIVE);
+    expect(updated?.willRenew).toBe(false);
+  });
+
+  it('still applies normal expiry mapping for non-refund notifications (DID_RENEW)', async () => {
+    await store.save(sampleSub({ originalTransactionId: 'orig_renew', willRenew: false }));
+
+    const signedTransactionInfo = makeJws({
+      bundleId: 'com.example.app',
+      type: 'Auto-Renewable Subscription',
+      productId: 'pro_monthly',
+      transactionId: 'tx_renew',
+      originalTransactionId: 'orig_renew',
+      purchaseDate: Date.now(),
+      expiresDate: Date.now() + 30 * 86400000,
+    });
+    const signedPayload = makeJws({
+      notificationType: 'DID_RENEW',
+      data: { signedTransactionInfo, signedRenewalInfo: makeJws({ autoRenewStatus: 1 }) },
+    });
+
+    await server.request('POST', '/onesub/webhook/apple', { signedPayload });
+
+    const updated = await store.getByTransactionId('orig_renew');
+    expect(updated?.status).toBe(SUBSCRIPTION_STATUS.ACTIVE);
+    // willRenew should reflect the renewal info (true), not stay false
+    expect(updated?.willRenew).toBe(true);
+  });
+});
+
+describe("refundPolicy 'until_expiry' — Google voided subscription", () => {
+  it('keeps status=active and only flips willRenew=false', async () => {
+    const { store, server } = buildWebhookServer({
+      google: googleConfig,
+      database: { url: '' },
+      refundPolicy: 'until_expiry',
+    });
+    await store.save(sampleSub({
+      platform: 'google',
+      originalTransactionId: 'tok_keep',
+      status: 'active',
+      willRenew: true,
+    }));
+
+    await server.request('POST', '/onesub/webhook/google', googleVoidedSubPayload('tok_keep'));
+
+    const updated = await store.getByTransactionId('tok_keep');
+    expect(updated?.status).toBe(SUBSCRIPTION_STATUS.ACTIVE);
+    expect(updated?.willRenew).toBe(false);
+  });
+});
+
+// ── IAP refund is unaffected by refundPolicy ────────────────────────────────
+
+describe('refundPolicy does NOT apply to one-time IAP refunds', () => {
+  const iap = (overrides?: Partial<PurchaseInfo>): PurchaseInfo => ({
+    userId: 'u',
+    productId: 'credits_100',
+    platform: 'apple',
+    type: 'consumable',
+    transactionId: 'iap_tx',
+    purchasedAt: '2026-01-01T00:00:00.000Z',
+    quantity: 1,
+    ...overrides,
+  });
+
+  it("Apple IAP REFUND removes the row even when refundPolicy='until_expiry'", async () => {
+    const { purchaseStore, server } = buildWebhookServer({
+      apple: appleConfig,
+      database: { url: '' },
+      refundPolicy: 'until_expiry',
+    });
+    await purchaseStore.savePurchase(iap({ transactionId: 'iap_keep_test' }));
+
+    await server.request('POST', '/onesub/webhook/apple', appleConsumableRefundPayload('iap_keep_test'));
+
+    expect(await purchaseStore.getPurchaseByTransactionId('iap_keep_test')).toBeNull();
+  });
+
+  it("Google voided IAP (productType=2) deletes the row even when refundPolicy='until_expiry'", async () => {
+    const { purchaseStore, server } = buildWebhookServer({
+      google: googleConfig,
+      database: { url: '' },
+      refundPolicy: 'until_expiry',
+    });
+    await purchaseStore.savePurchase(iap({ platform: 'google', transactionId: 'GPA.iap_keep' }));
+
+    const json = JSON.stringify({
+      version: '1.0',
+      packageName: 'com.example.app',
+      eventTimeMillis: String(Date.now()),
+      voidedPurchaseNotification: {
+        purchaseToken: 'tok',
+        orderId: 'GPA.iap_keep',
+        productType: 2,
+        refundType: 1,
+      },
+    });
+    await server.request('POST', '/onesub/webhook/google', {
+      message: { data: Buffer.from(json).toString('base64'), messageId: '1' },
+      subscription: 's',
+    });
+
+    expect(await purchaseStore.getPurchaseByTransactionId('GPA.iap_keep')).toBeNull();
+  });
+});
+
+// ── status route stale-record safety ────────────────────────────────────────
+
+describe('status route — stale active record', () => {
+  it('returns active=false when status=active but expiresAt is in the past', async () => {
+    const { store, server } = buildStatusServer();
+    await store.save(sampleSub({ userId: 'u_stale', status: 'active', expiresAt: pastExpiry }));
+
+    const resp = await server.request('GET', '/onesub/status?userId=u_stale');
+    expect(resp.status).toBe(200);
+    expect((resp.body as { active: boolean }).active).toBe(false);
+  });
+
+  it('returns active=true when status=active and expiresAt is in the future (normal case)', async () => {
+    const { store, server } = buildStatusServer();
+    await store.save(sampleSub({ userId: 'u_ok', status: 'active', expiresAt: futureExpiry }));
+
+    const resp = await server.request('GET', '/onesub/status?userId=u_ok');
+    expect((resp.body as { active: boolean }).active).toBe(true);
+  });
+
+  it('returns active=false for grace_period record past expiresAt', async () => {
+    const { store, server } = buildStatusServer();
+    await store.save(sampleSub({ userId: 'u_grace_stale', status: 'grace_period', expiresAt: pastExpiry }));
+
+    const resp = await server.request('GET', '/onesub/status?userId=u_grace_stale');
+    expect((resp.body as { active: boolean }).active).toBe(false);
+  });
+});

--- a/packages/server/src/routes/status.ts
+++ b/packages/server/src/routes/status.ts
@@ -42,9 +42,18 @@ export function createStatusRouter(store: SubscriptionStore): Router {
       // Entitlement is valid during the store-granted grace period (Apple
       // GRACE_PERIOD subtype, Google IN_GRACE_PERIOD). on_hold is excluded —
       // the user must fix payment before they regain access.
-      const active =
+      //
+      // The expiresAt check guards two cases:
+      //   1. refundPolicy='until_expiry' lets a refunded record keep
+      //      status='active' until the original expiry passes — without this
+      //      check, the user would keep entitlement forever if Apple/Google
+      //      never sent the matching EXPIRED notification.
+      //   2. Stale records where the EXPIRED webhook was missed entirely.
+      const statusAllows =
         sub.status === SUBSCRIPTION_STATUS.ACTIVE ||
         sub.status === SUBSCRIPTION_STATUS.GRACE_PERIOD;
+      const notYetExpired = new Date(sub.expiresAt).getTime() > Date.now();
+      const active = statusAllows && notYetExpired;
       const response: StatusResponse = { active, subscription: sub };
       res.status(200).json(response);
     } catch (err) {

--- a/packages/server/src/routes/webhook.ts
+++ b/packages/server/src/routes/webhook.ts
@@ -264,14 +264,24 @@ export function createWebhookRouter(
 
       const existing = await store.getByTransactionId(originalTransactionId);
       if (existing) {
-        const updated: SubscriptionInfo = {
-          ...existing,
-          status: finalStatus,
-          willRenew,
-          // expiresAt may be absent on non-subscription payloads — keep the
-          // previously-stored value rather than overwriting with null/empty.
-          expiresAt: expiresAt ?? existing.expiresAt,
-        };
+        // refundPolicy='until_expiry' for subscription refunds: keep status +
+        // expiresAt untouched, only flip willRenew=false. The status route's
+        // stale-record check will drop the user automatically once expiresAt
+        // passes. Refer to OneSubServerConfig.refundPolicy for rationale.
+        const isSubscriptionRefund =
+          isRefundOrRevoke && !isOneTimePurchase && notificationType !== 'CONSUMPTION_REQUEST';
+        const keepEntitlement = isSubscriptionRefund && config.refundPolicy === 'until_expiry';
+
+        const updated: SubscriptionInfo = keepEntitlement
+          ? { ...existing, willRenew: false }
+          : {
+              ...existing,
+              status: finalStatus,
+              willRenew,
+              // expiresAt may be absent on non-subscription payloads — keep the
+              // previously-stored value rather than overwriting with null/empty.
+              expiresAt: expiresAt ?? existing.expiresAt,
+            };
         await store.save(updated);
       } else if (config.apple?.issuerId && config.apple?.keyId && config.apple?.privateKey) {
         // No local record but App Store Server API credentials are present —
@@ -352,7 +362,12 @@ export function createWebhookRouter(
           // Subscription refund — purchaseToken is stored as originalTransactionId.
           const existing = await store.getByTransactionId(voided.purchaseToken);
           if (existing) {
-            await store.save({ ...existing, status: SUBSCRIPTION_STATUS.CANCELED });
+            // refundPolicy='until_expiry' for subscription refunds: keep
+            // status + expiresAt, only flip willRenew. See OneSubServerConfig.
+            const updated = config.refundPolicy === 'until_expiry'
+              ? { ...existing, willRenew: false }
+              : { ...existing, status: SUBSCRIPTION_STATUS.CANCELED };
+            await store.save(updated);
           } else {
             log.warn(
               '[onesub/webhook/google] voided subscription for unknown purchaseToken:',
@@ -361,6 +376,7 @@ export function createWebhookRouter(
           }
         } else {
           // One-time product refund — orderId is stored as transactionId.
+          // Always immediate (refundPolicy doesn't apply — IAP has no expiry).
           const removed = await purchaseStore.deletePurchaseByTransactionId(voided.orderId);
           if (!removed) {
             log.warn(

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -207,6 +207,24 @@ export interface OneSubServerConfig {
    * (`pino`, `winston`, `bunyan`, `console`) works.
    */
   logger?: OneSubLogger;
+  /**
+   * How to handle subscription refunds (Apple REFUND/REVOKE, Google
+   * voidedPurchaseNotification productType=1).
+   *
+   * - `'immediate'` (default): mark `status` as `canceled` right away. The
+   *   user loses entitlement immediately on the next /onesub/status check.
+   *   Strict, fraud-resistant.
+   *
+   * - `'until_expiry'`: keep `status` and `expiresAt` untouched, only flip
+   *   `willRenew` to `false`. The user keeps entitlement until the original
+   *   expiry passes (status route's stale-record check then drops them
+   *   automatically). Better UX for goodwill refunds; heavier on fraud risk.
+   *
+   * One-time purchases (consumable / non-consumable) are NOT affected by
+   * this setting — those always revoke immediately on refund because they
+   * have no expiry concept.
+   */
+  refundPolicy?: 'immediate' | 'until_expiry';
 }
 
 /** Purchase type */


### PR DESCRIPTION
## Summary

구독 환불 처리 정책을 config로 선택 가능하게. 부수적으로 status route에 stale-record 안전망 추가.

## refundPolicy

| 값 | 동작 | 적합한 경우 |
|---|---|---|
| `'immediate'` (default) | 환불 알림 즉시 `status='canceled'` | strict, fraud-resistant. 결제 직후 환불 악용 방지 |
| `'until_expiry'` | `status`/`expiresAt` 유지, `willRenew=false`만 | goodwill 정책. 사용자가 결제한 기간만큼 entitlement 유지 |

**적용 범위:**
- ✅ Apple webhook: `REFUND` / `REVOKE` 구독 알림
- ✅ Google webhook: `voidedPurchaseNotification` productType=1 (구독)
- ❌ IAP(consumable/non-consumable): 정책 무관, **항상 즉시 삭제** (만료 개념 없음)
- ❌ `CONSUMPTION_REQUEST`: refund 요청 단계지 확정 아니라서 제외

## 부수 변경 — status route 안전망

```ts
const active =
  (status === 'active' || status === 'grace_period') &&
  new Date(expiresAt).getTime() > Date.now();
```

**왜 같이?**
- `'until_expiry'` 모드에서 webhook이 `EXPIRED` 알림 못 받으면 record가 영원히 active 상태로 남음 → 무한 entitlement
- 일반적인 stale record(웹훅 누락)에도 안전망 — 별개 이득
- 기존 동작 호환: `status=active`이고 `expiresAt`이 미래면 그대로 `active=true`

## 주요 파일

- `packages/shared/src/types.ts` — `OneSubServerConfig.refundPolicy?: 'immediate' | 'until_expiry'`
- `packages/server/src/routes/webhook.ts` — Apple/Google 분기에 정책 반영
- `packages/server/src/routes/status.ts` — `expiresAt > now` 체크 추가

## Test plan

- [x] `npm run build` 통과
- [x] `npm test` — 257/257 (refund-policy.test.ts 11개 신규)
- [x] default(immediate): Apple REFUND + Google voided 모두 status=canceled 확인
- [x] until_expiry: status=active 유지, willRenew=false만 (Apple REFUND/REVOKE + Google voided)
- [x] until_expiry 모드에서도 IAP는 즉시 삭제 (Apple Consumable + Google productType=2)
- [x] until_expiry 모드에서 일반 알림(DID_RENEW)은 정상 처리 — willRenew도 freshly 적용
- [x] status route: active+pastExpiry → false, active+futureExpiry → true, grace_period+pastExpiry → false

## Breaking changes

**API 시그니처 동일.** 동작 변경 한 가지:
- `status='active'`이지만 `expiresAt`이 과거인 stale record는 이제 `active=false`로 보고됨
- 이전엔 `active=true`로 잘못 보고 — 명백한 안전 개선

## 참고

이 PR은 PR #24~#27 작업 라인의 4번째. 다음:
- #4 Google `SUBSCRIPTION_PAUSED` / `PAUSE_SCHEDULE_CHANGED`
- #5 Google `PRICE_CHANGE_CONFIRMED`
- #6 업그레이드/다운그레이드 (`linkedPurchaseToken`)

#3~#6 모두 머지 후 changeset cut 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)