### PR TITLE
feat(sdk): Entitlements 통합 (useOneSub.hasEntitlement / entitlements / refreshEntitlements)

### DIFF
--- a/packages/sdk/src/OneSubProvider.tsx
+++ b/packages/sdk/src/OneSubProvider.tsx
@@ -7,9 +7,15 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import type { OneSubConfig, SubscriptionInfo, PurchaseInfo, PurchaseType } from '@onesub/shared';
+import type {
+  OneSubConfig,
+  SubscriptionInfo,
+  PurchaseInfo,
+  PurchaseType,
+  EntitlementStatus,
+} from '@onesub/shared';
 import { PURCHASE_TYPE, ONESUB_ERROR_CODE } from '@onesub/shared';
-import { checkStatus, validateReceipt, validatePurchase } from './api.js';
+import { checkStatus, validateReceipt, validatePurchase, checkEntitlements } from './api.js';
 import {
   handlePurchaseEvent as handlePurchaseEventPure,
   registerInFlight as registerInFlightPure,
@@ -58,6 +64,16 @@ export interface OneSubContextValue {
     productId: string,
     type: 'consumable' | 'non_consumable',
   ) => Promise<(PurchaseInfo & { action?: 'new' | 'restored' }) | null>;
+  /**
+   * Map of entitlement id → evaluation status, populated from the server.
+   * Empty when the server has no entitlements configured. Auto-refreshed
+   * after subscribe / restore / purchase / restoreProduct.
+   */
+  entitlements: Record<string, EntitlementStatus>;
+  /** Convenience: `entitlements[id]?.active === true`. */
+  hasEntitlement: (id: string) => boolean;
+  /** Manually re-fetch the entitlements map. */
+  refreshEntitlements: () => Promise<void>;
 }
 
 const OneSubContext = createContext<OneSubContextValue | null>(null);
@@ -155,6 +171,7 @@ export function OneSubProvider({ config, userId, children }: OneSubProviderProps
   const [isActive, setIsActive] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [subscription, setSubscription] = useState<SubscriptionInfo | null>(null);
+  const [entitlements, setEntitlements] = useState<Record<string, EntitlementStatus>>({});
 
   const isBusyRef = useRef(false);
   const inFlightRef = useRef<Map<string, InFlightEntry>>(new Map());
@@ -224,6 +241,17 @@ export function OneSubProvider({ config, userId, children }: OneSubProviderProps
         }
       } finally {
         if (!cancelled) setIsLoading(false);
+      }
+    }
+
+    async function loadEntitlements() {
+      try {
+        const result = await checkEntitlements(config.serverUrl, userId);
+        if (!cancelled) setEntitlements(result.entitlements);
+      } catch {
+        // Network/server failure — leave existing entitlements untouched. The
+        // map will be retried on next refresh trigger (post-purchase /
+        // explicit refreshEntitlements call).
       }
     }
 
