### PR TITLE
docs(architecture): 0.7→0.9 신규 기능 architectural decision 반영

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,12 +33,30 @@ createOneSubMiddleware(config)
       │
       │── Subscriptions:
       ├── POST /onesub/validate           → zod → provider.validate → subscriptionStore.save
-      ├── GET  /onesub/status             → subscriptionStore.getByUserId → { active }
-      ├── POST /onesub/webhook/apple      → JWS verify → decode → subscriptionStore.save
-      ├── POST /onesub/webhook/google     → JWT verify → decode → subscriptionStore.save
+      │                                     (Google: acknowledgeGoogleSubscription fire-and-forget)
+      ├── GET  /onesub/status             → subscriptionStore.getByUserId
+      │                                     → active = (active|grace_period) && expiresAt > now
+      ├── POST /onesub/webhook/apple      → JWS verify → decode → mapAppleNotificationStatus
+      │                                     → IAP REFUND/REVOKE: purchaseStore.delete
+      │                                     → Sub: refundPolicy gating → store.save
+      │                                     → CONSUMPTION_REQUEST: consumptionInfoProvider hook
+      │                                       → sendAppleConsumptionResponse PUT
+      │                                     → unknown originalTransactionId + creds:
+      │                                       fetchAppleSubscriptionStatus → store.save
+      ├── POST /onesub/webhook/google     → JWT verify → decode
+      │                                     → voidedPurchaseNotification:
+      │                                       productType=1 → sub status update (refundPolicy)
+      │                                       productType=2 → purchaseStore.delete
+      │                                     → subscriptionNotification:
+      │                                       lifecycle map (active/grace_period/on_hold/paused/...)
+      │                                       → fresh re-fetch via subscriptionsv2.get
+      │                                       → store.save (linkedPurchaseToken continuity)
+      │                                     → PRICE_CHANGE_CONFIRMED: onPriceChangeConfirmed hook
       │
       │── One-time Purchases:
       ├── POST /onesub/purchase/validate  → zod → provider.validate → purchaseStore.save
+      │                                     (Google consumable: consumeGoogleProductReceipt fire-and-forget)
+      │                                     (Google non-consumable: acknowledgeGoogleProduct fire-and-forget)
       ├── GET  /onesub/purchase/status    → purchaseStore.getPurchasesByUserId → { purchases }
       │
       └── Admin (only if config.adminSecret is set; requires X-Admin-Secret header):
@@ -48,6 +66,8 @@ createOneSubMiddleware(config)
 ```
 
 All runtime logging goes through `config.logger` (OneSubLogger interface; defaults to `console`). Providers and routes import `log` from the internal `logger.ts` singleton instead of calling `console.*` directly.
+
+All outbound HTTP calls (Apple Status API, Apple Consumption Response, Google subscriptionsv2, Google OAuth, Google ack/consume) go through `http.ts/fetchWithTimeout` — `AbortController` with a 10s default budget so a hung upstream can't pile up webhook handlers.
 
 ## Store Interfaces
 
@@ -69,10 +89,25 @@ interface PurchaseStore {
   getPurchasesByUserId(userId: string): Promise<PurchaseInfo[]>;
   getPurchaseByTransactionId(txId: string): Promise<PurchaseInfo | null>;
   hasPurchased(userId: string, productId: string): Promise<boolean>;
-  reassignPurchase(transactionId: string, newUserId: string): Promise<boolean>; // 0.6.1+
-  deletePurchases(userId: string, productId: string): Promise<number>;          // 0.4.0+
+  reassignPurchase(transactionId: string, newUserId: string): Promise<boolean>;       // 0.6.1+
+  deletePurchases(userId: string, productId: string): Promise<number>;                // 0.4.0+
+  deletePurchaseByTransactionId(transactionId: string): Promise<boolean>;             // 0.8.0+
 }
 ```
+
+`deletePurchaseByTransactionId` is the precise single-row removal used by IAP refund paths (Apple `REFUND`/`REVOKE` for `Consumable`/`Non-Consumable`, Google `voidedPurchaseNotification` `productType=2`). Distinct from `deletePurchases(userId, productId)` which wipes all rows for that pair — using the userId/productId variant on a refund would also remove sibling consumable purchases the user still owns.
+
+### SubscriptionInfo extra fields
+
+```ts
+interface SubscriptionInfo {
+  // ...existing fields
+  linkedPurchaseToken?: string;   // Google plan upgrade chain (0.8.0+, populated only when chain exists)
+  autoResumeTime?: string;        // RFC3339, populated only when status === 'paused' (0.9.0+)
+}
+```
+
+Postgres columns added in `0.8.0` (`linked_purchase_token`) and `0.9.0` (`auto_resume_time`) are auto-backfilled by `initSchema()` via `ALTER TABLE IF NOT EXISTS` — safe to upgrade in place.
 
 Implementations:
 - `InMemorySubscriptionStore` / `InMemoryPurchaseStore` — development/testing only
