### PR TITLE
feat: Read API for metrics — count-based aggregation endpoints

### DIFF
--- a/packages/server/src/__tests__/metrics.test.ts
+++ b/packages/server/src/__tests__/metrics.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Read-only metrics endpoints — admin-gated aggregations over Subscription +
+ * PurchaseStore data.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import express from 'express';
+import type {
+  MetricsActiveResponse,
+  MetricsCountResponse,
+  OneSubServerConfig,
+  PurchaseInfo,
+  SubscriptionInfo,
+} from '@onesub/shared';
+import { SUBSCRIPTION_STATUS } from '@onesub/shared';
+import { createOneSubMiddleware, InMemorySubscriptionStore, InMemoryPurchaseStore } from '../index.js';
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+function sub(overrides?: Partial<SubscriptionInfo>): SubscriptionInfo {
+  return {
+    userId: 'u',
+    productId: 'pro_monthly',
+    platform: 'apple',
+    status: 'active',
+    expiresAt: '2099-01-01T00:00:00.000Z',
+    purchasedAt: '2026-04-01T00:00:00.000Z',
+    originalTransactionId: `orig_${Math.random()}`,
+    willRenew: true,
+    ...overrides,
+  };
+}
+
+function purchase(overrides?: Partial<PurchaseInfo>): PurchaseInfo {
+  return {
+    userId: 'u',
+    productId: 'lifetime_pass',
+    platform: 'apple',
+    type: 'non_consumable',
+    transactionId: `tx_${Math.random()}`,
+    purchasedAt: '2026-04-01T00:00:00.000Z',
+    quantity: 1,
+    ...overrides,
+  };
+}
+
+interface TestServer {
+  get: <T,>(path: string, headers?: Record<string, string>) => Promise<{ status: number; body: T }>;
+}
+
+function spinUp(handler: express.Express): TestServer {
+  return {
+    async get<T>(path: string, headers?: Record<string, string>): Promise<{ status: number; body: T }> {
+      const httpServer = handler.listen(0);
+      const port = (httpServer.address() as { port: number }).port;
+      try {
+        const resp = await fetch(`http://127.0.0.1:${port}${path}`, { headers });
+        const text = await resp.text();
+        let parsed: unknown = text;
+        try { parsed = JSON.parse(text); } catch { /* keep as text */ }
+        return { status: resp.status, body: parsed as T };
+      } finally {
+        await new Promise<void>((r) => httpServer.close(() => r()));
+      }
+    },
+  };
+}
+
+function buildServer(opts: { adminSecret?: string; subs?: SubscriptionInfo[]; purchases?: PurchaseInfo[] }) {
+  const store = new InMemorySubscriptionStore();
+  const purchaseStore = new InMemoryPurchaseStore();
+  const config: OneSubServerConfig = {
+    apple: { bundleId: 'com.example.app', skipJwsVerification: true },
+    database: { url: '' },
+    adminSecret: opts.adminSecret,
+  };
+  const app = express();
+  app.use(createOneSubMiddleware({ ...config, store, purchaseStore }));
+  return { store, purchaseStore, server: spinUp(app) };
+}
+
+const SECRET = 's3cr3t';
+const AUTH = { 'x-admin-secret': SECRET };
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Auth gate
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Metrics auth', () => {
+  it('returns 404 (router not mounted) when adminSecret is unset', async () => {
+    const { server } = buildServer({});
+    const resp = await server.get<unknown>('/onesub/metrics/active');
+    expect(resp.status).toBe(404);
+  });
+
+  it('returns 401 INVALID_ADMIN_SECRET when header is missing or wrong', async () => {
+    const { server } = buildServer({ adminSecret: SECRET });
+
+    const noHeader = await server.get<{ errorCode: string }>('/onesub/metrics/active');
+    expect(noHeader.status).toBe(401);
+    expect(noHeader.body.errorCode).toBe('INVALID_ADMIN_SECRET');
+
+    const wrongHeader = await server.get<{ errorCode: string }>(
+      '/onesub/metrics/active',
+      { 'x-admin-secret': 'wrong' },
+    );
+    expect(wrongHeader.status).toBe(401);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// /onesub/metrics/active
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /onesub/metrics/active', () => {
+  it('returns zeros for an empty store', async () => {
+    const { server } = buildServer({ adminSecret: SECRET });
+    const resp = await server.get<MetricsActiveResponse>('/onesub/metrics/active', AUTH);
+    expect(resp.status).toBe(200);
+    expect(resp.body).toEqual({
+      total: 0,
+      activeSubscriptions: 0,
+      gracePeriodSubscriptions: 0,
+      nonConsumablePurchases: 0,
+      byProduct: {},
+      byPlatform: {},
+    });
+  });
+
+  it('counts active subs + non-consumable purchases', async () => {
+    const { store, purchaseStore, server } = buildServer({ adminSecret: SECRET });
+    await store.save(sub({ userId: 'a', productId: 'pro_monthly', platform: 'apple' }));
+    await store.save(sub({ userId: 'b', productId: 'pro_yearly', platform: 'google' }));
+    await purchaseStore.savePurchase(purchase({ userId: 'c', platform: 'apple' }));
+
+    const resp = await server.get<MetricsActiveResponse>('/onesub/metrics/active', AUTH);
+
+    expect(resp.body.total).toBe(3);
+    expect(resp.body.activeSubscriptions).toBe(2);
+    expect(resp.body.nonConsumablePurchases).toBe(1);
+    expect(resp.body.byProduct).toEqual({ pro_monthly: 1, pro_yearly: 1 });  // purchases not in byProduct
+    expect(resp.body.byPlatform).toEqual({ apple: 2, google: 1 });
+  });
+
+  it('grace_period subs counted in activeSubscriptions AND gracePeriodSubscriptions', async () => {
+    const { store, server } = buildServer({ adminSecret: SECRET });
+    await store.save(sub({ userId: 'a', status: 'active' }));
+    await store.save(sub({ userId: 'b', status: 'grace_period' }));
+
+    const resp = await server.get<MetricsActiveResponse>('/onesub/metrics/active', AUTH);
+
+    expect(resp.body.activeSubscriptions).toBe(2);
+    expect(resp.body.gracePeriodSubscriptions).toBe(1);
+  });
+
+  it('on_hold / paused / canceled / expired subs NOT counted', async () => {
+    const { store, server } = buildServer({ adminSecret: SECRET });
+    for (const status of ['on_hold', 'paused', 'canceled', 'expired'] as const) {
+      await store.save(sub({ userId: status, status }));
+    }
+    await store.save(sub({ userId: 'real_active', status: 'active' }));
+
+    const resp = await server.get<MetricsActiveResponse>('/onesub/metrics/active', AUTH);
+
+    expect(resp.body.activeSubscriptions).toBe(1);
+  });
+
+  it('expired-by-time subs (status=active but expiresAt < now) NOT counted', async () => {
+    const { store, server } = buildServer({ adminSecret: SECRET });
+    await store.save(sub({ userId: 'past', status: 'active', expiresAt: '2024-01-01T00:00:00.000Z' }));
+    await store.save(sub({ userId: 'future', status: 'active', expiresAt: '2099-01-01T00:00:00.000Z' }));
+
+    const resp = await server.get<MetricsActiveResponse>('/onesub/metrics/active', AUTH);
+
+    expect(resp.body.activeSubscriptions).toBe(1);
+  });
+
+  it('consumable purchases NOT counted (only non_consumable contribute)', async () => {
+    const { purchaseStore, server } = buildServer({ adminSecret: SECRET });
+    await purchaseStore.savePurchase(purchase({ userId: 'a', type: 'consumable' }));
+    await purchaseStore.savePurchase(purchase({ userId: 'b', type: 'non_consumable' }));
+
+    const resp = await server.get<MetricsActiveResponse>('/onesub/metrics/active', AUTH);
+
+    expect(resp.body.nonConsumablePurchases).toBe(1);
+    expect(resp.body.total).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// /onesub/metrics/started
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /onesub/metrics/started', () => {
+  it('counts subs with purchasedAt within the [from, to] window', async () => {
+    const { store, server } = buildServer({ adminSecret: SECRET });
+    await store.save(sub({ userId: 'before', purchasedAt: '2026-03-15T00:00:00Z' }));
+    await store.save(sub({ userId: 'in1',    purchasedAt: '2026-04-01T00:00:00Z' }));
+    await store.save(sub({ userId: 'in2',    purchasedAt: '2026-04-15T00:00:00Z' }));
+    await store.save(sub({ userId: 'after',  purchasedAt: '2026-05-15T00:00:00Z' }));
+
+    const resp = await server.get<MetricsCountResponse>(
+      '/onesub/metrics/started?from=2026-04-01T00:00:00Z&to=2026-04-30T23:59:59Z',
+      AUTH,
+    );
+
+    expect(resp.body.total).toBe(2);
+    expect(resp.body.from).toBe('2026-04-01T00:00:00Z');
+    expect(resp.body.to).toBe('2026-04-30T23:59:59Z');
+  });
+
+  it('aggregates by product and platform', async () => {
+    const { store, server } = buildServer({ adminSecret: SECRET });
+    await store.save(sub({ userId: 'a', productId: 'pro_monthly', platform: 'apple', purchasedAt: '2026-04-10T00:00:00Z' }));
+    await store.save(sub({ userId: 'b', productId: 'pro_yearly', platform: 'google', purchasedAt: '2026-04-20T00:00:00Z' }));
+    await store.save(sub({ userId: 'c', productId: 'pro_monthly', platform: 'google', purchasedAt: '2026-04-25T00:00:00Z' }));
+
+    const resp = await server.get<MetricsCountResponse>(
+      '/onesub/metrics/started?from=2026-04-01T00:00:00Z&to=2026-04-30T23:59:59Z',
+      AUTH,
+    );
+
+    expect(resp.body.byProduct).toEqual({ pro_monthly: 2, pro_yearly: 1 });
+    expect(resp.body.byPlatform).toEqual({ apple: 1, google: 2 });
+  });
+
+  it('400 INVALID_INPUT when from/to are missing or malformed', async () => {
+    const { server } = buildServer({ adminSecret: SECRET });
+
+    const missing = await server.get<{ errorCode: string }>('/onesub/metrics/started', AUTH);
+    expect(missing.status).toBe(400);
+
+    const malformed = await server.get<{ errorCode: string }>(
+      '/onesub/metrics/started?from=not-a-date&to=2026-04-30T23:59:59Z',
+      AUTH,
+    );
+    expect(malformed.status).toBe(400);
+
+    const reversed = await server.get<{ errorCode: string }>(
+      '/onesub/metrics/started?from=2026-05-01T00:00:00Z&to=2026-04-01T00:00:00Z',
+      AUTH,
+    );
+    expect(reversed.status).toBe(400);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// /onesub/metrics/expired
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /onesub/metrics/expired', () => {
+  it('counts only subs where status ∈ {expired, canceled} AND expiresAt in window', async () => {
+    const { store, server } = buildServer({ adminSecret: SECRET });
+    // status active but expiresAt in window — NOT counted (not actually ended)
+    await store.save(sub({ userId: 'still_active', status: 'active', expiresAt: '2026-04-15T00:00:00Z' }));
+    // status expired, expiresAt in window — counted
+    await store.save(sub({ userId: 'expired_in', status: 'expired', expiresAt: '2026-04-10T00:00:00Z' }));
+    // status canceled (refund), expiresAt in window — counted
+    await store.save(sub({ userId: 'canceled_in', status: 'canceled', expiresAt: '2026-04-20T00:00:00Z' }));
+    // status expired but expiresAt before window
+    await store.save(sub({ userId: 'expired_before', status: 'expired', expiresAt: '2026-03-01T00:00:00Z' }));
+
+    const resp = await server.get<MetricsCountResponse>(
+      '/onesub/metrics/expired?from=2026-04-01T00:00:00Z&to=2026-04-30T23:59:59Z',
+      AUTH,
+    );
+
+    expect(resp.body.total).toBe(2);  // expired_in + canceled_in
+  });
+
+  it('returns 0 when nothing matches', async () => {
+    const { store, server } = buildServer({ adminSecret: SECRET });
+    await store.save(sub({ status: 'active' }));
+
+    const resp = await server.get<MetricsCountResponse>(
+      '/onesub/metrics/expired?from=2020-01-01T00:00:00Z&to=2020-12-31T23:59:59Z',
+      AUTH,
+    );
+
+    expect(resp.body.total).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Store listAll regression
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Store listAll', () => {
+  it('SubscriptionStore.listAll returns every record', async () => {
+    const store = new InMemorySubscriptionStore();
+    await store.save(sub({ userId: 'a', originalTransactionId: 't1' }));
+    await store.save(sub({ userId: 'b', originalTransactionId: 't2' }));
+    await store.save(sub({ userId: 'a', originalTransactionId: 't3' }));
+
+    const all = await store.listAll();
+    expect(all).toHaveLength(3);
+  });
+
+  it('PurchaseStore.listAll returns every record', async () => {
+    const purchaseStore = new InMemoryPurchaseStore();
+    await purchaseStore.savePurchase(purchase({ userId: 'a', transactionId: 'p1' }));
+    await purchaseStore.savePurchase(purchase({ userId: 'b', transactionId: 'p2' }));
+
+    const all = await purchaseStore.listAll();
+    expect(all).toHaveLength(2);
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -9,6 +9,7 @@ import { createWebhookRouter } from './routes/webhook.js';
 import { createPurchaseRouter } from './routes/purchase.js';
 import { createAdminRouter } from './routes/admin.js';
 import { createEntitlementRouter } from './routes/entitlements.js';
+import { createMetricsRouter } from './routes/metrics.js';
 import { setLogger } from './logger.js';
 
 /**
@@ -78,6 +79,11 @@ export function createOneSubMiddleware(config: OneSubMiddlewareConfig): Router {
   // Entitlement routes — only mounted when config.entitlements is set
   const entitlementRouter = createEntitlementRouter(config, store, purchaseStore);
   if (entitlementRouter) router.use(entitlementRouter);
+
+  // Metrics routes — only mounted when config.adminSecret is set (same gate
+  // as admin routes; metrics expose aggregate operational data)
+  const metricsRouter = createMetricsRouter(config, store, purchaseStore);
+  if (metricsRouter) router.use(metricsRouter);
 
   return router;
 }

--- a/packages/server/src/routes/metrics.ts
+++ b/packages/server/src/routes/metrics.ts
@@ -1,0 +1,218 @@
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { z } from 'zod';
+import type {
+  MetricsActiveResponse,
+  MetricsCountResponse,
+  OneSubServerConfig,
+  PurchaseInfo,
+  SubscriptionInfo,
+} from '@onesub/shared';
+import {
+  ROUTES,
+  SUBSCRIPTION_STATUS,
+  PURCHASE_TYPE,
+  ONESUB_ERROR_CODE,
+} from '@onesub/shared';
+import type { PurchaseStore, SubscriptionStore } from '../store.js';
+import { log } from '../logger.js';
+import { sendError } from '../errors.js';
+
+const ADMIN_SECRET_HEADER = 'x-admin-secret';
+
+/**
+ * Read-only aggregate metrics endpoints — gated behind `config.adminSecret`.
+ * Returns count-based metrics only (active count, started count, expired count).
+ *
+ * Revenue metrics (MRR, ARR, LTV) require per-product price configuration the
+ * server doesn't currently track; deferred to a follow-up release that adds
+ * `config.products: { 'pro_monthly': { price: 9.99, currency: 'USD' } }`.
+ *
+ * Aggregation strategy: pulls every record via `store.listAll()` and reduces
+ * in memory. Fine up to ~100k records; large deployments should optimise the
+ * Postgres path with SQL aggregates (separate PR).
+ */
+export function createMetricsRouter(
+  config: OneSubServerConfig,
+  store: SubscriptionStore,
+  purchaseStore: PurchaseStore,
+): Router | null {
+  if (!config.adminSecret) return null;
+
+  const router = Router();
+  const adminSecret = config.adminSecret;
+
+  // Auth middleware — only protects /onesub/metrics/* (siblings unaffected
+  // even when this router is mounted on the parent root).
+  router.use('/onesub/metrics', (req, res, next) => {
+    const provided = req.headers[ADMIN_SECRET_HEADER];
+    if (typeof provided !== 'string' || provided !== adminSecret) {
+      sendError(res, 401, ONESUB_ERROR_CODE.INVALID_ADMIN_SECRET, 'INVALID_ADMIN_SECRET');
+      return;
+    }
+    next();
+  });
+
+  // ── helpers ──────────────────────────────────────────────────────────────
+
+  const isActiveSub = (sub: SubscriptionInfo, now: number): boolean => {
+    const statusAllows =
+      sub.status === SUBSCRIPTION_STATUS.ACTIVE ||
+      sub.status === SUBSCRIPTION_STATUS.GRACE_PERIOD;
+    return statusAllows && new Date(sub.expiresAt).getTime() > now;
+  };
+
+  const bump = (map: Record<string, number>, key: string) => {
+    map[key] = (map[key] ?? 0) + 1;
+  };
+
+  // ── GET /onesub/metrics/active ───────────────────────────────────────────
+
+  router.get(ROUTES.METRICS_ACTIVE, async (_req: Request, res: Response) => {
+    try {
+      const [subs, purchases] = await Promise.all([
+        store.listAll(),
+        purchaseStore.listAll(),
+      ]);
+      const now = Date.now();
+
+      const byProduct: Record<string, number> = {};
+      const byPlatform: Record<string, number> = {};
+      let activeSubscriptions = 0;
+      let gracePeriodSubscriptions = 0;
+      let nonConsumablePurchases = 0;
+
+      for (const sub of subs) {
+        if (!isActiveSub(sub, now)) continue;
+        activeSubscriptions++;
+        if (sub.status === SUBSCRIPTION_STATUS.GRACE_PERIOD) {
+          gracePeriodSubscriptions++;
+        }
+        bump(byProduct, sub.productId);
+        bump(byPlatform, sub.platform);
+      }
+
+      for (const p of purchases) {
+        if (p.type !== PURCHASE_TYPE.NON_CONSUMABLE) continue;
+        nonConsumablePurchases++;
+        // Don't add to byProduct (subscription-only metric for product distribution)
+        bump(byPlatform, p.platform);
+      }
+
+      const response: MetricsActiveResponse = {
+        total: activeSubscriptions + nonConsumablePurchases,
+        activeSubscriptions,
+        gracePeriodSubscriptions,
+        nonConsumablePurchases,
+        byProduct,
+        byPlatform,
+      };
+      res.status(200).json(response);
+    } catch (err) {
+      log.error('[onesub/metrics/active] error:', err);
+      sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, 'Internal server error');
+    }
+  });
+
+  // ── GET /onesub/metrics/started?from=&to= ────────────────────────────────
+
+  const rangeSchema = z.object({
+    from: z.string().min(1),
+    to: z.string().min(1),
+  });
+
+  type Range = { fromMs: number; toMs: number };
+
+  function parseRange(req: Request): Range | { error: string } {
+    const parsed = rangeSchema.safeParse(req.query);
+    if (!parsed.success) return { error: 'from and to are required (ISO 8601)' };
+    const fromMs = new Date(parsed.data.from).getTime();
+    const toMs = new Date(parsed.data.to).getTime();
+    if (Number.isNaN(fromMs) || Number.isNaN(toMs)) {
+      return { error: 'from / to must be ISO 8601 timestamps' };
+    }
+    if (fromMs > toMs) return { error: 'from must be ≤ to' };
+    return { fromMs, toMs };
+  }
+
+  router.get(ROUTES.METRICS_STARTED, async (req: Request, res: Response) => {
+    const range = parseRange(req);
+    if ('error' in range) {
+      sendError(res, 400, ONESUB_ERROR_CODE.INVALID_INPUT, range.error);
+      return;
+    }
+    try {
+      const subs = await store.listAll();
+      const byProduct: Record<string, number> = {};
+      const byPlatform: Record<string, number> = {};
+      let total = 0;
+
+      for (const sub of subs) {
+        const purchasedMs = new Date(sub.purchasedAt).getTime();
+        if (purchasedMs < range.fromMs || purchasedMs > range.toMs) continue;
+        total++;
+        bump(byProduct, sub.productId);
+        bump(byPlatform, sub.platform);
+      }
+
+      const response: MetricsCountResponse = {
+        from: req.query['from'] as string,
+        to: req.query['to'] as string,
+        total,
+        byProduct,
+        byPlatform,
+      };
+      res.status(200).json(response);
+    } catch (err) {
+      log.error('[onesub/metrics/started] error:', err);
+      sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, 'Internal server error');
+    }
+  });
+
+  // ── GET /onesub/metrics/expired?from=&to= ────────────────────────────────
+
+  router.get(ROUTES.METRICS_EXPIRED, async (req: Request, res: Response) => {
+    const range = parseRange(req);
+    if ('error' in range) {
+      sendError(res, 400, ONESUB_ERROR_CODE.INVALID_INPUT, range.error);
+      return;
+    }
+    try {
+      const subs = await store.listAll();
+      const byProduct: Record<string, number> = {};
+      const byPlatform: Record<string, number> = {};
+      let total = 0;
+
+      for (const sub of subs) {
+        // Counted only if currently expired or canceled — a record that's
+        // still active doesn't qualify even if its expiresAt happened to fall
+        // inside the window (e.g. mid-period billing renewal).
+        if (
+          sub.status !== SUBSCRIPTION_STATUS.EXPIRED &&
+          sub.status !== SUBSCRIPTION_STATUS.CANCELED
+        ) continue;
+        const expiredMs = new Date(sub.expiresAt).getTime();
+        if (expiredMs < range.fromMs || expiredMs > range.toMs) continue;
+        total++;
+        bump(byProduct, sub.productId);
+        bump(byPlatform, sub.platform);
+      }
+
+      const response: MetricsCountResponse = {
+        from: req.query['from'] as string,
+        to: req.query['to'] as string,
+        total,
+        byProduct,
+        byPlatform,
+      };
+      res.status(200).json(response);
+    } catch (err) {
+      log.error('[onesub/metrics/expired] error:', err);
+      sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, 'Internal server error');
+    }
+  });
+
+  return router;
+}
+
+export type { PurchaseInfo, SubscriptionInfo };

--- a/packages/server/src/store.ts
+++ b/packages/server/src/store.ts
@@ -15,6 +15,12 @@ export interface SubscriptionStore {
   getByUserId(userId: string): Promise<SubscriptionInfo | null>;
   getByTransactionId(txId: string): Promise<SubscriptionInfo | null>;
   /**
+   * Returns every subscription record in the store. Used by metrics
+   * aggregation. Hosts shouldn't expose this through unauthenticated routes —
+   * the built-in `/onesub/metrics/*` endpoints gate it behind `adminSecret`.
+   */
+  listAll(): Promise<SubscriptionInfo[]>;
+  /**
    * Returns every subscription record for the user (across all productIds),
    * ordered most-recent-first. Used by entitlement evaluation, which needs to
    * see all of a user's active subscriptions to decide whether any of them
@@ -60,6 +66,10 @@ export class InMemorySubscriptionStore implements SubscriptionStore {
   async getByTransactionId(txId: string): Promise<SubscriptionInfo | null> {
     return this.byTransactionId.get(txId) ?? null;
   }
+
+  async listAll(): Promise<SubscriptionInfo[]> {
+    return [...this.byTransactionId.values()];
+  }
 }
 
 /**
@@ -69,6 +79,8 @@ export interface PurchaseStore {
   savePurchase(purchase: PurchaseInfo): Promise<void>;
   getPurchasesByUserId(userId: string): Promise<PurchaseInfo[]>;
   getPurchaseByTransactionId(txId: string): Promise<PurchaseInfo | null>;
+  /** Returns every purchase record. Used by metrics aggregation; admin-gated. */
+  listAll(): Promise<PurchaseInfo[]>;
   /** For non-consumables: check if a user has already purchased a product. */
   hasPurchased(userId: string, productId: string): Promise<boolean>;
   /**
@@ -161,6 +173,10 @@ export class InMemoryPurchaseStore implements PurchaseStore {
       if (p.productId === productId) this.byTransactionId.delete(p.transactionId);
     }
     return deleted;
+  }
+
+  async listAll(): Promise<PurchaseInfo[]> {
+    return [...this.byTransactionId.values()];
   }
 
   async deletePurchaseByTransactionId(transactionId: string): Promise<boolean> {

--- a/packages/server/src/stores/postgres.ts
+++ b/packages/server/src/stores/postgres.ts
@@ -143,6 +143,12 @@ export class PostgresSubscriptionStore implements SubscriptionStore {
     return result.rows.length > 0 ? rowToSubscriptionInfo(result.rows[0]) : null;
   }
 
+  async listAll(): Promise<SubscriptionInfo[]> {
+    const pool = await this.getPool();
+    const result = await pool.query<DbRow>(`SELECT * FROM onesub_subscriptions`);
+    return result.rows.map(rowToSubscriptionInfo);
+  }
+
   /** Gracefully close the underlying connection pool. */
   async close(): Promise<void> {
     if (this.poolPromise) {
@@ -299,6 +305,12 @@ export class PostgresPurchaseStore implements PurchaseStore {
       [transactionId]
     );
     return (result.rowCount ?? 0) > 0;
+  }
+
+  async listAll(): Promise<PurchaseInfo[]> {
+    const pool = await this.getPool();
+    const result = await pool.query<PurchaseDbRow>(`SELECT * FROM onesub_purchases`);
+    return result.rows.map(rowToPurchaseInfo);
   }
 
   /** Gracefully close the underlying connection pool. */

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -8,6 +8,9 @@ export const ROUTES = {
   PURCHASE_STATUS: '/onesub/purchase/status',
   ENTITLEMENT: '/onesub/entitlement',
   ENTITLEMENTS: '/onesub/entitlements',
+  METRICS_ACTIVE: '/onesub/metrics/active',
+  METRICS_STARTED: '/onesub/metrics/started',
+  METRICS_EXPIRED: '/onesub/metrics/expired',
 } as const;
 
 /** Default server port */

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -389,6 +389,41 @@ export interface PurchaseStatusResponse {
   errorCode?: OneSubErrorCode;
 }
 
+// ─── Metrics (read-only admin API) ──────────────────────────────────────────
+
+/**
+ * Snapshot of currently-entitled users at the moment of the request.
+ * Aggregates active subscriptions + non-consumable purchases.
+ */
+export interface MetricsActiveResponse {
+  /** Total entitled users (active subs + grace_period subs + non-consumable owners). */
+  total: number;
+  /** Active + grace_period subscriptions only (no purchases). */
+  activeSubscriptions: number;
+  /** grace_period subset of activeSubscriptions — the "at risk" cohort. */
+  gracePeriodSubscriptions: number;
+  /** Non-consumable purchase rows (lifetime products). */
+  nonConsumablePurchases: number;
+  /** Subscription product distribution. Counted from activeSubscriptions only. */
+  byProduct: Record<string, number>;
+  /** 'apple' | 'google' counts across both subs and purchases. */
+  byPlatform: Record<string, number>;
+}
+
+/**
+ * Count of records that started or ended within the given window.
+ * Used for cohort / churn analysis.
+ */
+export interface MetricsCountResponse {
+  /** ISO range echoed back for client-side caching. */
+  from: string;
+  to: string;
+  /** Total matching records in the range. */
+  total: number;
+  byProduct: Record<string, number>;
+  byPlatform: Record<string, number>;
+}
+
 /** SDK config (client-side) */
 export interface OneSubConfig {
   serverUrl: string;


### PR DESCRIPTION
## Summary

운영자/PM이 호스트 dashboard 없이도 핵심 metrics 조회 가능. RevenueCat 격차 분석 시 **두 번째 1순위 항목**. 호스트가 raw API → Grafana / Metabase로 시각화.

## API

모두 `X-Admin-Secret` 헤더 필수. `config.adminSecret` 미설정 시 라우터 미마운트(404).

```
GET /onesub/metrics/active
  → {
      total, activeSubscriptions, gracePeriodSubscriptions, nonConsumablePurchases,
      byProduct: { pro_monthly: 80, pro_yearly: 43 },
      byPlatform: { apple: 70, google: 53 }
    }

GET /onesub/metrics/started?from=2026-04-01T00:00:00Z&to=2026-04-30T23:59:59Z
  → { from, to, total, byProduct, byPlatform }

GET /onesub/metrics/expired?from=&to=
  → 동일 shape — status가 expired/canceled로 끝났고 expiresAt이 window인 sub만
```

## 매출 metrics(MRR/LTV)는 deferred

`SubscriptionInfo`에 가격 정보 없음 (Apple/Google이 관리). 별개 PR에서 `config.products: { 'pro_monthly': { price: 9.99, currency: 'USD' } }` 매핑 추가하면 MRR/LTV 계산 가능.

## 평가 로직 디테일

### `/metrics/active`
- `activeSubscriptions`: status ∈ {`active`, `grace_period`} **AND** `expiresAt > now` (status route의 backstop과 동일)
- `gracePeriodSubscriptions`: 위의 grace_period subset (at-risk cohort)
- `nonConsumablePurchases`: type=non_consumable purchase 수 (consumable 제외 — entitlement 평가와 일관)
- `byProduct`: subscription only (purchase는 lifetime이라 의미 다름)
- `byPlatform`: sub + non-consumable purchase 합산

### `/metrics/started`
- `purchasedAt`이 [from, to] window에 들어가는 sub 수

### `/metrics/expired`
- `status` ∈ {`expired`, `canceled`} **AND** `expiresAt`이 window에 들어가는 sub 수
- `status=active`는 `expiresAt`이 window여도 제외 (갱신 가능 — 진짜 끝난 게 아님)

## 구현 디테일

- **Store 확장**: `SubscriptionStore.listAll()` + `PurchaseStore.listAll()` — InMemory iterate, Postgres `SELECT *`
- **Aggregation**: list 받아 in-memory reduce. ~100k records까지 충분. 큰 deployment는 SQL aggregate 최적화 별개 PR
- **Auth**: `adminSecret` 재사용 (admin route와 동일 gate). future에 metrics-only secret으로 분리 가능

## Test plan

- [x] `npm run build` 통과
- [x] `npm test` — 340/340 (이전 325 + 15 신규)
- [x] Auth 3 케이스 (미설정 404 / 헤더 누락 401 / 헤더 틀림 401)
- [x] /active 6 케이스 (빈 store / sub+purchase 합산 / grace 분리 / on_hold·paused·canceled·expired 제외 / expiresAt 만료된 active 제외 / consumable 제외)
- [x] /started 3 케이스 (window filter / by product+platform / 400 input)
- [x] /expired 2 케이스 (status+window 결합 / 매칭 0)
- [x] Store listAll regression 2 케이스

## Breaking changes

없음. 모두 additive:
- `Store` interface 확장 (`listAll`) — 새 메서드 추가, 기존 contract 보존
- 라우터는 `adminSecret` 명시될 때만 mount (이전 동작 그대로)
- 새 endpoint, 새 type — 기존 호출자 무영향

## 다음

- 매출 metrics PR (가격 매핑 추가 후 MRR/ARR/LTV)
- SQL aggregate 최적화 (PostgresStore in `listAll()` 대신 dedicated `countActive()` SQL)
- Time-series snapshot (cron으로 hourly/daily snapshot DB 저장 — 시점별 정확 조회)
- Customer support tools (transactionId search, audit log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)