### PR TITLE
paused.autoResumeTime 메타데이터 노출 (Google subscriptionsv2)

### DIFF
--- a/packages/server/sql/schema.sql
+++ b/packages/server/sql/schema.sql
@@ -25,15 +25,17 @@ CREATE TABLE IF NOT EXISTS onesub_subscriptions (
   purchased_at            TIMESTAMPTZ NOT NULL,
   will_renew              BOOLEAN     NOT NULL,
   linked_purchase_token   TEXT,
+  auto_resume_time        TIMESTAMPTZ,
   updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE INDEX IF NOT EXISTS idx_onesub_subscriptions_user_id
   ON onesub_subscriptions (user_id, updated_at DESC);
 
--- Backfill column for installs that already created the table from an older
+-- Backfill columns for installs that already created the table from an older
 -- schema. Safe to re-run.
 ALTER TABLE onesub_subscriptions ADD COLUMN IF NOT EXISTS linked_purchase_token TEXT;
+ALTER TABLE onesub_subscriptions ADD COLUMN IF NOT EXISTS auto_resume_time TIMESTAMPTZ;
 
 -- ─── One-time purchases (consumable + non-consumable) ────────────────────────
 -- `transaction_id` is the primary key: enforces one row per Apple/Google

--- a/packages/server/src/__tests__/paused-auto-resume.test.ts
+++ b/packages/server/src/__tests__/paused-auto-resume.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for SubscriptionInfo.autoResumeTime — Google paused subscriptions
+ * surface the auto-resume timestamp from v2 pausedStateContext, so host apps
+ * can render "재개 예정: YYYY-MM-DD" UX.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+import express from 'express';
+import { generateKeyPairSync } from 'crypto';
+import type { OneSubServerConfig, SubscriptionInfo } from '@onesub/shared';
+import { SUBSCRIPTION_STATUS } from '@onesub/shared';
+import { validateGoogleReceipt } from '../providers/google.js';
+import { createStatusRouter } from '../routes/status.js';
+import { InMemorySubscriptionStore } from '../store.js';
+import { isLocalhostUrl, urlHost } from './test-utils.js';
+
+let testPrivateKey: string;
+
+beforeAll(() => {
+  const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  testPrivateKey = privateKey.export({ type: 'pkcs8', format: 'pem' }) as string;
+});
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+function googleConfig(): NonNullable<OneSubServerConfig['google']> {
+  return {
+    packageName: 'com.example.app',
+    serviceAccountKey: JSON.stringify({
+      client_email: `test-${Math.random()}@test.iam.gserviceaccount.com`,
+      private_key: testPrivateKey,
+      token_uri: 'https://oauth2.googleapis.com/token',
+    }),
+  };
+}
+
+interface V2Response {
+  startTime?: string;
+  subscriptionState?: string;
+  latestOrderId?: string;
+  pausedStateContext?: { autoResumeTime?: string };
+  lineItems?: Array<{
+    productId?: string;
+    expiryTime?: string;
+    autoRenewingPlan?: { autoRenewEnabled?: boolean };
+  }>;
+}
+
+function v2Paused(opts: { autoResumeTime?: string; productId?: string }): V2Response {
+  return {
+    startTime: '2026-01-01T00:00:00Z',
+    subscriptionState: 'SUBSCRIPTION_STATE_PAUSED',
+    latestOrderId: 'GPA.paused_order',
+    pausedStateContext: opts.autoResumeTime ? { autoResumeTime: opts.autoResumeTime } : undefined,
+    lineItems: [{
+      productId: opts.productId ?? 'pro_monthly',
+      expiryTime: '2027-01-01T00:00:00Z',
+      autoRenewingPlan: { autoRenewEnabled: true },
+    }],
+  };
+}
+
+function v2Active(productId = 'pro_monthly'): V2Response {
+  return {
+    startTime: '2026-01-01T00:00:00Z',
+    subscriptionState: 'SUBSCRIPTION_STATE_ACTIVE',
+    latestOrderId: 'GPA.active_order',
+    lineItems: [{
+      productId,
+      expiryTime: '2027-01-01T00:00:00Z',
+      autoRenewingPlan: { autoRenewEnabled: true },
+    }],
+  };
+}
+
+function mockV2Fetch(responseBody: V2Response) {
+  const originalFetch = global.fetch;
+  vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+    if (isLocalhostUrl(url)) return originalFetch(url, init);
+    const host = urlHost(url);
+    if (host === 'oauth2.googleapis.com') {
+      return {
+        ok: true,
+        json: async () => ({ access_token: 'tok', expires_in: 3600 }),
+        text: async () => '',
+      } as Response;
+    }
+    if (host === 'androidpublisher.googleapis.com') {
+      return {
+        ok: true,
+        json: async () => responseBody,
+        text: async () => JSON.stringify(responseBody),
+      } as Response;
+    }
+    throw new Error(`[test] Unexpected URL: ${String(url)}`);
+  });
+}
+
+// ── validateGoogleReceipt surfaces autoResumeTime ───────────────────────────
+
+describe('validateGoogleReceipt — autoResumeTime passthrough', () => {
+  it('surfaces autoResumeTime when subscription is paused', async () => {
+    mockV2Fetch(v2Paused({ autoResumeTime: '2026-08-15T00:00:00Z' }));
+
+    const result = await validateGoogleReceipt('tok_paused', 'pro_monthly', googleConfig());
+
+    expect(result?.status).toBe(SUBSCRIPTION_STATUS.PAUSED);
+    expect(result?.autoResumeTime).toBe('2026-08-15T00:00:00Z');
+  });
+
+  it('autoResumeTime is undefined when paused but Google omits the timestamp', async () => {
+    // Google sometimes returns SUBSCRIPTION_STATE_PAUSED without
+    // pausedStateContext (rare, but the API allows it).
+    mockV2Fetch(v2Paused({}));
+
+    const result = await validateGoogleReceipt('tok_paused_no_ctx', 'pro_monthly', googleConfig());
+
+    expect(result?.status).toBe(SUBSCRIPTION_STATUS.PAUSED);
+    expect(result?.autoResumeTime).toBeUndefined();
+  });
+
+  it('autoResumeTime is undefined for active subscription (no pausedStateContext)', async () => {
+    mockV2Fetch(v2Active('pro_monthly'));
+
+    const result = await validateGoogleReceipt('tok_active', 'pro_monthly', googleConfig());
+
+    expect(result?.status).toBe(SUBSCRIPTION_STATUS.ACTIVE);
+    expect(result?.autoResumeTime).toBeUndefined();
+  });
+
+  it('autoResumeTime is undefined even if pausedStateContext appears on a non-paused state (defensive)', async () => {
+    // Google shouldn't send pausedStateContext for non-paused states, but if
+    // they ever do, we should not surface it as if the user were paused.
+    mockV2Fetch({
+      ...v2Active('pro_monthly'),
+      pausedStateContext: { autoResumeTime: '2099-01-01T00:00:00Z' },
+    });
+
+    const result = await validateGoogleReceipt('tok_defensive', 'pro_monthly', googleConfig());
+
+    expect(result?.status).toBe(SUBSCRIPTION_STATUS.ACTIVE);
+    expect(result?.autoResumeTime).toBeUndefined();
+  });
+});
+
+// ── status route surfaces autoResumeTime in subscription payload ────────────
+
+interface TestServer {
+  request: (path: string) => Promise<{ status: number; body: unknown }>;
+}
+
+function spinUpStatus(): { store: InMemorySubscriptionStore; server: TestServer } {
+  const store = new InMemorySubscriptionStore();
+  const app = express();
+  app.use(express.json());
+  app.use(createStatusRouter(store));
+  return {
+    store,
+    server: {
+      async request(path) {
+        const httpServer = app.listen(0);
+        const address = httpServer.address();
+        const port = typeof address === 'object' && address ? address.port : 0;
+        try {
+          const resp = await fetch(`http://127.0.0.1:${port}${path}`);
+          const body = await resp.json();
+          return { status: resp.status, body };
+        } finally {
+          await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+        }
+      },
+    },
+  };
+}
+
+const sampleSub = (overrides?: Partial<SubscriptionInfo>): SubscriptionInfo => ({
+  userId: 'u_pause',
+  productId: 'pro_monthly',
+  platform: 'google',
+  status: 'paused',
+  expiresAt: '2099-01-01T00:00:00.000Z',
+  originalTransactionId: 'tok_p',
+  purchasedAt: '2026-01-01T00:00:00.000Z',
+  willRenew: true,
+  ...overrides,
+});
+
+describe('status route — autoResumeTime in subscription payload', () => {
+  it('returns the saved autoResumeTime so the host can show "재개 예정" UX', async () => {
+    const { store, server } = spinUpStatus();
+    await store.save(sampleSub({
+      userId: 'u_with_resume',
+      autoResumeTime: '2026-09-01T00:00:00.000Z',
+    }));
+
+    const resp = await server.request('/onesub/status?userId=u_with_resume');
+    const body = resp.body as { active: boolean; subscription: SubscriptionInfo | null };
+
+    expect(body.active).toBe(false);  // paused stays revoked
+    expect(body.subscription?.autoResumeTime).toBe('2026-09-01T00:00:00.000Z');
+  });
+});

