### PR TITLE
docs: lifecycle states + new options (0.7→0.9 changes)

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -4,6 +4,79 @@ Upgrade notes for breaking releases of `@onesub/server`. Minor/patch releases wi
 
 ---
 
+## `@onesub/server` 0.7.x → 0.9.x
+
+Two minor releases in one window. Almost no host code change; the visible changes are **new lifecycle states**, **new opt-in config options**, and **two auto-backfilled Postgres columns**.
+
+### What changed
+
+**1. Lifecycle states added** (`@onesub/shared` 0.4.0 + 0.5.0):
+
+`SubscriptionStatus` gained three values:
+- `grace_period` — payment failed but Apple/Google still grants access (Apple `DID_FAIL_TO_RENEW` + `GRACE_PERIOD` subtype, Google `IN_GRACE_PERIOD`)
+- `on_hold` — grace ended, billing retry continues, entitlement REVOKED (Apple post-`GRACE_PERIOD_EXPIRED`, Google `ON_HOLD`)
+- `paused` — user-voluntary pause (Google only); resumes at `autoResumeTime`
+
+The `/onesub/status` route's `active: boolean` continues to work — it now treats `grace_period` as active and additionally checks `expiresAt > now` (stale-record safety + natural expiry for `until_expiry` refunds).
+
+**2. Webhook lifecycle classification fixed**:
+- Google: `IN_GRACE_PERIOD` (6) was previously misclassified as `active`; `ON_HOLD` (5) was unhandled. Now both map correctly.
+- Apple: `DID_FAIL_TO_RENEW` + `GRACE_PERIOD_EXPIRED` are now mapped explicitly (previously fell through to JWS-derived status).
+- Google: `validateGoogleReceipt` returns `'paused'` for `SUBSCRIPTION_STATE_PAUSED` (previously returned `'on_hold'` — see PR #29).
+
+**3. Google Play Developer API v1 → v2** (`subscriptionsv2.get`):
+Internal change. The v2 endpoint returns explicit `subscriptionState` enum strings instead of having to infer from `expiryTime`/`cancelReason`, which is what enables the correct grace/hold/paused classification above.
+
+**4. Two auto-backfilled Postgres columns**:
+- `onesub_subscriptions.linked_purchase_token TEXT`
+- `onesub_subscriptions.auto_resume_time TIMESTAMPTZ`
+
+`store.initSchema()` runs `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` on the next startup. No manual migration needed.
+
+**5. New opt-in config options** — all default to off; existing behavior unchanged.
+
+### You're affected if
+
+- You `switch (status)` exhaustively on `SubscriptionStatus`. The new values will need cases (TS will tell you).
+- You read `validateGoogleReceipt` output and compare the `status` string for `SUBSCRIPTION_STATE_PAUSED`-derived records. They now arrive as `'paused'` instead of `'on_hold'`.
+- You run a manually-applied schema (you don't call `store.initSchema()`). Add the two columns yourself or call `initSchema()` once on next deploy.
+
+### You're NOT affected if
+
+- You only check `isActive` (the SDK / status route's `active` boolean). The new states fold into the same active/not-active answer correctly.
+- You let `PostgresSubscriptionStore.initSchema()` run at boot.
+
+### Action
+
+```bash
+npm install @onesub/server@^0.9 @onesub/shared@^0.5
+```
+
+Optional follow-ups:
+
+```ts
+// Goodwill refund: keep entitlement until expiry
+{ refundPolicy: 'until_expiry' }
+
+// Apple App Store Server API features (status fetch fallback + consumption response)
+apple: { keyId, issuerId, privateKey, consumptionInfoProvider: ... }
+
+// Google price-change analytics
+google: { onPriceChangeConfirmed: (ctx) => analytics.track(...) }
+```
+
+### New behaviors to verify in sandbox
+
+The internal hardening (Apple JWT cache, fetch timeouts) is transparent. The lifecycle reclassification is not — verify:
+
+1. Apple billing retry: `SUBSCRIBED → DID_FAIL_TO_RENEW(GRACE) → GRACE_PERIOD_EXPIRED → DID_RENEW`
+2. Google paused: `PURCHASED → PAUSED → RESTARTED` (`autoResumeTime` populated while paused)
+3. Google plan upgrade: new token's `linkedPurchaseToken` correctly inherits the previous `userId`
+4. Apple subscription `REFUND` with `refundPolicy: 'immediate'` (default) flips to `canceled` immediately
+5. Apple webhook for an unknown `originalTransactionId` triggers Status API fallback (with API creds)
+
+---
+
 ## `@onesub/server` 0.6.x → 0.7.0
 
 **What changed:** `express`가 `dependencies`에서 **`peerDependencies`로 이동**. 더 이상 `@onesub/server`가 자체 express 사본을 끌고 들어오지 않음.

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -24,7 +24,15 @@ import { createOneSubMiddleware, PostgresSubscriptionStore, PostgresPurchaseStor
 const app = express();
 
 app.use(createOneSubMiddleware({
-  apple:  { bundleId: 'com.yourapp.id', sharedSecret: process.env.APPLE_SHARED_SECRET },
+  apple: {
+    bundleId: 'com.yourapp.id',
+    sharedSecret: process.env.APPLE_SHARED_SECRET,
+    // Optional — required only for the App Store Server API features below
+    // (status fetch fallback, consumption response).
+    keyId: process.env.APPLE_KEY_ID,
+    issuerId: process.env.APPLE_ISSUER_ID,
+    privateKey: process.env.APPLE_PRIVATE_KEY,
+  },
   google: { packageName: 'com.yourapp.id', serviceAccountKey: process.env.GOOGLE_SERVICE_ACCOUNT_KEY },
   database: { url: process.env.DATABASE_URL },
   store:         new PostgresSubscriptionStore(process.env.DATABASE_URL),
@@ -32,6 +40,7 @@ app.use(createOneSubMiddleware({
   // Optional:
   adminSecret: process.env.ADMIN_SECRET,   // enables /onesub/purchase/admin/*
   logger: require('pino')(),               // any { info, warn, error } logger
+  refundPolicy: 'immediate',               // 'immediate' (default) | 'until_expiry'
 }));
 
 app.listen(4100);
@@ -51,9 +60,85 @@ app.listen(4100);
 | `POST /onesub/purchase/admin/grant` | Manually grant a purchase (requires `adminSecret`) |
 | `POST /onesub/purchase/admin/transfer` | Reassign a `transactionId` to a new `userId` (requires `adminSecret`) |
 
+## Lifecycle states (`0.4.0+`)
+
+`SubscriptionInfo.status` carries the full lifecycle. The status route's `active: boolean` is computed as `(active || grace_period) && expiresAt > now` — but the raw status lets you render accurate UX:
+
+| Status | active | UX hint |
+|--------|--------|---------|
+| `active` | ✅ | normal |
+| `grace_period` | ✅ | "결제 정보 확인 필요 (계속 사용 가능)" |
+| `on_hold` | ❌ | "결제 정보를 업데이트하세요" |
+| `paused` | ❌ | "재개 예정: \{autoResumeTime\}" |
+| `expired` / `canceled` | ❌ | re-purchase or restore |
+
+See [`@onesub/shared` README](../shared/README.md) for the full mapping.
+
+## Refund policy (`0.8.0+`)
+
+```ts
+refundPolicy: 'immediate' | 'until_expiry'   // default 'immediate'
+```
+
+- `'immediate'` — subscription refunds (Apple `REFUND`/`REVOKE`, Google voided productType=1) flip status to `canceled` right away. Strict, fraud-resistant.
+- `'until_expiry'` — keep `status`/`expiresAt` untouched, only flip `willRenew = false`. User keeps entitlement until the original expiry. Better UX for goodwill refunds.
+
+IAP refunds (consumable / non-consumable) are **always immediate** regardless of policy — they have no expiry concept.
+
+## Optional Apple App Store Server API features (`0.8.0+`)
+
+Set `apple.keyId` / `apple.issuerId` / `apple.privateKey` (PKCS8 ES256 from App Store Connect → Users and Access → Keys) to unlock:
+
+### Status API fallback (automatic)
+
+If a webhook arrives for an `originalTransactionId` the store doesn't know (server downtime, queue truncation, fresh install), the webhook handler calls `GET /inApps/v1/subscriptions/{originalTransactionId}` to fetch canonical state from Apple and saves a record under a placeholder `userId`. Subsequent `/onesub/validate` from the host can claim ownership.
+
+You can also call it directly:
+
+```ts
+import { fetchAppleSubscriptionStatus } from '@onesub/server';
+
+const sub = await fetchAppleSubscriptionStatus(originalTxId, config.apple, { sandbox: false });
+// sub: SubscriptionInfo | null  — null on missing creds / 404 / network failure
+```
+
+### CONSUMPTION_REQUEST response hook
+
+When Apple sends a `CONSUMPTION_REQUEST` notification (consumable refund review), without a hook Apple has no usage signal and tends to grant the refund. Provide a hook to PUT consumption info back to `/inApps/v1/transactions/consumption/{txId}`:
+
+```ts
+apple: {
+  // ...
+  consumptionInfoProvider: async (ctx) => ({
+    customerConsented: true,                  // required; false makes Apple ignore the response
+    consumptionStatus: 3,                     // 0=undeclared, 1=not consumed, 2=partial, 3=full
+    deliveryStatus: 1,                        // 0=undeclared, 1=delivered & working, 2=quality issue, ...
+    refundPreference: 2,                      // 0=undeclared, 1=grant, 2=decline, 3=no preference
+    // see AppleConsumptionRequest for the full set of optional fields
+  }),
+}
+```
+
+Fire-and-forget; failures are logged but don't block the webhook 200.
+
+## Optional Google hooks (`0.8.0+`)
+
+```ts
+google: {
+  // ...
+  // Called when SUBSCRIPTION_PRICE_CHANGE_CONFIRMED (8) arrives — user agreed
+  // to a price change; new price applies on next renewal. Useful for analytics.
+  onPriceChangeConfirmed: async (ctx) => {
+    await analytics.track('price_change_confirmed', ctx);
+  },
+}
+```
+
 ## Schema
 
 Canonical Postgres DDL shipped at [`sql/schema.sql`](./sql/schema.sql). Apply with `psql -f` or let `store.initSchema()` run it for you on startup.
+
+`store.initSchema()` is **safe to call on every boot** — all DDL is `IF NOT EXISTS`. New columns added in later releases (e.g. `linked_purchase_token`, `auto_resume_time`) ship with `ALTER TABLE IF NOT EXISTS` so existing installs auto-backfill on the next startup.
 
 ## Security
 

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -6,10 +6,10 @@ You don't install this package directly — it's pulled in as a transitive depen
 
 ```ts
 import {
-  // Types
+  // Core types
   OneSubServerConfig,
   OneSubLogger,
-  SubscriptionInfo,
+  SubscriptionInfo,           // includes optional linkedPurchaseToken + autoResumeTime (Google)
   PurchaseInfo,
   ValidateReceiptRequest,
   ValidateReceiptResponse,
@@ -19,13 +19,34 @@ import {
   AppleNotificationPayload,
   GoogleNotificationPayload,
 
+  // Apple App Store Server API hook types
+  AppleConsumptionRequest,    // body shape for PUT /inApps/v1/transactions/consumption/{txId}
+  AppleConsumptionContext,    // arg passed to apple.consumptionInfoProvider hook
+
+  // Google RTDN hook types
+  GooglePriceChangeContext,   // arg passed to google.onPriceChangeConfirmed hook
+
   // Constants
-  SUBSCRIPTION_STATUS,   // 'active' | 'expired' | 'canceled' | 'none'
+  SUBSCRIPTION_STATUS,   // 'active' | 'grace_period' | 'on_hold' | 'paused' | 'expired' | 'canceled' | 'none'
   PURCHASE_TYPE,          // 'consumable' | 'non_consumable' | 'subscription'
   ROUTES,                 // canonical route path constants
   DEFAULT_PORT,
 } from '@onesub/shared';
 ```
+
+### Lifecycle states (since 0.4.0)
+
+| Value | Entitlement | When |
+|-------|------------|------|
+| `active` | ✅ valid | paid period |
+| `grace_period` | ✅ valid | payment failed but Apple/Google grants temporary access (Apple `DID_FAIL_TO_RENEW` + `GRACE_PERIOD` subtype, Google `IN_GRACE_PERIOD`) |
+| `on_hold` | ❌ revoked | grace ended; billing retry continues; user must fix payment |
+| `paused` | ❌ revoked | user-voluntary pause (Google only); resumes at `autoResumeTime` |
+| `expired` | ❌ revoked | natural end without renewal |
+| `canceled` | ❌ revoked | refunded or revoked by store |
+| `none` | ❌ revoked | no record |
+
+The status route's `active: boolean` is computed as `(status === 'active' || status === 'grace_period') && expiresAt > now`. Hosts that branch on the raw `status` string get the full granularity above (e.g. `paused` → "재개 예정" UX, `on_hold` → "결제 정보 업데이트" UX).
 
 All type definitions are single-source-of-truth. Don't re-declare them in consuming packages — derive from these.
 


### PR DESCRIPTION
## Summary

이번 두 release(0.7.x → 0.9.x)에서 추가된 기능들이 README/CHANGELOG에만 있고 사용 가이드가 없던 문제 해결. 외부 사용자가 새 기능 인식 못 하던 격차 해소.

## 갱신 파일

### `packages/shared/README.md`
- `SUBSCRIPTION_STATUS` 주석을 7개 값(`grace_period`/`on_hold`/`paused` 포함)으로 갱신 (이전엔 4개만 표시 — stale 정보)
- 새 hook context 타입 import 예제 추가
- **라이프사이클 상태 표 + entitlement 매핑** 섹션 신규 (호스트 앱 UX 가이드)

### `packages/server/README.md`
- Quick start 예제에 Apple App Store Server API 자격증명 + `refundPolicy` 노출
- 라이프사이클 상태 표 (UX hint 포함)
- **Refund policy** 섹션 (immediate vs until_expiry, IAP는 정책 무관)
- **Optional Apple App Store Server API features** 섹션 (Status fetch fallback + `consumptionInfoProvider` hook)
- **Optional Google hooks** 섹션 (`onPriceChangeConfirmed`)
- Schema 섹션에 `ALTER TABLE IF NOT EXISTS` 자동 backfill 명시

### `docs/MIGRATION.md`
- **`0.7.x → 0.9.x` 섹션** 신규 (이전엔 0.6→0.7까지만 있었음)
- 변경 5개 (라이프사이클 상태, webhook 분류 fix, Google v1→v2, Postgres 자동 backfill, 새 옵션)
- 영향 받음/안 받음 기준
- sandbox 검증 시나리오 5종

## 코드 변경 0줄

문서만 변경. CI/테스트는 baseline (296/296) 그대로 통과.

## Test plan

- [x] `npm run build` 통과
- [x] `npm test` — 296/296 (이전과 동일)

## 다음

루트 README의 Roadmap 갱신 + ARCHITECTURE.md 새 기능 architectural decision 반영은 별개 PR로 미룸 (분량 더 크고 reorg 필요).

🤖 Generated with [Claude Code](https://claude.com/claude-code)