@@ -306,6 +334,7 @@ export function OneSubProvider({ config, userId, children }: OneSubProviderProps
 
     logger.trace('provider mount', { serverUrl: config.serverUrl, userId, mockMode });
     void loadStatus();
+    void loadEntitlements();
     void setupIap();
 
     return () => {
@@ -591,14 +620,68 @@ export function OneSubProvider({ config, userId, children }: OneSubProviderProps
     [config, userId, mockMode],
   );
 
+  // Stable refresh function exposed via context. Re-fetches the entitlements
+  // map without touching subscription state. Called automatically after
+  // subscribe/restore/purchase/restoreProduct via the wrappers below; hosts can
+  // also call it directly when they know server-side state changed (e.g. after
+  // an admin grant).
+  const refreshEntitlements = useCallback(async () => {
+    try {
+      const result = await checkEntitlements(config.serverUrl, userId);
+      setEntitlements(result.entitlements);
+    } catch {
+      // Leave previous map in place on transient failure.
+    }
+  }, [config.serverUrl, userId]);
+
+  const hasEntitlement = useCallback(
+    (id: string) => entitlements[id]?.active === true,
+    [entitlements],
+  );
+
+  // Wrap the four mutation methods so a successful run automatically triggers
+  // an entitlements refresh — the host doesn't have to remember to refresh
+  // after each purchase/restore. Failures don't trigger a refresh (status
+  // unchanged).
+  const subscribeWithRefresh = useCallback(async () => {
+    await subscribe();
+    void refreshEntitlements();
+  }, [subscribe, refreshEntitlements]);
+
+  const restoreWithRefresh = useCallback(async () => {
+    await restore();
+    void refreshEntitlements();
+  }, [restore, refreshEntitlements]);
+
+  const purchaseProductWithRefresh = useCallback(
+    async (productId: string, type: 'consumable' | 'non_consumable') => {
+      const result = await purchaseProduct(productId, type);
+      if (result) void refreshEntitlements();
+      return result;
+    },
+    [purchaseProduct, refreshEntitlements],
+  );
+
+  const restoreProductWithRefresh = useCallback(
+    async (productId: string, type: 'consumable' | 'non_consumable') => {
+      const result = await restoreProduct(productId, type);
+      if (result) void refreshEntitlements();
+      return result;
+    },
+    [restoreProduct, refreshEntitlements],
+  );
+
   const value: OneSubContextValue = {
     isActive,
     isLoading,
     subscription,
-    subscribe,
-    restore,
-    purchaseProduct,
-    restoreProduct,
+    subscribe: subscribeWithRefresh,
+    restore: restoreWithRefresh,
+    purchaseProduct: purchaseProductWithRefresh,
+    restoreProduct: restoreProductWithRefresh,
+    entitlements,
+    hasEntitlement,
+    refreshEntitlements,
   };
 
   return <OneSubContext.Provider value={value}>{children}</OneSubContext.Provider>;

--- a/packages/sdk/src/__tests__/entitlements-api.test.ts
+++ b/packages/sdk/src/__tests__/entitlements-api.test.ts
@@ -1,0 +1,152 @@
+/**
+ * SDK API helpers for entitlements — checkEntitlement / checkEntitlements.
+ *
+ * The Provider wiring (auto-refresh on subscribe/purchase, hasEntitlement,
+ * refreshEntitlements) is integration territory and runs better against the
+ * server's own test harness; here we cover only the pure HTTP helpers.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { checkEntitlement, checkEntitlements } from '../api.js';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+function mockJsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status < 400,
+    status,
+    statusText: status === 200 ? 'OK' : status === 404 ? 'Not Found' : 'Error',
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+// ── checkEntitlement ────────────────────────────────────────────────────────
+
+describe('checkEntitlement', () => {
+  it('GETs /onesub/entitlement?userId=&id=', async () => {
+    const calls: string[] = [];
+    vi.spyOn(global, 'fetch').mockImplementation(async (url) => {
+      calls.push(String(url));
+      return mockJsonResponse(200, {
+        id: 'premium',
+        active: true,
+        source: 'subscription',
+        productId: 'pro_monthly',
+        expiresAt: '2099-01-01T00:00:00Z',
+      });
+    });
+
+    const result = await checkEntitlement('https://api.example.com', 'u_42', 'premium');
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toBe(
+      'https://api.example.com/onesub/entitlement?userId=u_42&id=premium',
+    );
+    expect(result.active).toBe(true);
+    expect(result.productId).toBe('pro_monthly');
+  });
+
+  it('strips trailing slash from serverUrl', async () => {
+    const calls: string[] = [];
+    vi.spyOn(global, 'fetch').mockImplementation(async (url) => {
+      calls.push(String(url));
+      return mockJsonResponse(200, { id: 'premium', active: false, source: null });
+    });
+
+    await checkEntitlement('https://api.example.com/', 'u', 'premium');
+
+    expect(calls[0]).toBe('https://api.example.com/onesub/entitlement?userId=u&id=premium');
+  });
+
+  it('URL-encodes userId and id', async () => {
+    const calls: string[] = [];
+    vi.spyOn(global, 'fetch').mockImplementation(async (url) => {
+      calls.push(String(url));
+      return mockJsonResponse(200, { id: 'pro mode', active: false, source: null });
+    });
+
+    await checkEntitlement('https://api.example.com', 'u with spaces', 'pro mode');
+
+    expect(calls[0]).toContain('userId=u%20with%20spaces');
+    expect(calls[0]).toContain('id=pro%20mode');
+  });
+
+  it('throws on 4xx/5xx (lets caller distinguish unknown id from "not entitled")', async () => {
+    vi.spyOn(global, 'fetch').mockImplementation(async () =>
+      mockJsonResponse(404, { errorCode: 'ENTITLEMENT_NOT_FOUND' }),
+    );
+
+    await expect(
+      checkEntitlement('https://api.example.com', 'u', 'enterprise'),
+    ).rejects.toThrow(/Entitlement check failed: 404/);
+  });
+
+  it('returns active=false (not throw) for normal "user has nothing" case', async () => {
+    vi.spyOn(global, 'fetch').mockImplementation(async () =>
+      mockJsonResponse(200, { id: 'premium', active: false, source: null }),
+    );
+
+    const result = await checkEntitlement('https://api.example.com', 'u_none', 'premium');
+    expect(result.active).toBe(false);
+    expect(result.source).toBeNull();
+  });
+});
+
+// ── checkEntitlements ──────────────────────────────────────────────────────
+
+describe('checkEntitlements (bulk)', () => {
+  it('GETs /onesub/entitlements?userId= and returns the map', async () => {
+    const calls: string[] = [];
+    vi.spyOn(global, 'fetch').mockImplementation(async (url) => {
+      calls.push(String(url));
+      return mockJsonResponse(200, {
+        entitlements: {
+          premium: { active: true, source: 'subscription', productId: 'pro_monthly' },
+          promode: { active: false, source: null },
+        },
+      });
+    });
+
+    const result = await checkEntitlements('https://api.example.com', 'u_bulk');
+
+    expect(calls[0]).toBe('https://api.example.com/onesub/entitlements?userId=u_bulk');
+    expect(result.entitlements.premium.active).toBe(true);
+    expect(result.entitlements.promode.active).toBe(false);
+  });
+
+  it('returns empty map (NOT throw) when server has no entitlements configured (404)', async () => {
+    // Server with no entitlements config returns 404 (router not mounted).
+    // The SDK treats this as a valid runtime state, not an error — so the
+    // host can mount the Provider before deciding on entitlement strategy.
+    vi.spyOn(global, 'fetch').mockImplementation(async () =>
+      mockJsonResponse(404, { error: 'Not Found' }),
+    );
+
+    const result = await checkEntitlements('https://api.example.com', 'u');
+    expect(result.entitlements).toEqual({});
+  });
+
+  it('throws on 5xx (genuine server error)', async () => {
+    vi.spyOn(global, 'fetch').mockImplementation(async () =>
+      mockJsonResponse(500, { error: 'Internal' }),
+    );
+
+    await expect(checkEntitlements('https://api.example.com', 'u')).rejects.toThrow(
+      /Entitlements bulk check failed: 500/,
+    );
+  });
+
+  it('strips trailing slash from serverUrl', async () => {
+    const calls: string[] = [];
+    vi.spyOn(global, 'fetch').mockImplementation(async (url) => {
+      calls.push(String(url));
+      return mockJsonResponse(200, { entitlements: {} });
+    });
+
+    await checkEntitlements('https://api.example.com/', 'u');
+    expect(calls[0]).toBe('https://api.example.com/onesub/entitlements?userId=u');
+  });
+});

--- a/packages/sdk/src/api.ts
+++ b/packages/sdk/src/api.ts
@@ -5,6 +5,8 @@ import type {
   ValidatePurchaseRequest,
   ValidatePurchaseResponse,
   PurchaseStatusResponse,
+  EntitlementResponse,
+  EntitlementsResponse,
 } from '@onesub/shared';
 import { ROUTES } from '@onesub/shared';
 
@@ -111,4 +113,64 @@ export async function checkPurchaseStatus(
 
   const data = (await response.json()) as PurchaseStatusResponse;
   return data;
+}
+
+/**
+ * Check a single entitlement for a user. Returns `{ active: false, source: null }`
+ * when the user has no matching record, or throws on transport / server error.
+ *
+ * Returns 404 errorCode `ENTITLEMENT_NOT_FOUND` when the id is unknown to the
+ * server (config mismatch). The throw differentiates this from "user not entitled".
+ */
+export async function checkEntitlement(
+  serverUrl: string,
+  userId: string,
+  id: string,
+): Promise<EntitlementResponse> {
+  const url =
+    `${serverUrl.replace(/\/$/, '')}${ROUTES.ENTITLEMENT}` +
+    `?userId=${encodeURIComponent(userId)}&id=${encodeURIComponent(id)}`;
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`[onesub] Entitlement check failed: ${response.status} ${response.statusText}`);
+  }
+  return (await response.json()) as EntitlementResponse;
+}
+
+/**
+ * Check all entitlements configured on the server in one round-trip.
+ * Use on app launch / login to populate the entitlements map.
+ *
+ * Returns `{ entitlements: {} }` when the server has no entitlements
+ * configured (the route is not mounted, returning 404 — surfaced here as an
+ * empty map rather than a throw, since "no entitlements configured" is a
+ * valid runtime state, not an error).
+ */
+export async function checkEntitlements(
+  serverUrl: string,
+  userId: string,
+): Promise<EntitlementsResponse> {
+  const url =
+    `${serverUrl.replace(/\/$/, '')}${ROUTES.ENTITLEMENTS}` +
+    `?userId=${encodeURIComponent(userId)}`;
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  if (response.status === 404) {
+    // Route not mounted — server has no entitlements configured. Empty map is
+    // the right state-of-the-world here.
+    return { entitlements: {} };
+  }
+  if (!response.ok) {
+    throw new Error(`[onesub] Entitlements bulk check failed: ${response.status} ${response.statusText}`);
+  }
+  return (await response.json()) as EntitlementsResponse;
 }

