### PR TITLE
Google SUBSCRIPTION_PRICE_CHANGE_CONFIRMED 처리 + onPriceChangeConfirmed hook

### DIFF
--- a/packages/server/src/__tests__/google-price-change.test.ts
+++ b/packages/server/src/__tests__/google-price-change.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests for Google webhook SUBSCRIPTION_PRICE_CHANGE_CONFIRMED (8) handling
+ * + the onPriceChangeConfirmed hook.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express from 'express';
+import type { OneSubServerConfig, SubscriptionInfo, GooglePriceChangeContext } from '@onesub/shared';
+import { SUBSCRIPTION_STATUS } from '@onesub/shared';
+import { createWebhookRouter } from '../routes/webhook.js';
+import { InMemorySubscriptionStore, InMemoryPurchaseStore } from '../store.js';
+
+interface TestServer {
+  request: (path: string, body: unknown) => Promise<{ status: number; body: unknown }>;
+}
+
+function spinUp(handler: express.Express): TestServer {
+  return {
+    async request(path, body) {
+      const server = handler.listen(0);
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      try {
+        const resp = await fetch(`http://127.0.0.1:${port}${path}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        const text = await resp.text();
+        let parsed: unknown = text;
+        try { parsed = JSON.parse(text); } catch { /* keep as text */ }
+        return { status: resp.status, body: parsed };
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    },
+  };
+}
+
+const sampleSub = (overrides?: Partial<SubscriptionInfo>): SubscriptionInfo => ({
+  userId: 'user_pc',
+  productId: 'pro_monthly',
+  platform: 'google',
+  status: 'active',
+  expiresAt: '2099-01-01T00:00:00.000Z',
+  originalTransactionId: 'tok_pc',
+  purchasedAt: '2026-01-01T00:00:00.000Z',
+  willRenew: true,
+  ...overrides,
+});
+
+function priceChangePushBody(purchaseToken = 'tok_pc') {
+  const json = JSON.stringify({
+    version: '1.0',
+    packageName: 'com.example.app',
+    eventTimeMillis: String(Date.now()),
+    subscriptionNotification: {
+      version: '1.0',
+      notificationType: 8, // SUBSCRIPTION_PRICE_CHANGE_CONFIRMED
+      purchaseToken,
+      subscriptionId: 'pro_monthly',
+    },
+  });
+  return {
+    message: { data: Buffer.from(json).toString('base64'), messageId: '1' },
+    subscription: 's',
+  };
+}
+
+function buildServer(config: OneSubServerConfig): {
+  store: InMemorySubscriptionStore;
+  server: TestServer;
+} {
+  const store = new InMemorySubscriptionStore();
+  const purchaseStore = new InMemoryPurchaseStore();
+  const app = express();
+  app.use(express.json());
+  app.use(createWebhookRouter(config, store, purchaseStore));
+  return { store, server: spinUp(app) };
+}
+
+describe('Google webhook — SUBSCRIPTION_PRICE_CHANGE_CONFIRMED (8)', () => {
+  it('keeps status=active for the existing record', async () => {
+    const { store, server } = buildServer({
+      google: { packageName: 'com.example.app' },
+      database: { url: '' },
+    });
+    await store.save(sampleSub({ originalTransactionId: 'tok_keep' }));
+
+    const resp = await server.request('/onesub/webhook/google', priceChangePushBody('tok_keep'));
+
+    expect(resp.status).toBe(200);
+    expect((await store.getByTransactionId('tok_keep'))?.status).toBe(SUBSCRIPTION_STATUS.ACTIVE);
+  });
+
+  it('invokes onPriceChangeConfirmed hook with correct context', async () => {
+    const captured: GooglePriceChangeContext[] = [];
+    const { store, server } = buildServer({
+      google: {
+        packageName: 'com.example.app',
+        onPriceChangeConfirmed: (ctx) => {
+          captured.push(ctx);
+        },
+      },
+      database: { url: '' },
+    });
+    await store.save(sampleSub({ originalTransactionId: 'tok_hook' }));
+
+    await server.request('/onesub/webhook/google', priceChangePushBody('tok_hook'));
+
+    // Hook is fire-and-forget — give microtask queue a tick
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).toEqual({
+      purchaseToken: 'tok_hook',
+      subscriptionId: 'pro_monthly',
+      packageName: 'com.example.app',
+    });
+  });
+
+  it('async hook is awaited internally without blocking the webhook response', async () => {
+    let hookResolved = false;
+    const { store, server } = buildServer({
+      google: {
+        packageName: 'com.example.app',
+        onPriceChangeConfirmed: async () => {
+          await new Promise((r) => setTimeout(r, 50));
+          hookResolved = true;
+        },
+      },
+      database: { url: '' },
+    });
+    await store.save(sampleSub({ originalTransactionId: 'tok_async' }));
+
+    const start = Date.now();
+    const resp = await server.request('/onesub/webhook/google', priceChangePushBody('tok_async'));
+    const responseLatency = Date.now() - start;
+
+    // Webhook returned 200 fast — host's slow hook didn't block
+    expect(resp.status).toBe(200);
+    expect(responseLatency).toBeLessThan(50);
+    expect(hookResolved).toBe(false);
+
+    // Hook still completes eventually
+    await new Promise((r) => setTimeout(r, 80));
+    expect(hookResolved).toBe(true);
+  });
+
+  it('hook errors are swallowed (webhook still returns 200)', async () => {
+    const { store, server } = buildServer({
+      google: {
+        packageName: 'com.example.app',
+        onPriceChangeConfirmed: () => {
+          throw new Error('boom');
+        },
+      },
+      database: { url: '' },
+    });
+    await store.save(sampleSub({ originalTransactionId: 'tok_throw' }));
+
+    const resp = await server.request('/onesub/webhook/google', priceChangePushBody('tok_throw'));
+    expect(resp.status).toBe(200);
+  });
+
+  it('does nothing extra when hook is not configured', async () => {
+    const { store, server } = buildServer({
+      google: { packageName: 'com.example.app' },
+      database: { url: '' },
+    });
+    await store.save(sampleSub({ originalTransactionId: 'tok_nohook' }));
+
+    const resp = await server.request('/onesub/webhook/google', priceChangePushBody('tok_nohook'));
+
+    expect(resp.status).toBe(200);
+    // Subscription still active — webhook didn't fail just because no hook
+    expect((await store.getByTransactionId('tok_nohook'))?.status).toBe(SUBSCRIPTION_STATUS.ACTIVE);
+  });
+
+  it('hook is NOT invoked for other notification types (e.g. DID_RENEW)', async () => {
+    const hookSpy = vi.fn();
+    const { store, server } = buildServer({
+      google: {
+        packageName: 'com.example.app',
+        onPriceChangeConfirmed: hookSpy,
+      },
+      database: { url: '' },
+    });
+    await store.save(sampleSub({ originalTransactionId: 'tok_other' }));
+
+    const renewBody = {
+      message: {
+        data: Buffer.from(JSON.stringify({
+          version: '1.0',
+          packageName: 'com.example.app',
+          eventTimeMillis: String(Date.now()),
+          subscriptionNotification: {
+            version: '1.0',
+            notificationType: 2, // SUBSCRIPTION_RENEWED
+            purchaseToken: 'tok_other',
+            subscriptionId: 'pro_monthly',
+          },
+        })).toString('base64'),
+        messageId: '1',
+      },
+      subscription: 's',
+    };
+
+    await server.request('/onesub/webhook/google', renewBody);
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(hookSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/providers/google.ts
+++ b/packages/server/src/providers/google.ts
@@ -703,3 +703,11 @@ export function isGoogleOnHoldNotification(notificationType: GoogleNotificationT
 export function isGooglePausedNotification(notificationType: GoogleNotificationType): boolean {
   return notificationType === GOOGLE_NOTIFICATION_TYPE.SUBSCRIPTION_PAUSED;
 }
+
+/**
+ * User agreed to a developer-initiated price change. The new price applies
+ * on the next renewal. Subscription remains active in the meantime.
+ */
+export function isGooglePriceChangeConfirmedNotification(notificationType: GoogleNotificationType): boolean {
+  return notificationType === GOOGLE_NOTIFICATION_TYPE.SUBSCRIPTION_PRICE_CHANGE_CONFIRMED;
+}

--- a/packages/server/src/routes/webhook.ts
+++ b/packages/server/src/routes/webhook.ts
@@ -25,6 +25,7 @@ import {
   isGoogleGracePeriodNotification,
   isGoogleOnHoldNotification,
   isGooglePausedNotification,
+  isGooglePriceChangeConfirmedNotification,
 } from '../providers/google.js';
 import { log } from '../logger.js';
 import { sendError } from '../errors.js';
@@ -429,6 +430,11 @@ export function createWebhookRouter(
         finalStatus = SUBSCRIPTION_STATUS.ON_HOLD;
       } else if (isGooglePausedNotification(notificationType)) {
         finalStatus = SUBSCRIPTION_STATUS.PAUSED;
+      } else if (isGooglePriceChangeConfirmedNotification(notificationType)) {
+        // User accepted a developer-initiated price change. Subscription stays
+        // active; the new price kicks in at the next renewal. Host can hook
+        // onPriceChangeConfirmed below to log/notify.
+        finalStatus = SUBSCRIPTION_STATUS.ACTIVE;
       } else if (isGoogleCanceledNotification(notificationType)) {
         finalStatus = SUBSCRIPTION_STATUS.CANCELED;
       } else if (isGoogleExpiredNotification(notificationType)) {
@@ -438,6 +444,19 @@ export function createWebhookRouter(
         // re-fetch from Play API will correct the status (subscriptionsv2 returns
         // SUBSCRIPTION_STATE_PAUSED etc. directly).
         finalStatus = SUBSCRIPTION_STATUS.ACTIVE; // optimistic; re-fetch below will correct it
+      }
+
+      // Fire-and-forget hook for PRICE_CHANGE_CONFIRMED — happens before store
+      // save so the hook still runs even if save errors out (the host's
+      // analytics/notification side effect shouldn't block on DB issues).
+      if (
+        isGooglePriceChangeConfirmedNotification(notificationType) &&
+        config.google?.onPriceChangeConfirmed
+      ) {
+        const hook = config.google.onPriceChangeConfirmed;
+        void Promise.resolve()
+          .then(() => hook({ purchaseToken, subscriptionId, packageName }))
+          .catch((err) => log.warn('[onesub/webhook/google] onPriceChangeConfirmed hook failed:', err));
       }
 
       if (existing) {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -122,6 +122,15 @@ export interface AppleConsumptionContext {
   environment: 'Production' | 'Sandbox';
 }
 
+/** Context passed to the Google onPriceChangeConfirmed hook. */
+export interface GooglePriceChangeContext {
+  /** purchaseToken — the same id stored as originalTransactionId for Google subs. */
+  purchaseToken: string;
+  /** Subscription productId (Google: subscriptionId). */
+  subscriptionId: string;
+  packageName: string;
+}
+
 /** Google RTDN (Real-Time Developer Notification) */
 export interface GoogleNotificationPayload {
   message: {
@@ -196,6 +205,17 @@ export interface OneSubServerConfig {
      * receipt string pattern. **NEVER enable in production.**
      */
     mockMode?: boolean;
+    /**
+     * Called when a SUBSCRIPTION_PRICE_CHANGE_CONFIRMED RTDN arrives — the
+     * user has agreed to the price change and the new price applies on the
+     * next renewal. Useful for analytics / in-app notifications / audit logs.
+     *
+     * Fire-and-forget: failures are logged, never thrown — the webhook still
+     * 200s. Receives only the routing context; for the actual new price,
+     * call purchases.subscriptionsv2 directly (the lineItem's
+     * autoRenewingPlan.priceChangeDetails carries newPrice + chargeTime).
+     */
+    onPriceChangeConfirmed?: (ctx: GooglePriceChangeContext) => void | Promise<void>;
   };
   database: {
     url: string;


### PR DESCRIPTION
## Summary

Google `SUBSCRIPTION_PRICE_CHANGE_CONFIRMED` (notification type 8) RTDN을 명시적으로 처리. 호스트 앱이 가격 변경 확인 시점에 분석/감사/사용자 알림 처리할 수 있게 옵션 hook 추가.

## 컨텍스트

- 개발자가 가격 인상 → Google이 사용자에게 동의 요청 (Play 결제 UI)
- 사용자 동의 시 `PRICE_CHANGE_CONFIRMED` RTDN 발송
- 새 가격은 **다음 갱신 시점부터** 적용. 그 동안 구독은 계속 `active`

기존 코드는 이 알림을 unhandled로 떨어뜨려 fresh re-fetch에 의존. 동작은 같지만 의도 불명확. 이번 PR로 명시 처리.

## API

**`config.google.onPriceChangeConfirmed?`** (옵션):
```ts
onPriceChangeConfirmed?: (ctx: {
  purchaseToken: string;
  subscriptionId: string;
  packageName: string;
}) => void | Promise<void>;
```

Fire-and-forget. 에러는 `log.warn`. 정확한 새 가격은 `purchases.subscriptionsv2` 직접 호출 (`lineItem.autoRenewingPlan.priceChangeDetails.newPrice`).

## 주요 파일

- `packages/shared/src/types.ts` — `GooglePriceChangeContext`, `OneSubServerConfig.google.onPriceChangeConfirmed`
- `packages/server/src/providers/google.ts` — `isGooglePriceChangeConfirmedNotification` 헬퍼
- `packages/server/src/routes/webhook.ts` — 명시 매핑 + hook 호출

## Test plan

- [x] `npm run build` 통과
- [x] `npm test` — 268/268 (google-price-change.test.ts 6개 신규)
- [x] PRICE_CHANGE_CONFIRMED → status=active 유지
- [x] hook이 정확한 context로 호출됨
- [x] async hook이 webhook response를 블록하지 않음 (latency<50ms)
- [x] hook throw → webhook 여전히 200
- [x] hook 미설정 시 정상 동작
- [x] 다른 알림(DID_RENEW)에는 hook 안 호출됨

## Breaking changes

없음. hook은 옵션, 매핑 변경은 기존 fresh re-fetch와 같은 결과.

## 참고

PR #28 작업 라인의 6번째. 다음:
- #6 업그레이드/다운그레이드 (`linkedPurchaseToken` 체인 추적)

#3~#6 머지 후 changeset cut 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)