@@ -104,6 +139,70 @@ MCP output is regression-tested: tests assert generated code contains `useOneSub
 ## Concurrency Model
 
 - Node.js single-threaded — no mutex needed for InMemoryStore Map operations
-- Google OAuth token: promise deduplication prevents thundering herd
+- Google OAuth token: promise deduplication prevents thundering herd, 60s pre-expiry refresh window
+- **Apple App Store Server API JWT**: same pattern — module-level cache keyed by `${issuerId}|${keyId}`, 20-minute TTL, refresh 60s before expiry, in-flight Promise dedup so concurrent burst pays one ECDSA-sign (`0.9.0+`)
 - Apple JWKS: `jose.createRemoteJWKSet` handles caching/refresh internally
 - PostgresStore UPSERT: atomic `ON CONFLICT DO UPDATE` — no read-then-write race
+- Outbound `fetchWithTimeout` (`http.ts`, `0.9.0+`): every upstream call wrapped with `AbortController` (default 10s). Caller signals composed via `addEventListener('abort', { once: true })`. Timer cleared in `finally` — no leaked handles
+
+## Lifecycle State Machine
+
+`SubscriptionInfo.status` is the canonical lifecycle state. The transitions are driven by:
+
+1. **Notification mapping** (webhook handler) — primary signal. Apple `mapAppleNotificationStatus(notificationType, subtype)` and Google `isGoogle*Notification(notificationType)` family return the new status string deterministically per notification.
+2. **Fresh re-fetch** (Google only) — after the notification map yields a status, `validateGoogleReceipt` is called against `subscriptionsv2.get` to refresh `expiresAt`/`willRenew`/`linkedPurchaseToken`/`autoResumeTime`. The notification-derived status is *preserved* for `grace_period`/`on_hold` (the v2 mapping can't always re-derive these without notification context); other statuses defer to the v2 response.
+3. **Apple Status API fallback** — for an unknown `originalTransactionId`, `fetchAppleSubscriptionStatus` resolves canonical state from Apple, mapping `status` codes 1..5 → `active`/`expired`/`on_hold`/`grace_period`/`canceled`.
+
+The status route's `active: boolean` collapses the lifecycle:
+```
+active = (status === 'active' || status === 'grace_period') && expiresAt > now
+```
+
+The `expiresAt > now` half is a backstop. Two cases need it:
+- `refundPolicy: 'until_expiry'` keeps `status === 'active'` after a refund — `active` flips false naturally when expiry passes (no `EXPIRED` webhook required).
+- General stale-record safety: if an `EXPIRED` webhook is missed, the user doesn't keep entitlement forever.
+
+See `README.md` for the visual state diagram and host UX hints.
+
+## Refund Policy
+
+```ts
+config.refundPolicy?: 'immediate' | 'until_expiry'   // default 'immediate'
+```
+
+Applies only to subscription refunds (Apple `REFUND`/`REVOKE`, Google `voidedPurchaseNotification` `productType=1`). Webhook handler decision tree:
+
+```
+isRefund?
+  ├── IAP (type === 'Consumable' || 'Non-Consumable', or Google productType=2)
+  │   → purchaseStore.deletePurchaseByTransactionId — always immediate (no expiry concept)
+  │
+  └── Subscription
+      ├── refundPolicy === 'until_expiry'
+      │   → store.save({ ...existing, willRenew: false })  // status + expiresAt preserved
+      │
+      └── refundPolicy === 'immediate' (default)
+          → store.save({ ...existing, status: 'canceled', willRenew, expiresAt: fresh })
+```
+
+Apple `CONSUMPTION_REQUEST` is intentionally excluded from the refund branch — it's a refund *review* request, not a confirmed refund. Host can decide via `apple.consumptionInfoProvider`.
+
+## Webhook Recovery (Apple Status API fallback)
+
+When the Apple webhook receives a notification for an `originalTransactionId` the local store doesn't know:
+
+1. If `apple.keyId` / `apple.issuerId` / `apple.privateKey` are configured: call `fetchAppleSubscriptionStatus(originalTransactionId, config.apple, { sandbox: env === 'Sandbox' })`.
+2. The response contains `lastTransactions[]` with the canonical state. Pick the entry matching the requested `originalTransactionId`, decode `signedTransactionInfo` + `signedRenewalInfo`, map `status` 1..5 → lifecycle state.
+3. Save the recovered record under a placeholder `userId = originalTransactionId`.
+4. The first subsequent `POST /onesub/validate` from the host will overwrite that placeholder with the real `userId` (provider derives it from the request body).
+
+Without API credentials the webhook still 200s (so Apple stops retrying) but logs the missed transaction. Recovery requires manual re-validate from the host.
+
+## Hooks (host integration points)
+
+Hooks let the host plug analytics / business logic into webhook lifecycle without forking onesub. All hooks are **fire-and-forget** — failures are caught + logged via `log.warn`, never propagated to the webhook response.
+
+| Hook | When | Purpose |
+|------|------|---------|
+| `apple.consumptionInfoProvider(ctx)` | `CONSUMPTION_REQUEST` notification + apple credentials present | Return `AppleConsumptionRequest` body; webhook PUTs it to Apple's `/inApps/v1/transactions/consumption/{txId}`. Without it, Apple has no usage signal and tends to grant the refund. |
+| `google.onPriceChangeConfirmed(ctx)` | `SUBSCRIPTION_PRICE_CHANGE_CONFIRMED` (8) RTDN | Notify analytics / send in-app notification; new price applies on next renewal. For the actual new price, host calls `subscriptionsv2.get` directly. |


### PR DESCRIPTION
## Summary

`docs/ARCHITECTURE.md`가 0.7→0.9 release(PR #24~#41)의 architectural decision을 반영 못 하던 격차 해소. 1 파일, +105/-6.

## 갱신 + 신규 섹션

### Server Middleware Architecture (대폭 갱신)
- Apple webhook: IAP REFUND 분기, refundPolicy gating, CONSUMPTION_REQUEST hook + sendAppleConsumptionResponse, unknown originalTransactionId fallback fetch
- Google webhook: voidedPurchaseNotification (productType 1/2 분기), subscriptionsv2 fresh re-fetch + linkedPurchaseToken continuity, PRICE_CHANGE_CONFIRMED hook
- Validate routes: Google ack 자동 호출
- Outbound HTTP: `fetchWithTimeout` (AbortController) — 모든 upstream 호출에 적용

### Store Interfaces (갱신)
- `PurchaseStore.deletePurchaseByTransactionId` (0.8.0+) 추가 + `deletePurchases`와의 의미 차이 명시
- `SubscriptionInfo` 새 옵션 필드 (`linkedPurchaseToken`, `autoResumeTime`)
- Postgres `ALTER TABLE IF NOT EXISTS` 자동 backfill 정책

### Concurrency Model (갱신)
- Apple App Store Server API JWT 캐시 (Google 패턴 미러링: `issuerId|keyId` 키, 20분 TTL, 60s pre-expiry refresh, Promise dedup)
- `fetchWithTimeout` AbortController 합성 + timer cleanup

### 신규 섹션 4종
1. **Lifecycle State Machine** — 3가지 상태 전이 동력(알림 매핑 / fresh re-fetch / Apple Status API fallback)의 우선순위 + `active` 계산식의 `expiresAt > now` backstop 의도
2. **Refund Policy** — IAP vs sub 분기 + CONSUMPTION_REQUEST를 refund branch에서 제외한 이유 (refund REVIEW지 confirmed refund 아님)
3. **Webhook Recovery** — Apple Status API fallback 4단계 시퀀스 + creds 없을 때의 ack-only 동작
4. **Hooks** — host 통합 포인트 표 (consumptionInfoProvider, onPriceChangeConfirmed) + fire-and-forget 정책 명시

## Test plan

- [x] `npm run build` 통과
- [x] `npm test` — 296/296 (이전 baseline)

## Breaking changes

없음. 문서만.

## 다음

루트 README + ARCHITECTURE.md 모두 0.9.x 반영 완료. 큰 docs reorg 라운드 종료. 다음 deferred 항목(Family Sharing, Promotional Offer 등 신규 기능)은 수요 생기면 별개 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)