--- a/packages/sdk/src/useOneSub.ts
+++ b/packages/sdk/src/useOneSub.ts
@@ -1,4 +1,4 @@
-import type { SubscriptionInfo, PurchaseInfo } from '@onesub/shared';
+import type { SubscriptionInfo, PurchaseInfo, EntitlementStatus } from '@onesub/shared';
 import { useOneSubContext } from './OneSubProvider.js';
 
 export interface UseOneSubReturn {
@@ -23,6 +23,16 @@ export interface UseOneSubReturn {
    * no record of the product.
    */
   restoreProduct: (productId: string, type: 'consumable' | 'non_consumable') => Promise<(PurchaseInfo & { action?: 'new' | 'restored' }) | null>;
+  /**
+   * Map of entitlement id → evaluation status, populated from the server's
+   * `GET /onesub/entitlements`. Empty map when the server has no entitlements
+   * configured. Refreshed automatically after subscribe / purchase / restore.
+   */
+  entitlements: Record<string, EntitlementStatus>;
+  /** Convenience: `entitlements[id]?.active === true`. Safe even if the id is unknown. */
+  hasEntitlement: (id: string) => boolean;
+  /** Manually re-fetch the entitlements map (e.g. after a server-side state change). */
+  refreshEntitlements: () => Promise<void>;
 }
 
 /**


### PR DESCRIPTION
## Summary

PR #44 (server-side entitlements)와 짝. 호스트 앱이 `useOneSub` 한 번으로 entitlement 체크 + 자동 refresh 받게.

## API

```tsx
const {
  isActive,                  // 기존 (default productId 기반)
  hasEntitlement,            // 신규
  entitlements,              // 신규
  refreshEntitlements,       // 신규
  subscribe, restore, purchaseProduct, restoreProduct,  // 기존 동일
} = useOneSub();

if (hasEntitlement('premium')) {
  // entitled — productId 신경 안 써도 됨
}

console.log(entitlements);
// { premium: { active: true, source: 'subscription', productId: 'pro_yearly', expiresAt: '...' },
//   promode: { active: false, source: null } }
```

## 자동 refresh 트리거

- Provider mount (initial fetch)
- `subscribe()` 성공 후
- `restore()` 후
- `purchaseProduct()` 성공 후 (구매 결과가 truthy일 때만)
- `restoreProduct()` 성공 후
- 수동 호출: `refreshEntitlements()`

호스트가 매번 refresh 명시 호출할 필요 없음. mutation 메서드들은 `...WithRefresh` wrapper로 감쌌고, **외부 시그니처는 동일**.

## 404 처리

서버에 `entitlements` config가 없으면 라우터가 mount 안 됨 → 404. SDK는 이걸 **에러가 아닌 빈 map**으로 처리 (`{ entitlements: {} }`). 호스트가 Provider 마운트 후 entitlement 전략 결정 가능.

`checkEntitlement` 단일 호출은 4xx에 throw — 호스트가 "unknown id" vs "not entitled" 구분 가능.

## 주요 변경

- `packages/sdk/src/api.ts` — `checkEntitlement` / `checkEntitlements` 신규
- `packages/sdk/src/OneSubProvider.tsx` — state + initial fetch + auto-refresh wrappers
- `packages/sdk/src/useOneSub.ts` — return shape에 3개 신규 멤버

## Test plan

- [x] `npm run build` 통과
- [x] `npm test` — 325/325 (이전 316 + 9 신규 SDK API)
- [x] checkEntitlement: URL 형식, encoding, throw on 4xx
- [x] checkEntitlements: bulk URL, 404 → 빈 map, 5xx throw
- [ ] (수동) coffee에 도입해 dogfood

## Breaking changes

없음. 모두 additive — 기존 `useOneSub` 호출자 무영향.

🤖 Generated with [Claude Code](https://claude.com/claude-code)