### PR TITLE
feat: Entitlements 추상화 (server-side)

### DIFF
--- a/packages/server/src/__tests__/entitlements.test.ts
+++ b/packages/server/src/__tests__/entitlements.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Entitlements abstraction tests.
+ *
+ * Covers:
+ *   - evaluateEntitlement helper (subscription / purchase / mixed / none /
+ *     expired sub / wrong status / consumable excluded)
+ *   - GET /onesub/entitlement single-check route (404 unknown id, 400 bad input)
+ *   - GET /onesub/entitlements bulk route
+ *   - Router not mounted when config.entitlements is absent (404)
+ *   - getAllByUserId returns multi-product subscriptions (regression for the
+ *     InMemoryStore change that backs entitlements)
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import express from 'express';
+import type {
+  EntitlementResponse,
+  EntitlementsConfig,
+  EntitlementsResponse,
+  OneSubServerConfig,
+  PurchaseInfo,
+  SubscriptionInfo,
+} from '@onesub/shared';
+import { SUBSCRIPTION_STATUS, PURCHASE_TYPE } from '@onesub/shared';
+import { createOneSubMiddleware } from '../index.js';
+import { evaluateEntitlement } from '../routes/entitlements.js';
+import { InMemorySubscriptionStore, InMemoryPurchaseStore } from '../store.js';
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+const futureExpiry = '2099-01-01T00:00:00.000Z';
+const pastExpiry = '2024-01-01T00:00:00.000Z';
+
+function sub(overrides?: Partial<SubscriptionInfo>): SubscriptionInfo {
+  return {
+    userId: 'u',
+    productId: 'pro_monthly',
+    platform: 'apple',
+    status: 'active',
+    expiresAt: futureExpiry,
+    originalTransactionId: `orig_${Math.random()}`,
+    purchasedAt: '2026-01-01T00:00:00.000Z',
+    willRenew: true,
+    ...overrides,
+  };
+}
+
+function purchase(overrides?: Partial<PurchaseInfo>): PurchaseInfo {
+  return {
+    userId: 'u',
+    productId: 'lifetime_pass',
+    platform: 'apple',
+    type: 'non_consumable',
+    transactionId: `tx_${Math.random()}`,
+    purchasedAt: '2026-01-01T00:00:00.000Z',
+    quantity: 1,
+    ...overrides,
+  };
+}
+
+interface TestServer {
+  get: <T,>(path: string) => Promise<{ status: number; body: T }>;
+}
+
+function spinUp(handler: express.Express): TestServer {
+  return {
+    async get<T>(path: string): Promise<{ status: number; body: T }> {
+      const httpServer = handler.listen(0);
+      const port = (httpServer.address() as { port: number }).port;
+      try {
+        const resp = await fetch(`http://127.0.0.1:${port}${path}`);
+        const text = await resp.text();
+        let parsed: unknown = text;
+        try { parsed = JSON.parse(text); } catch { /* keep as text */ }
+        return { status: resp.status, body: parsed as T };
+      } finally {
+        await new Promise<void>((r) => httpServer.close(() => r()));
+      }
+    },
+  };
+}
+
+function buildServer(opts: {
+  entitlements?: EntitlementsConfig;
+  subs?: SubscriptionInfo[];
+  purchases?: PurchaseInfo[];
+}): {
+  store: InMemorySubscriptionStore;
+  purchaseStore: InMemoryPurchaseStore;
+  server: TestServer;
+} {
+  const store = new InMemorySubscriptionStore();
+  const purchaseStore = new InMemoryPurchaseStore();
+  const config: OneSubServerConfig = {
+    apple: { bundleId: 'com.example.app', skipJwsVerification: true },
+    database: { url: '' },
+    entitlements: opts.entitlements,
+  };
+
+  const app = express();
+  // createOneSubMiddleware mounts express.json itself, but the entitlement
+  // routes are GET-only so it's fine either way.
+  const middleware = createOneSubMiddleware({ ...config, store, purchaseStore });
+  app.use(middleware);
+
+  return { store, purchaseStore, server: spinUp(app) };
+}
+
+const PREMIUM: EntitlementsConfig = {
+  premium: { productIds: ['pro_monthly', 'pro_yearly', 'lifetime_pass'] },
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// evaluateEntitlement (unit, no HTTP)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('evaluateEntitlement', () => {
+  let store: InMemorySubscriptionStore;
+  let purchaseStore: InMemoryPurchaseStore;
+
+  beforeEach(() => {
+    store = new InMemorySubscriptionStore();
+    purchaseStore = new InMemoryPurchaseStore();
+  });
+
+  it('active subscription matching one of the productIds → entitled', async () => {
+    await store.save(sub({ userId: 'u1', productId: 'pro_yearly' }));
+    const result = await evaluateEntitlement('u1', PREMIUM.premium, store, purchaseStore);
+    expect(result.active).toBe(true);
+    expect(result.source).toBe('subscription');
+    expect(result.productId).toBe('pro_yearly');
+    expect(result.expiresAt).toBe(futureExpiry);
+  });
+
+  it('non-consumable purchase matching one of the productIds → entitled', async () => {
+    await purchaseStore.savePurchase(purchase({ userId: 'u2', productId: 'lifetime_pass' }));
+    const result = await evaluateEntitlement('u2', PREMIUM.premium, store, purchaseStore);
+    expect(result.active).toBe(true);
+    expect(result.source).toBe('purchase');
+    expect(result.productId).toBe('lifetime_pass');
+    expect(result.expiresAt).toBeUndefined();
+  });
+
+  it('no matching record → not entitled', async () => {
+    const result = await evaluateEntitlement('u_none', PREMIUM.premium, store, purchaseStore);
+    expect(result).toEqual({ active: false, source: null });
+  });
+
+  it('subscription preferred over purchase when both match', async () => {
+    await store.save(sub({ userId: 'u3', productId: 'pro_monthly' }));
+    await purchaseStore.savePurchase(purchase({ userId: 'u3', productId: 'lifetime_pass' }));
+    const result = await evaluateEntitlement('u3', PREMIUM.premium, store, purchaseStore);
+    expect(result.source).toBe('subscription');
+    expect(result.productId).toBe('pro_monthly');
+  });
+
+  it('expired subscription (expiresAt < now) → not entitled even if status=active', async () => {
+    await store.save(sub({ userId: 'u4', productId: 'pro_monthly', expiresAt: pastExpiry }));
+    const result = await evaluateEntitlement('u4', PREMIUM.premium, store, purchaseStore);
+    expect(result.active).toBe(false);
+  });
+
+  it('grace_period subscription → entitled (still has valid expiresAt)', async () => {
+    await store.save(sub({ userId: 'u5', productId: 'pro_monthly', status: 'grace_period' }));
+    const result = await evaluateEntitlement('u5', PREMIUM.premium, store, purchaseStore);
+    expect(result.active).toBe(true);
+    expect(result.source).toBe('subscription');
+  });
+
+  it('on_hold / paused / canceled / expired status → not entitled', async () => {
+    for (const status of ['on_hold', 'paused', 'canceled', 'expired'] as const) {
+      const localStore = new InMemorySubscriptionStore();
+      await localStore.save(sub({ userId: 'u', productId: 'pro_monthly', status }));
+      const result = await evaluateEntitlement('u', PREMIUM.premium, localStore, purchaseStore);
+      expect(result.active).toBe(false);
+    }
+  });
+
+  it('consumable purchase is NOT considered for entitlement', async () => {
+    await purchaseStore.savePurchase(purchase({
+      userId: 'u6',
+      productId: 'pro_monthly',  // even matching productId
+      type: 'consumable',
+    }));
+    const result = await evaluateEntitlement('u6', PREMIUM.premium, store, purchaseStore);
+    expect(result.active).toBe(false);
+  });
+
+  it('multi-product subscriptions: returns the first matching active sub', async () => {
+    // User has two subs — one for pro_yearly (matches), one for off-premium product (no match)
+    await store.save(sub({ userId: 'u7', productId: 'unrelated_product' }));
+    await store.save(sub({ userId: 'u7', productId: 'pro_yearly' }));
+    const result = await evaluateEntitlement('u7', PREMIUM.premium, store, purchaseStore);
+    expect(result.active).toBe(true);
+    expect(result.productId).toBe('pro_yearly');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// HTTP routes
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /onesub/entitlement', () => {
+  it('returns active=true when user has matching active sub', async () => {
+    const { store, server } = buildServer({ entitlements: PREMIUM });
+    await store.save(sub({ userId: 'u_yes', productId: 'pro_monthly' }));
+
+    const resp = await server.get<EntitlementResponse>('/onesub/entitlement?userId=u_yes&id=premium');
+
+    expect(resp.status).toBe(200);
+    expect(resp.body.id).toBe('premium');
+    expect(resp.body.active).toBe(true);
+    expect(resp.body.source).toBe('subscription');
+  });
+
+  it('returns active=false when no matching record', async () => {
+    const { server } = buildServer({ entitlements: PREMIUM });
+    const resp = await server.get<EntitlementResponse>('/onesub/entitlement?userId=u_none&id=premium');
+    expect(resp.status).toBe(200);
+    expect(resp.body.active).toBe(false);
+    expect(resp.body.source).toBeNull();
+  });
+
+  it('404 + ENTITLEMENT_NOT_FOUND for unknown id', async () => {
+    const { server } = buildServer({ entitlements: PREMIUM });
+    const resp = await server.get<{ errorCode: string }>('/onesub/entitlement?userId=u&id=enterprise');
+    expect(resp.status).toBe(404);
+    expect(resp.body.errorCode).toBe('ENTITLEMENT_NOT_FOUND');
+  });
+
+  it('400 INVALID_INPUT when userId or id is missing', async () => {
+    const { server } = buildServer({ entitlements: PREMIUM });
+    const resp = await server.get<{ errorCode: string }>('/onesub/entitlement?userId=u');
+    expect(resp.status).toBe(400);
+    expect(resp.body.errorCode).toBe('INVALID_INPUT');
+  });
+});
+
+describe('GET /onesub/entitlements (bulk)', () => {
+  it('evaluates every configured entitlement in one round-trip', async () => {
+    const config: EntitlementsConfig = {
+      premium: { productIds: ['pro_monthly', 'pro_yearly'] },
+      promode: { productIds: ['dev_tools_addon'] },
+    };
+    const { store, server } = buildServer({ entitlements: config });
+    await store.save(sub({ userId: 'u_bulk', productId: 'pro_yearly' }));
+
+    const resp = await server.get<EntitlementsResponse>('/onesub/entitlements?userId=u_bulk');
+
+    expect(resp.status).toBe(200);
+    expect(resp.body.entitlements.premium.active).toBe(true);
+    expect(resp.body.entitlements.premium.productId).toBe('pro_yearly');
+    expect(resp.body.entitlements.promode.active).toBe(false);
+  });
+
+  it('returns empty entitlement statuses for a user with nothing', async () => {
+    const config: EntitlementsConfig = {
+      premium: { productIds: ['pro_monthly'] },
+      addon: { productIds: ['some_addon'] },
+    };
+    const { server } = buildServer({ entitlements: config });
+
+    const resp = await server.get<EntitlementsResponse>('/onesub/entitlements?userId=u_empty');
+
+    expect(resp.body.entitlements.premium.active).toBe(false);
+    expect(resp.body.entitlements.addon.active).toBe(false);
+  });
+});
+
+describe('Entitlement routes are NOT mounted without config', () => {
+  it('returns 404 when config.entitlements is absent', async () => {
+    const { server } = buildServer({});  // no entitlements
+
+    const resp = await server.get<unknown>('/onesub/entitlement?userId=u&id=premium');
+    expect(resp.status).toBe(404);
+
+    const respBulk = await server.get<unknown>('/onesub/entitlements?userId=u');
+    expect(respBulk.status).toBe(404);
+  });
+
+  it('returns 404 when config.entitlements is empty {}', async () => {
+    const { server } = buildServer({ entitlements: {} });
+    const resp = await server.get<unknown>('/onesub/entitlement?userId=u&id=premium');
+    expect(resp.status).toBe(404);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Store regression: getAllByUserId returns multi-product subs
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('InMemorySubscriptionStore — multi-sub per user (entitlement support)', () => {
+  it('getAllByUserId returns all subs across productIds, latest first', async () => {
+    const store = new InMemorySubscriptionStore();
+    await store.save(sub({ userId: 'u', productId: 'pro_monthly', originalTransactionId: 'orig_a' }));
+    await store.save(sub({ userId: 'u', productId: 'pro_yearly', originalTransactionId: 'orig_b' }));
+    await store.save(sub({ userId: 'u', productId: 'addon', originalTransactionId: 'orig_c' }));
+
+    const all = await store.getAllByUserId('u');
+    expect(all.map((s) => s.productId)).toEqual(['addon', 'pro_yearly', 'pro_monthly']);
+  });
+
+  it('getByUserId still returns the most recent (legacy contract preserved)', async () => {
+    const store = new InMemorySubscriptionStore();
+    await store.save(sub({ userId: 'u', productId: 'pro_monthly', originalTransactionId: 'orig_a' }));
+    await store.save(sub({ userId: 'u', productId: 'pro_yearly', originalTransactionId: 'orig_b' }));
+
+    const latest = await store.getByUserId('u');
+    expect(latest?.productId).toBe('pro_yearly');
+  });
+
+  it('save() with same originalTransactionId replaces prior record (no duplicates)', async () => {
+    const store = new InMemorySubscriptionStore();
+    await store.save(sub({
+      userId: 'u', productId: 'pro_monthly', originalTransactionId: 'orig_x',
+      status: 'active',
+    }));
+    await store.save(sub({
+      userId: 'u', productId: 'pro_monthly', originalTransactionId: 'orig_x',
+      status: 'canceled',
+    }));
+
+    const all = await store.getAllByUserId('u');
+    expect(all).toHaveLength(1);
+    expect(all[0].status).toBe(SUBSCRIPTION_STATUS.CANCELED);
+  });
+});
+
+// keep the import honest
+PURCHASE_TYPE;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -8,6 +8,7 @@ import { createStatusRouter } from './routes/status.js';
 import { createWebhookRouter } from './routes/webhook.js';
 import { createPurchaseRouter } from './routes/purchase.js';
 import { createAdminRouter } from './routes/admin.js';
+import { createEntitlementRouter } from './routes/entitlements.js';
 import { setLogger } from './logger.js';
 
 /**
@@ -74,6 +75,10 @@ export function createOneSubMiddleware(config: OneSubMiddlewareConfig): Router {
   const adminRouter = createAdminRouter(config, purchaseStore);
   if (adminRouter) router.use(adminRouter);
 
+  // Entitlement routes — only mounted when config.entitlements is set
+  const entitlementRouter = createEntitlementRouter(config, store, purchaseStore);
+  if (entitlementRouter) router.use(entitlementRouter);
+
   return router;
 }
 
@@ -106,6 +111,10 @@ export { PostgresSubscriptionStore, PostgresPurchaseStore } from './stores/postg
 // Provider functions for direct (non-HTTP) usage
 export { validateAppleReceipt, fetchAppleSubscriptionStatus } from './providers/apple.js';
 export { validateGoogleReceipt } from './providers/google.js';
+
+// Entitlement evaluator — exported so hosts can evaluate entitlements
+// in-process (e.g. from non-HTTP background workers, custom routes).
+export { evaluateEntitlement } from './routes/entitlements.js';
 
 // Logger plumbing — expose so non-middleware callers (direct provider use)
 // can still redirect logs.

--- a/packages/server/src/routes/entitlements.ts
+++ b/packages/server/src/routes/entitlements.ts
@@ -1,0 +1,161 @@
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { z } from 'zod';
+import type {
+  Entitlement,
+  EntitlementResponse,
+  EntitlementStatus,
+  EntitlementsConfig,
+  EntitlementsResponse,
+  OneSubServerConfig,
+  PurchaseInfo,
+  SubscriptionInfo,
+} from '@onesub/shared';
+import { ROUTES, SUBSCRIPTION_STATUS, ONESUB_ERROR_CODE, PURCHASE_TYPE } from '@onesub/shared';
+import type { PurchaseStore, SubscriptionStore } from '../store.js';
+import { log } from '../logger.js';
+import { sendError } from '../errors.js';
+
+/**
+ * Evaluate a single entitlement for a user.
+ *
+ * A user is entitled when EITHER condition holds for any productId in
+ * `entitlement.productIds`:
+ *   1. an active subscription (status === active|grace_period AND
+ *      expiresAt > now) for that productId exists
+ *   2. a non-consumable purchase for that productId exists
+ *
+ * Consumables are intentionally excluded — they grant a one-time resource,
+ * not an ongoing right.
+ *
+ * Subscription is preferred over purchase when both match (subs carry an
+ * expiry; non-consumables are forever) so the source field skews toward the
+ * more "interesting" signal for ops/analytics.
+ */
+export async function evaluateEntitlement(
+  userId: string,
+  entitlement: Entitlement,
+  store: SubscriptionStore,
+  purchaseStore: PurchaseStore,
+): Promise<EntitlementStatus> {
+  const productIdSet = new Set(entitlement.productIds);
+  const now = Date.now();
+
+  // 1. Check subscriptions first (richer signal — has expiry).
+  const subs = await store.getAllByUserId(userId);
+  for (const sub of subs) {
+    if (!productIdSet.has(sub.productId)) continue;
+    const statusAllows =
+      sub.status === SUBSCRIPTION_STATUS.ACTIVE ||
+      sub.status === SUBSCRIPTION_STATUS.GRACE_PERIOD;
+    if (!statusAllows) continue;
+    if (new Date(sub.expiresAt).getTime() <= now) continue;
+    return {
+      active: true,
+      source: 'subscription',
+      productId: sub.productId,
+      expiresAt: sub.expiresAt,
+    };
+  }
+
+  // 2. Check non-consumable purchases.
+  const purchases = await purchaseStore.getPurchasesByUserId(userId);
+  for (const p of purchases) {
+    if (p.type !== PURCHASE_TYPE.NON_CONSUMABLE) continue;
+    if (!productIdSet.has(p.productId)) continue;
+    return {
+      active: true,
+      source: 'purchase',
+      productId: p.productId,
+    };
+  }
+
+  return { active: false, source: null };
+}
+
+const userIdSchema = z.string().min(1).max(256);
+const entitlementIdSchema = z.string().min(1).max(128);
+
+export function createEntitlementRouter(
+  config: OneSubServerConfig,
+  store: SubscriptionStore,
+  purchaseStore: PurchaseStore,
+): Router | null {
+  // Only mount when entitlements are configured. Without this guard, the
+  // routes would always 503 — better to make the absence loud (404 from
+  // express) so misconfiguration is obvious during dev.
+  if (!config.entitlements || Object.keys(config.entitlements).length === 0) {
+    return null;
+  }
+  const entitlements: EntitlementsConfig = config.entitlements;
+
+  const router = Router();
+
+  /**
+   * GET /onesub/entitlement?userId=&id=premium
+   * Single entitlement check.
+   */
+  router.get(ROUTES.ENTITLEMENT, async (req: Request, res: Response) => {
+    let userId: string;
+    let id: string;
+    try {
+      userId = userIdSchema.parse(req.query['userId']);
+      id = entitlementIdSchema.parse(req.query['id']);
+    } catch {
+      sendError(res, 400, ONESUB_ERROR_CODE.INVALID_INPUT, 'userId and id are required');
+      return;
+    }
+
+    const entitlement = entitlements[id];
+    if (!entitlement) {
+      sendError(res, 404, ONESUB_ERROR_CODE.ENTITLEMENT_NOT_FOUND, `Unknown entitlement: ${id}`);
+      return;
+    }
+
+    try {
+      const status = await evaluateEntitlement(userId, entitlement, store, purchaseStore);
+      const response: EntitlementResponse = { id, ...status };
+      res.status(200).json(response);
+    } catch (err) {
+      log.error('[onesub/entitlement] evaluation error:', err);
+      sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, 'Internal server error');
+    }
+  });
+
+  /**
+   * GET /onesub/entitlements?userId=
+   * Evaluate every configured entitlement in one round-trip — useful on
+   * app launch / login when the host wants the full entitlement map.
+   */
+  router.get(ROUTES.ENTITLEMENTS, async (req: Request, res: Response) => {
+    let userId: string;
+    try {
+      userId = userIdSchema.parse(req.query['userId']);
+    } catch {
+      sendError(res, 400, ONESUB_ERROR_CODE.INVALID_INPUT, 'userId is required');
+      return;
+    }
+
+    try {
+      const entries = await Promise.all(
+        Object.entries(entitlements).map(async ([id, entitlement]) => {
+          const status = await evaluateEntitlement(userId, entitlement, store, purchaseStore);
+          return [id, status] as const;
+        }),
+      );
+      const response: EntitlementsResponse = {
+        entitlements: Object.fromEntries(entries),
+      };
+      res.status(200).json(response);
+    } catch (err) {
+      log.error('[onesub/entitlements] evaluation error:', err);
+      sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, 'Internal server error', { entitlements: {} });
+    }
+  });
+
+  return router;
+}
+
+// Keep the unused-type imports honest — these are exported as documentation
+// for callers writing their own evaluators.
+export type { Entitlement, EntitlementStatus, PurchaseInfo, SubscriptionInfo };

--- a/packages/server/src/store.ts
+++ b/packages/server/src/store.ts
@@ -7,8 +7,23 @@ import type { SubscriptionInfo, PurchaseInfo } from '@onesub/shared';
  */
 export interface SubscriptionStore {
   save(sub: SubscriptionInfo): Promise<void>;
+  /**
+   * Returns the most recent subscription for the user, or null if none exist.
+   * Use this for legacy single-product checks (`/onesub/status`); for
+   * entitlements that span multiple productIds, prefer `getAllByUserId`.
+   */
   getByUserId(userId: string): Promise<SubscriptionInfo | null>;
   getByTransactionId(txId: string): Promise<SubscriptionInfo | null>;
+  /**
+   * Returns every subscription record for the user (across all productIds),
+   * ordered most-recent-first. Used by entitlement evaluation, which needs to
+   * see all of a user's active subscriptions to decide whether any of them
+   * grants the requested entitlement.
+   *
+   * Implementations: in-memory currently coalesces by userId so this returns
+   * at most one row; Postgres returns the full history.
+   */
+  getAllByUserId(userId: string): Promise<SubscriptionInfo[]>;
 }
 
 /**
@@ -16,16 +31,30 @@ export interface SubscriptionStore {
  * Data is lost on process restart.
  */
 export class InMemorySubscriptionStore implements SubscriptionStore {
-  private readonly byUserId = new Map<string, SubscriptionInfo>();
+  // Multiple records per user (different originalTransactionIds) — required
+  // for entitlement evaluation across multiple productIds. Ordering is
+  // last-written-first so getByUserId returns "most recent" naturally.
+  private readonly byUserId = new Map<string, SubscriptionInfo[]>();
   private readonly byTransactionId = new Map<string, SubscriptionInfo>();
 
   async save(sub: SubscriptionInfo): Promise<void> {
-    this.byUserId.set(sub.userId, sub);
     this.byTransactionId.set(sub.originalTransactionId, sub);
+
+    const existing = this.byUserId.get(sub.userId) ?? [];
+    // Replace any prior record with the same originalTransactionId, then
+    // unshift to the front so the latest write is index 0 (= getByUserId result).
+    const filtered = existing.filter((s) => s.originalTransactionId !== sub.originalTransactionId);
+    filtered.unshift(sub);
+    this.byUserId.set(sub.userId, filtered);
   }
 
   async getByUserId(userId: string): Promise<SubscriptionInfo | null> {
-    return this.byUserId.get(userId) ?? null;
+    const list = this.byUserId.get(userId);
+    return list?.[0] ?? null;
+  }
+
+  async getAllByUserId(userId: string): Promise<SubscriptionInfo[]> {
+    return [...(this.byUserId.get(userId) ?? [])];
   }
 
   async getByTransactionId(txId: string): Promise<SubscriptionInfo | null> {

--- a/packages/server/src/stores/postgres.ts
+++ b/packages/server/src/stores/postgres.ts
@@ -111,6 +111,24 @@ export class PostgresSubscriptionStore implements SubscriptionStore {
   }
 
   /**
+   * Returns every subscription record for the user (across all productIds),
+   * ordered most-recent-first. Used by entitlement evaluation, which needs to
+   * see all of a user's active subscriptions to decide whether any of them
+   * grants the requested entitlement.
+   */
+  async getAllByUserId(userId: string): Promise<SubscriptionInfo[]> {
+    const pool = await this.getPool();
+    const result = await pool.query<DbRow>(
+      `SELECT *
+         FROM onesub_subscriptions
+        WHERE user_id = $1
+        ORDER BY updated_at DESC`,
+      [userId]
+    );
+    return result.rows.map(rowToSubscriptionInfo);
+  }
+
+  /**
    * Returns the subscription identified by `originalTransactionId` (the
    * table primary key), or `null` if it does not exist.
    */

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -6,6 +6,8 @@ export const ROUTES = {
   WEBHOOK_GOOGLE: '/onesub/webhook/google',
   VALIDATE_PURCHASE: '/onesub/purchase/validate',
   PURCHASE_STATUS: '/onesub/purchase/status',
+  ENTITLEMENT: '/onesub/entitlement',
+  ENTITLEMENTS: '/onesub/entitlements',
 } as const;
 
 /** Default server port */
@@ -63,6 +65,10 @@ export const ONESUB_ERROR_CODE = {
   INVALID_SIGNED_PAYLOAD: 'INVALID_SIGNED_PAYLOAD',
   MISSING_MESSAGE_DATA: 'MISSING_MESSAGE_DATA',
   PACKAGE_NAME_MISMATCH: 'PACKAGE_NAME_MISMATCH',
+
+  // ── Entitlements ──
+  ENTITLEMENT_NOT_FOUND: 'ENTITLEMENT_NOT_FOUND',
+  ENTITLEMENTS_NOT_CONFIGURED: 'ENTITLEMENTS_NOT_CONFIGURED',
 
   // ── Server internal ──
   INTERNAL_ERROR: 'INTERNAL_ERROR',

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -249,6 +249,21 @@ export interface OneSubServerConfig {
    */
   logger?: OneSubLogger;
   /**
+   * Entitlement definitions — maps host-defined access rights to productIds.
+   * Lets app code branch on stable entitlement names ("premium") instead of
+   * productIds ("pro_monthly"), insulating it from SKU changes / promos.
+   *
+   * When set, `/onesub/entitlement` and `/onesub/entitlements` routes are
+   * mounted. Without it, those routes return 503 ENTITLEMENTS_NOT_CONFIGURED.
+   *
+   * @example
+   * entitlements: {
+   *   premium: { productIds: ['pro_monthly', 'pro_yearly', 'lifetime_pass'] },
+   *   promode: { productIds: ['dev_tools_addon'] },
+   * }
+   */
+  entitlements?: EntitlementsConfig;
+  /**
    * How to handle subscription refunds (Apple REFUND/REVOKE, Google
    * voidedPurchaseNotification productType=1).
    *
@@ -266,6 +281,65 @@ export interface OneSubServerConfig {
    * have no expiry concept.
    */
   refundPolicy?: 'immediate' | 'until_expiry';
+}
+
+/**
+ * Entitlement abstraction — maps host-defined access rights (e.g. "premium")
+ * to one or more store-side productIds. Lets the app code branch on stable
+ * entitlement names instead of brittle productId strings, so adding a promo
+ * SKU or migrating from monthly→yearly doesn't ripple through the codebase.
+ *
+ * Defined statically in `OneSubServerConfig.entitlements`. A user is entitled
+ * to `'premium'` if any of:
+ *   - they have an active subscription (status === 'active' || 'grace_period',
+ *     not yet expired) for a productId in `productIds`
+ *   - they have a non-consumable purchase for a productId in `productIds`
+ *
+ * Consumables are NOT considered for entitlement checks — they grant the user
+ * a one-time consumable resource (coins, lives), not an ongoing right.
+ */
+export interface Entitlement {
+  productIds: string[];
+}
+
+/** Map of entitlement id → definition. Pass via `OneSubServerConfig.entitlements`. */
+export type EntitlementsConfig = Record<string, Entitlement>;
+
+/** Result of evaluating a single entitlement for a userId. */
+export interface EntitlementStatus {
+  /** True when at least one matching active subscription or non-consumable purchase exists. */
+  active: boolean;
+  /**
+   * Where the entitlement was sourced from when active:
+   *   - 'subscription' — an active SubscriptionInfo matched
+   *   - 'purchase'     — a non-consumable PurchaseInfo matched
+   *   - null when not active
+   */
+  source: 'subscription' | 'purchase' | null;
+  /** The matched productId (only present when active). */
+  productId?: string;
+  /** Subscription expiry (only present when source === 'subscription'). */
+  expiresAt?: string;
+}
+
+/** Response from `GET /onesub/entitlement?userId=&id=premium`. */
+export interface EntitlementResponse extends EntitlementStatus {
+  /** The entitlement id queried, echoed back for client-side caching. */
+  id: string;
+  /** Human-readable error. For programmatic handling use `errorCode`. */
+  error?: string;
+  /** Machine-readable canonical error code. */
+  errorCode?: OneSubErrorCode;
+}
+
+/**
+ * Response from `GET /onesub/entitlements?userId=` — every configured
+ * entitlement evaluated for the user in one round-trip.
+ */
+export interface EntitlementsResponse {
+  entitlements: Record<string, EntitlementStatus>;
+  error?: string;
+  errorCode?: OneSubErrorCode;
 }
 
 /** Purchase type */


### PR DESCRIPTION
## Summary

호스트 앱이 productId 대신 안정적인 entitlement 이름(`'premium'`)으로 권한 체크하게 — productId 변경 / promo SKU 추가 / monthly→yearly 마이그레이션이 호스트 코드에 ripple하지 않음. **RevenueCat의 핵심 추상화를 OSS로**.

## 설계

### Config (정적)

```ts
config.entitlements: {
  premium: { productIds: ['pro_monthly', 'pro_yearly', 'lifetime_pass'] },
  promode: { productIds: ['dev_tools_addon'] },
}
```

DB 동적 관리는 deferred. 코드/배포 시점 정의.

### Endpoints (config.entitlements 있을 때만 마운트)

```
GET /onesub/entitlement?userId=&id=premium
  → { id, active, source: 'subscription'|'purchase'|null, productId?, expiresAt? }

GET /onesub/entitlements?userId=
  → { entitlements: { premium: {...}, promode: {...} } }
```

### 평가 로직

1. 활성 subscription (`active` || `grace_period`, `expiresAt > now`) 매칭 → entitled
2. non-consumable purchase 매칭 → entitled (lifetime)
3. consumable은 entitlement 평가에서 제외 (one-time resource, not ongoing right)
4. subscription 우선 (richer signal — has expiry)

### Helper export

```ts
import { evaluateEntitlement } from '@onesub/server';
const status = await evaluateEntitlement(userId, entitlement, store, purchaseStore);
```

호스트가 background worker / 커스텀 라우트에서 in-process 평가 가능.

## 주요 변경

- **`packages/shared`** — 6개 새 export (Entitlement, Config, Status, Response 2종, ROUTES 2개, error code 2개)
- **`packages/server/src/routes/entitlements.ts`** — 신규 router + evaluateEntitlement
- **`packages/server/src/store.ts`** — `SubscriptionStore.getAllByUserId` 신규 + InMemoryStore가 user당 multi-record 보관 (이전엔 single coalesce — entitlement에 부정확)
- **`packages/server/src/stores/postgres.ts`** — `getAllByUserId` 구현 (LIMIT 없는 SELECT)
- **`packages/server/src/index.ts`** — 라우터 마운트 + evaluateEntitlement export

## Test plan

- [x] `npm run build` 통과
- [x] `npm test` — 316/316 (이전 296 + 20 신규)
- [x] evaluateEntitlement 8 케이스 (sub/purchase/mixed/none/expired/grace/on_hold·paused·canceled·expired/consumable 제외/multi-product)
- [x] HTTP routes 6 케이스 (single, bulk, 404 unknown id, 400 input, 라우터 미마운트 시 404 × 2)
- [x] InMemoryStore regression 3 케이스 (getAllByUserId, getByUserId 호환, save 중복 방지)
- [ ] (수동) findthem에 entitlements config 도입해 dogfood

## Breaking changes

없음. 모두 additive:
- 새 타입/route/메서드 추가
- `getByUserId` 기존 동작(latest single) 그대로
- `config.entitlements` 미설정 시 라우터 미마운트 (이전 동작)

InMemoryStore가 user당 multi-record 보관으로 변경됐지만 `getByUserId`/`getByTransactionId` 동작 호환 — 296개 기존 테스트 그대로 통과.

## 다음

PR B (별개): SDK 통합
- `useOneSub().hasEntitlement('premium')` → boolean
- `useOneSub().entitlements` → record map
- OneSubProvider가 mount 시 자동 fetch + cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)