--- a/packages/server/src/providers/google.ts
+++ b/packages/server/src/providers/google.ts
@@ -488,6 +488,14 @@ export async function validateGoogleReceipt(
   const purchasedAt = purchase.startTime ?? new Date().toISOString();
   const willRenew = lineItem.autoRenewingPlan?.autoRenewEnabled ?? false;
 
+  // Surface autoResumeTime only when the subscription is actually paused —
+  // pausedStateContext is undefined for any other state, but be defensive in
+  // case Google starts including it on adjacent states (e.g. recently-resumed).
+  const autoResumeTime =
+    status === SUBSCRIPTION_STATUS.PAUSED
+      ? purchase.pausedStateContext?.autoResumeTime
+      : undefined;
+
   return {
     userId: '',  // caller fills this in
     productId,
@@ -500,6 +508,7 @@ export async function validateGoogleReceipt(
     // Surface the linked token so host apps (and our webhook userId-continuity
     // logic) can follow upgrade/downgrade chains.
     linkedPurchaseToken: purchase.linkedPurchaseToken,
+    autoResumeTime,
   };
 }
 

--- a/packages/server/src/stores/postgres.ts
+++ b/packages/server/src/stores/postgres.ts
@@ -61,8 +61,9 @@ export class PostgresSubscriptionStore implements SubscriptionStore {
     await pool.query(
       `INSERT INTO onesub_subscriptions
          (original_transaction_id, user_id, product_id, platform, status,
-          expires_at, purchased_at, will_renew, linked_purchase_token, updated_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
+          expires_at, purchased_at, will_renew, linked_purchase_token,
+          auto_resume_time, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW())
        ON CONFLICT (original_transaction_id) DO UPDATE SET
          user_id    = EXCLUDED.user_id,
          product_id = EXCLUDED.product_id,
@@ -72,6 +73,7 @@ export class PostgresSubscriptionStore implements SubscriptionStore {
          purchased_at = EXCLUDED.purchased_at,
          will_renew = EXCLUDED.will_renew,
          linked_purchase_token = EXCLUDED.linked_purchase_token,
+         auto_resume_time = EXCLUDED.auto_resume_time,
          updated_at = NOW()`,
       [
         sub.originalTransactionId,
@@ -83,6 +85,7 @@ export class PostgresSubscriptionStore implements SubscriptionStore {
         sub.purchasedAt,
         sub.willRenew,
         sub.linkedPurchaseToken ?? null,
+        sub.autoResumeTime ?? null,
       ]
     );
   }
@@ -304,6 +307,7 @@ interface DbRow {
   purchased_at: Date;
   will_renew: boolean;
   linked_purchase_token: string | null;
+  auto_resume_time: Date | null;
 }
 
 function rowToSubscriptionInfo(row: DbRow): SubscriptionInfo {
@@ -317,6 +321,7 @@ function rowToSubscriptionInfo(row: DbRow): SubscriptionInfo {
     purchasedAt: row.purchased_at.toISOString(),
     willRenew: row.will_renew,
     linkedPurchaseToken: row.linked_purchase_token ?? undefined,
+    autoResumeTime: row.auto_resume_time?.toISOString(),
   };
 }
 

--- a/packages/server/src/stores/schema.ts
+++ b/packages/server/src/stores/schema.ts
@@ -21,15 +21,17 @@ CREATE TABLE IF NOT EXISTS onesub_subscriptions (
   purchased_at            TIMESTAMPTZ NOT NULL,
   will_renew              BOOLEAN     NOT NULL,
   linked_purchase_token   TEXT,
+  auto_resume_time        TIMESTAMPTZ,
   updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE INDEX IF NOT EXISTS idx_onesub_subscriptions_user_id
   ON onesub_subscriptions (user_id, updated_at DESC);
 
--- Backfill column for installs that already created the table from an older
+-- Backfill columns for installs that already created the table from an older
 -- schema. Safe to re-run.
 ALTER TABLE onesub_subscriptions ADD COLUMN IF NOT EXISTS linked_purchase_token TEXT;
+ALTER TABLE onesub_subscriptions ADD COLUMN IF NOT EXISTS auto_resume_time TIMESTAMPTZ;
 `.trim();
 
 export const PURCHASES_SCHEMA_SQL = `

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -65,6 +65,14 @@ export interface SubscriptionInfo {
    * new token per plan change). Null/undefined for first-purchase or Apple.
    */
   linkedPurchaseToken?: string;
+  /**
+   * Google-only. When `status === 'paused'`, the RFC3339 timestamp at which
+   * Google plans to auto-resume the subscription (from
+   * `pausedStateContext.autoResumeTime` in subscriptionsv2). Lets the host UX
+   * show "재개 예정: YYYY-MM-DD" instead of just "일시정지 중". Undefined when
+   * not paused or if Google didn't supply it.
+   */
+  autoResumeTime?: string;
 }
 
 /** Subscription status check response */


### PR DESCRIPTION
## Summary

`paused` 상태에서 호스트 앱이 "재개 예정: YYYY-MM-DD" UX를 정확히 표시할 수 있도록 Google v2의 `pausedStateContext.autoResumeTime`을 `SubscriptionInfo`에 노출.

## 변경

- **`SubscriptionInfo.autoResumeTime?`** 추가 (Google 전용, 옵션 RFC3339 string)
- **`validateGoogleReceipt`**: `status === 'paused'`일 때만 `pausedStateContext.autoResumeTime` 추출 (defensive — 다른 상태에 잘못 붙어 와도 무시)
- **Postgres**: `onesub_subscriptions.auto_resume_time TIMESTAMPTZ` 칼럼 + `ALTER TABLE IF NOT EXISTS`로 자동 backfill
- INSERT/UPSERT/SELECT 매핑 + DbRow 업데이트, `sql/schema.sql` ↔ `stores/schema.ts` 동기화

## 시나리오

```
[t=0]   사용자가 Google Play에서 구독을 8월 15일까지 일시정지
[t=0+ε] Google webhook SUBSCRIPTION_PAUSED → finalStatus=paused, fresh re-fetch
[t=0+ε] v2 응답: { subscriptionState: 'PAUSED', pausedStateContext: { autoResumeTime: '2026-08-15T00:00:00Z' } }
[t=0+ε] store.save({ status: 'paused', autoResumeTime: '2026-08-15...' })
[t=N]   GET /onesub/status → { active: false, subscription: { status: 'paused', autoResumeTime: '2026-08-15...' } }
[t=N]   호스트 앱: "재개 예정: 2026-08-15"
```

## Test plan

- [x] `npm run build` 통과
- [x] `npm test` — 287/287 (paused-auto-resume.test.ts 5개 신규)
- [x] paused일 때 autoResumeTime 추출
- [x] paused지만 Google이 pausedStateContext 안 보낼 때 undefined
- [x] active 상태에서는 undefined
- [x] (defensive) active + pausedStateContext가 잘못 붙어와도 undefined
- [x] status route가 subscription record에 autoResumeTime 보존

## Breaking changes

없음. 옵션 필드 추가만.

**Postgres 사용자**: `initSchema()` 자동 backfill (`ALTER TABLE IF NOT EXISTS auto_resume_time TIMESTAMPTZ`). 수동 schema 적용한 경우 한 번 실행 권장.

## 다음

PR A(#34, fetch hardening) + 이 PR을 묶어 단일 release. 두 PR 모두 머지 후 changeset 작성.

🤖 Generated with [Claude Code](https://claude.com/claude-code)