### PR TITLE
feat(dashboard): Phase 1b — subscriptions list page + admin list endpoint

### DIFF
--- a/packages/dashboard/app/dashboard/layout.tsx
+++ b/packages/dashboard/app/dashboard/layout.tsx
@@ -14,13 +14,12 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
           >
             Overview
           </Link>
-          <span
-            aria-disabled
-            title="Coming in Phase 1b"
-            className="block cursor-not-allowed rounded-md px-3 py-2 text-slate-400"
+          <Link
+            href="/dashboard/subscriptions"
+            className="block rounded-md px-3 py-2 font-medium text-slate-700 hover:bg-slate-100"
           >
             Subscriptions
-          </span>
+          </Link>
           <span
             aria-disabled
             title="Coming in Phase 3"

--- a/packages/dashboard/app/dashboard/subscriptions/page.tsx
+++ b/packages/dashboard/app/dashboard/subscriptions/page.tsx
@@ -1,0 +1,252 @@
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import type { ListSubscriptionsQuery, SubscriptionInfo } from '@onesub/shared';
+import { requireClient, clearAdminSecret } from '../../../lib/auth';
+import { OneSubFetchError } from '../../../lib/onesub-client';
+
+export const dynamic = 'force-dynamic';
+
+const PAGE_SIZE = 50;
+
+const STATUSES = [
+  '', 'active', 'grace_period', 'on_hold', 'paused', 'expired', 'canceled',
+] as const;
+
+const PLATFORMS = ['', 'apple', 'google'] as const;
+
+interface PageProps {
+  searchParams: Promise<{
+    userId?: string;
+    status?: string;
+    productId?: string;
+    platform?: string;
+    offset?: string;
+  }>;
+}
+
+function parseQuery(raw: Awaited<PageProps['searchParams']>): ListSubscriptionsQuery {
+  const out: ListSubscriptionsQuery = { limit: PAGE_SIZE };
+  if (raw.userId)    out.userId = raw.userId;
+  if (raw.productId) out.productId = raw.productId;
+  // status / platform are validated server-side; we just pass them through.
+  if (raw.status && raw.status !== '')   out.status = raw.status as ListSubscriptionsQuery['status'];
+  if (raw.platform && raw.platform !== '') out.platform = raw.platform as ListSubscriptionsQuery['platform'];
+  if (raw.offset) {
+    const n = parseInt(raw.offset, 10);
+    if (Number.isFinite(n) && n >= 0) out.offset = n;
+  }
+  return out;
+}
+
+function formatExpiry(iso: string): string {
+  // Compact YYYY-MM-DD for table cells; the full ISO string lives in the row's
+  // title attribute so operators can hover for the precise instant.
+  return iso.slice(0, 10);
+}
+
+function StatusBadge({ status }: { status: SubscriptionInfo['status'] }) {
+  const styles: Record<SubscriptionInfo['status'], string> = {
+    active:        'bg-emerald-100 text-emerald-800',
+    grace_period:  'bg-amber-100 text-amber-800',
+    on_hold:       'bg-rose-100 text-rose-800',
+    paused:        'bg-sky-100 text-sky-800',
+    expired:       'bg-slate-200 text-slate-600',
+    canceled:      'bg-slate-200 text-slate-600',
+    none:          'bg-slate-100 text-slate-500',
+  };
+  return (
+    <span className={`inline-block rounded px-2 py-0.5 text-xs font-medium ${styles[status]}`}>
+      {status}
+    </span>
+  );
+}
+
+export default async function SubscriptionsPage({ searchParams }: PageProps) {
+  const raw = await searchParams;
+  const query = parseQuery(raw);
+
+  const client = await requireClient();
+  let result;
+  try {
+    result = await client.listSubscriptions(query);
+  } catch (err) {
+    if (err instanceof OneSubFetchError && err.status === 401) {
+      await clearAdminSecret();
+      redirect('/login');
+    }
+    throw err;
+  }
+
+  const offset = query.offset ?? 0;
+  const limit = query.limit ?? PAGE_SIZE;
+  const hasPrev = offset > 0;
+  const hasNext = offset + limit < result.total;
+  const start = result.total === 0 ? 0 : offset + 1;
+  const end = Math.min(offset + limit, result.total);
+
+  function pageHref(targetOffset: number): string {
+    const params = new URLSearchParams();
+    if (query.userId)    params.set('userId', query.userId);
+    if (query.status)    params.set('status', query.status);
+    if (query.productId) params.set('productId', query.productId);
+    if (query.platform)  params.set('platform', query.platform);
+    if (targetOffset > 0) params.set('offset', String(targetOffset));
+    const qs = params.toString();
+    return qs ? `/dashboard/subscriptions?${qs}` : '/dashboard/subscriptions';
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Subscriptions</h1>
+        <p className="mt-1 text-sm text-slate-500">
+          모든 구독 record. URL params로 필터 + 페이지네이션이 sync됩니다.
+        </p>
+      </div>
+
+      {/* GET form — submits as URL params, page re-renders server-side */}
+      <form method="get" className="flex flex-wrap items-end gap-3 rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+        <FilterInput name="userId" label="userId" defaultValue={query.userId} />
+        <FilterSelect name="status" label="status" options={STATUSES} defaultValue={query.status ?? ''} />
+        <FilterInput name="productId" label="productId" defaultValue={query.productId} />
+        <FilterSelect name="platform" label="platform" options={PLATFORMS} defaultValue={query.platform ?? ''} />
+        <button
+          type="submit"
+          className="rounded-md bg-brand-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-brand-700"
+        >
+          Apply
+        </button>
+        {(query.userId || query.status || query.productId || query.platform) ? (
+          <Link
+            href="/dashboard/subscriptions"
+            className="text-sm text-slate-500 underline-offset-2 hover:underline"
+          >
+            Clear
+          </Link>
+        ) : null}
+      </form>
+
+      <div className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+            <tr>
+              <Th>userId</Th>
+              <Th>productId</Th>
+              <Th>status</Th>
+              <Th>platform</Th>
+              <Th>expiresAt</Th>
+              <Th>willRenew</Th>
+              <Th>originalTransactionId</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {result.items.length === 0 ? (
+              <tr>
+                <td colSpan={7} className="px-5 py-8 text-center text-slate-400">
+                  조건과 일치하는 구독이 없습니다.
+                </td>
+              </tr>
+            ) : (
+              result.items.map((s) => (
+                <tr key={s.originalTransactionId} className="border-t border-slate-100" title={s.expiresAt}>
+                  <Td className="font-mono text-xs">{s.userId}</Td>
+                  <Td>{s.productId}</Td>
+                  <Td><StatusBadge status={s.status} /></Td>
+                  <Td>{s.platform}</Td>
+                  <Td className="font-mono tabular-nums">{formatExpiry(s.expiresAt)}</Td>
+                  <Td>{s.willRenew ? 'yes' : 'no'}</Td>
+                  <Td className="font-mono text-xs text-slate-500">{s.originalTransactionId}</Td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center justify-between text-sm text-slate-600">
+        <div>
+          {result.total === 0 ? '0 results' : `${start.toLocaleString()}–${end.toLocaleString()} of ${result.total.toLocaleString()}`}
+        </div>
+        <div className="flex gap-2">
+          <PageLink href={pageHref(Math.max(0, offset - limit))} disabled={!hasPrev}>← Prev</PageLink>
+          <PageLink href={pageHref(offset + limit)} disabled={!hasNext}>Next →</PageLink>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── small UI bits ──────────────────────────────────────────────────────────
+
+function Th({ children }: { children: React.ReactNode }) {
+  return <th className="px-4 py-3">{children}</th>;
+}
+function Td({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <td className={`px-4 py-3 align-middle ${className ?? ''}`}>{children}</td>;
+}
+
+interface FilterInputProps {
+  name: string;
+  label: string;
+  defaultValue?: string;
+}
+function FilterInput({ name, label, defaultValue }: FilterInputProps) {
+  return (
+    <label className="flex flex-col text-xs font-medium text-slate-600">
+      <span>{label}</span>
+      <input
+        type="text"
+        name={name}
+        defaultValue={defaultValue ?? ''}
+        autoComplete="off"
+        className="mt-1 block w-44 rounded-md border border-slate-300 bg-white px-2 py-1.5 text-sm shadow-sm focus:border-brand-600 focus:outline-none focus:ring-1 focus:ring-brand-600"
+      />
+    </label>
+  );
+}
+
+interface FilterSelectProps {
+  name: string;
+  label: string;
+  options: readonly string[];
+  defaultValue: string;
+}
+function FilterSelect({ name, label, options, defaultValue }: FilterSelectProps) {
+  return (
+    <label className="flex flex-col text-xs font-medium text-slate-600">
+      <span>{label}</span>
+      <select
+        name={name}
+        defaultValue={defaultValue}
+        className="mt-1 block w-36 rounded-md border border-slate-300 bg-white px-2 py-1.5 text-sm shadow-sm focus:border-brand-600 focus:outline-none focus:ring-1 focus:ring-brand-600"
+      >
+        {options.map((opt) => (
+          <option key={opt} value={opt}>{opt === '' ? 'any' : opt}</option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+interface PageLinkProps {
+  href: string;
+  disabled: boolean;
+  children: React.ReactNode;
+}
+function PageLink({ href, disabled, children }: PageLinkProps) {
+  if (disabled) {
+    return (
+      <span className="cursor-not-allowed rounded-md border border-slate-200 bg-white px-3 py-1.5 text-slate-300">
+        {children}
+      </span>
+    );
+  }
+  return (
+    <Link
+      href={href}
+      className="rounded-md border border-slate-200 bg-white px-3 py-1.5 text-slate-700 shadow-sm hover:bg-slate-50"
+    >
+      {children}
+    </Link>
+  );
+}

--- a/packages/dashboard/lib/onesub-client.ts
+++ b/packages/dashboard/lib/onesub-client.ts
@@ -7,12 +7,18 @@
  * Phase 3 work).
  */
 
-import type { MetricsActiveResponse, MetricsCountResponse } from '@onesub/shared';
+import type {
+  ListSubscriptionsQuery,
+  ListSubscriptionsResponse,
+  MetricsActiveResponse,
+  MetricsCountResponse,
+} from '@onesub/shared';
 
 export interface OneSubClient {
   getActiveMetrics(): Promise<MetricsActiveResponse>;
   getStartedMetrics(from: Date, to: Date): Promise<MetricsCountResponse>;
   getExpiredMetrics(from: Date, to: Date): Promise<MetricsCountResponse>;
+  listSubscriptions(query: ListSubscriptionsQuery): Promise<ListSubscriptionsResponse>;
 }
 
 export class OneSubFetchError extends Error {
@@ -52,5 +58,16 @@ export function createClient(serverUrl: string, adminSecret: string): OneSubClie
       get<MetricsCountResponse>(
         `/onesub/metrics/expired?from=${from.toISOString()}&to=${to.toISOString()}`,
       ),
+    listSubscriptions: (query) => {
+      const params = new URLSearchParams();
+      if (query.userId)    params.set('userId', query.userId);
+      if (query.status)    params.set('status', query.status);
+      if (query.productId) params.set('productId', query.productId);
+      if (query.platform)  params.set('platform', query.platform);
+      if (query.limit !== undefined)  params.set('limit', String(query.limit));
+      if (query.offset !== undefined) params.set('offset', String(query.offset));
+      const qs = params.toString();
+      return get<ListSubscriptionsResponse>(`/onesub/admin/subscriptions${qs ? `?${qs}` : ''}`);
+    },
   };
 }

--- a/packages/server/src/__tests__/admin-list-subscriptions.test.ts
+++ b/packages/server/src/__tests__/admin-list-subscriptions.test.ts
@@ -1,0 +1,270 @@
+/**
+ * GET /onesub/admin/subscriptions — filtered/paginated list endpoint.
+ *
+ * Backs the dashboard's subscriptions page; gated behind adminSecret like
+ * the other /onesub/admin/* and /onesub/metrics/* endpoints.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import express from 'express';
+import type {
+  ListSubscriptionsResponse,
+  OneSubServerConfig,
+  SubscriptionInfo,
+} from '@onesub/shared';
+import { createOneSubMiddleware, InMemorySubscriptionStore, InMemoryPurchaseStore } from '../index.js';
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+function sub(overrides?: Partial<SubscriptionInfo>): SubscriptionInfo {
+  return {
+    userId: 'u',
+    productId: 'pro_monthly',
+    platform: 'apple',
+    status: 'active',
+    expiresAt: '2099-01-01T00:00:00.000Z',
+    purchasedAt: '2026-04-01T00:00:00.000Z',
+    originalTransactionId: `orig_${Math.random()}`,
+    willRenew: true,
+    ...overrides,
+  };
+}
+
+interface TestServer {
+  get: <T,>(path: string, headers?: Record<string, string>) => Promise<{ status: number; body: T }>;
+}
+
+function spinUp(handler: express.Express): TestServer {
+  return {
+    async get<T>(path: string, headers?: Record<string, string>): Promise<{ status: number; body: T }> {
+      const httpServer = handler.listen(0);
+      const port = (httpServer.address() as { port: number }).port;
+      try {
+        const resp = await fetch(`http://127.0.0.1:${port}${path}`, { headers });
+        const text = await resp.text();
+        let parsed: unknown = text;
+        try { parsed = JSON.parse(text); } catch { /* keep as text */ }
+        return { status: resp.status, body: parsed as T };
+      } finally {
+        await new Promise<void>((r) => httpServer.close(() => r()));
+      }
+    },
+  };
+}
+
+function buildServer(opts: { adminSecret?: string; subs?: SubscriptionInfo[] }) {
+  const store = new InMemorySubscriptionStore();
+  const purchaseStore = new InMemoryPurchaseStore();
+  const config: OneSubServerConfig = {
+    apple: { bundleId: 'com.example.app', skipJwsVerification: true },
+    database: { url: '' },
+    adminSecret: opts.adminSecret,
+  };
+  const app = express();
+  app.use(createOneSubMiddleware({ ...config, store, purchaseStore }));
+  return { store, server: spinUp(app) };
+}
+
+const SECRET = 's3cr3t';
+const AUTH = { 'x-admin-secret': SECRET };
+
+// ── auth ────────────────────────────────────────────────────────────────────
+
+describe('GET /onesub/admin/subscriptions auth', () => {
+  it('returns 404 when adminSecret is unset (router not mounted)', async () => {
+    const { server } = buildServer({});
+    const resp = await server.get<unknown>('/onesub/admin/subscriptions');
+    expect(resp.status).toBe(404);
+  });
+
+  it('returns 401 INVALID_ADMIN_SECRET when header is missing or wrong', async () => {
+    const { server } = buildServer({ adminSecret: SECRET });
+
+    const noHeader = await server.get<{ errorCode: string }>('/onesub/admin/subscriptions');
+    expect(noHeader.status).toBe(401);
+    expect(noHeader.body.errorCode).toBe('INVALID_ADMIN_SECRET');
+
+    const wrongHeader = await server.get<{ errorCode: string }>(
+      '/onesub/admin/subscriptions',
+      { 'x-admin-secret': 'wrong' },
+    );
+    expect(wrongHeader.status).toBe(401);
+  });
+});
+
+// ── basic listing ───────────────────────────────────────────────────────────
+
+describe('GET /onesub/admin/subscriptions basics', () => {
+  it('returns empty list with total=0 for an empty store', async () => {
+    const { server } = buildServer({ adminSecret: SECRET });
+    const resp = await server.get<ListSubscriptionsResponse>('/onesub/admin/subscriptions', AUTH);
+    expect(resp.status).toBe(200);
+    expect(resp.body.items).toEqual([]);
+    expect(resp.body.total).toBe(0);
+    expect(resp.body.limit).toBe(50);
+    expect(resp.body.offset).toBe(0);
+  });
+
+  it('returns all subs when no filter is passed', async () => {
+    const { store, server } = buildServer({ adminSecret: SECRET });
+    await store.save(sub({ userId: 'a', originalTransactionId: 't1' }));
+    await store.save(sub({ userId: 'b', originalTransactionId: 't2' }));
+    await store.save(sub({ userId: 'c', originalTransactionId: 't3' }));
+
+    const resp = await server.get<ListSubscriptionsResponse>('/onesub/admin/subscriptions', AUTH);
+    expect(resp.body.total).toBe(3);
+    expect(resp.body.items).toHaveLength(3);
+  });
+});
+
+// ── filters ─────────────────────────────────────────────────────────────────
+
+describe('GET /onesub/admin/subscriptions filters', () => {
+  it('filters by userId', async () => {
+    const { store, server } = buildServer({ adminSecret: SECRET });
+    await store.save(sub({ userId: 'a', originalTransactionId: 't1' }));
+    await store.save(sub({ userId: 'b', originalTransactionId: 't2' }));
+    await store.save(sub({ userId: 'a', originalTransactionId: 't3' }));
+
+    const resp = await server.get<ListSubscriptionsResponse>(
+      '/onesub/admin/subscriptions?userId=a',
+      AUTH,
+    );
+    expect(resp.body.total).toBe(2);
+    expect(resp.body.items.every((s) => s.userId === 'a')).toBe(true);
+  });
+
+  it('filters by status', async () => {
+    const { store, server } = buildServer({ adminSecret: SECRET });
+    await store.save(sub({ userId: 'a', status: 'active', originalTransactionId: 't1' }));
+    await store.save(sub({ userId: 'b', status: 'expired', originalTransactionId: 't2' }));
+    await store.save(sub({ userId: 'c', status: 'active', originalTransactionId: 't3' }));
+    await store.save(sub({ userId: 'd', status: 'paused', originalTransactionId: 't4' }));
+
+    const active = await server.get<ListSubscriptionsResponse>(
+      '/onesub/admin/subscriptions?status=active',
+      AUTH,
+    );
+    expect(active.body.total).toBe(2);
+
+    const paused = await server.get<ListSubscriptionsResponse>(
+      '/onesub/admin/subscriptions?status=paused',
+      AUTH,
+    );
+    expect(paused.body.total).toBe(1);
+  });
+
+  it('filters by productId + platform combined (AND)', async () => {
+    const { store, server } = buildServer({ adminSecret: SECRET });
+    await store.save(sub({ userId: 'a', productId: 'pro_monthly', platform: 'apple', originalTransactionId: 't1' }));
+    await store.save(sub({ userId: 'b', productId: 'pro_yearly', platform: 'apple', originalTransactionId: 't2' }));
+    await store.save(sub({ userId: 'c', productId: 'pro_monthly', platform: 'google', originalTransactionId: 't3' }));
+
+    const resp = await server.get<ListSubscriptionsResponse>(
+      '/onesub/admin/subscriptions?productId=pro_monthly&platform=apple',
+      AUTH,
+    );
+    expect(resp.body.total).toBe(1);
+    expect(resp.body.items[0].userId).toBe('a');
+  });
+
+  it('rejects unknown status with 400', async () => {
+    const { server } = buildServer({ adminSecret: SECRET });
+    const resp = await server.get<{ errorCode?: string }>(
+      '/onesub/admin/subscriptions?status=zombie',
+      AUTH,
+    );
+    expect(resp.status).toBe(400);
+  });
+
+  it('rejects unknown platform with 400', async () => {
+    const { server } = buildServer({ adminSecret: SECRET });
+    const resp = await server.get<{ errorCode?: string }>(
+      '/onesub/admin/subscriptions?platform=amazon',
+      AUTH,
+    );
+    expect(resp.status).toBe(400);
+  });
+});
+
+// ── pagination ──────────────────────────────────────────────────────────────
+
+describe('GET /onesub/admin/subscriptions pagination', () => {
+  it('respects limit and offset', async () => {
+    const { store, server } = buildServer({ adminSecret: SECRET });
+    for (let i = 0; i < 7; i++) {
+      await store.save(sub({ userId: `u${i}`, originalTransactionId: `t${i}` }));
+    }
+
+    const page1 = await server.get<ListSubscriptionsResponse>(
+      '/onesub/admin/subscriptions?limit=3&offset=0',
+      AUTH,
+    );
+    expect(page1.body.items).toHaveLength(3);
+    expect(page1.body.total).toBe(7);
+    expect(page1.body.limit).toBe(3);
+
+    const page2 = await server.get<ListSubscriptionsResponse>(
+      '/onesub/admin/subscriptions?limit=3&offset=3',
+      AUTH,
+    );
+    expect(page2.body.items).toHaveLength(3);
+    expect(page2.body.offset).toBe(3);
+
+    const page3 = await server.get<ListSubscriptionsResponse>(
+      '/onesub/admin/subscriptions?limit=3&offset=6',
+      AUTH,
+    );
+    expect(page3.body.items).toHaveLength(1);
+  });
+
+  it('caps limit at 200 (zod refuses larger values)', async () => {
+    const { server } = buildServer({ adminSecret: SECRET });
+    const resp = await server.get<{ errorCode?: string }>(
+      '/onesub/admin/subscriptions?limit=999',
+      AUTH,
+    );
+    expect(resp.status).toBe(400);
+  });
+
+  it('rejects negative offset', async () => {
+    const { server } = buildServer({ adminSecret: SECRET });
+    const resp = await server.get<{ errorCode?: string }>(
+      '/onesub/admin/subscriptions?offset=-1',
+      AUTH,
+    );
+    expect(resp.status).toBe(400);
+  });
+});
+
+// ── store.listFiltered direct (bypass HTTP) ─────────────────────────────────
+
+describe('InMemorySubscriptionStore.listFiltered', () => {
+  let store: InMemorySubscriptionStore;
+
+  beforeEach(() => {
+    store = new InMemorySubscriptionStore();
+  });
+
+  it('combines all four filters with AND semantics', async () => {
+    await store.save(sub({ userId: 'a', productId: 'pro', platform: 'apple', status: 'active', originalTransactionId: 't1' }));
+    await store.save(sub({ userId: 'a', productId: 'pro', platform: 'google', status: 'active', originalTransactionId: 't2' }));
+    await store.save(sub({ userId: 'a', productId: 'pro', platform: 'apple', status: 'expired', originalTransactionId: 't3' }));
+
+    const result = await store.listFiltered({
+      userId: 'a',
+      productId: 'pro',
+      platform: 'apple',
+      status: 'active',
+    });
+    expect(result.total).toBe(1);
+    expect(result.items[0].originalTransactionId).toBe('t1');
+  });
+
+  it('defaults to limit=50, offset=0', async () => {
+    await store.save(sub());
+    const result = await store.listFiltered({});
+    expect(result.limit).toBe(50);
+    expect(result.offset).toBe(0);
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -73,7 +73,7 @@ export function createOneSubMiddleware(config: OneSubMiddlewareConfig): Router {
   router.use(createPurchaseRouter(config, purchaseStore));
 
   // Admin routes — only mounted when config.adminSecret is set
-  const adminRouter = createAdminRouter(config, purchaseStore);
+  const adminRouter = createAdminRouter(config, purchaseStore, store);
   if (adminRouter) router.use(adminRouter);
 
   // Entitlement routes — only mounted when config.entitlements is set

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -1,9 +1,15 @@
 import { Router } from 'express';
 import type { Request, Response } from 'express';
 import { z } from 'zod';
-import type { OneSubServerConfig, PurchaseInfo } from '@onesub/shared';
-import { PURCHASE_TYPE, ONESUB_ERROR_CODE } from '@onesub/shared';
-import type { PurchaseStore } from '../store.js';
+import type {
+  OneSubServerConfig,
+  PurchaseInfo,
+  ListSubscriptionsResponse,
+  Platform,
+  SubscriptionStatus,
+} from '@onesub/shared';
+import { PURCHASE_TYPE, ONESUB_ERROR_CODE, ROUTES, SUBSCRIPTION_STATUS } from '@onesub/shared';
+import type { PurchaseStore, SubscriptionStore } from '../store.js';
 import { sendError, sendZodError } from '../errors.js';
 
 const ADMIN_SECRET_HEADER = 'x-admin-secret';
@@ -20,27 +26,36 @@ const ADMIN_SECRET_HEADER = 'x-admin-secret';
  *   POST /onesub/purchase/admin/grant
  *     → manually insert a purchase record (skips store verification)
  *     body: { userId, productId, platform, type?, transactionId? }
+ *
+ *   POST /onesub/purchase/admin/transfer
+ *     → reassign a transactionId to a new userId (device migration)
+ *
+ *   GET /onesub/admin/subscriptions?userId=&status=&productId=&platform=&limit=&offset=
+ *     → filtered/paginated subscription list (used by dashboard + scripts)
  */
 export function createAdminRouter(
   config: OneSubServerConfig,
   purchaseStore: PurchaseStore,
+  store: SubscriptionStore,
 ): Router | null {
   if (!config.adminSecret) return null;
 
   const router = Router();
   const adminSecret = config.adminSecret;
 
-  // Auth middleware — scoped to /onesub/purchase/admin/* so it doesn't
-  // swallow unrelated requests (e.g. host-app routes like /health) when the
-  // admin router is mounted at the parent root.
-  router.use('/onesub/purchase/admin', (req, res, next) => {
+  // Auth middleware — applied to both admin scopes. Without this guard, a
+  // misconfigured mount on the parent root would expose admin endpoints
+  // alongside host-app routes (e.g. /health).
+  const adminAuth = (req: Request, res: Response, next: () => void) => {
     const provided = req.headers[ADMIN_SECRET_HEADER];
     if (typeof provided !== 'string' || provided !== adminSecret) {
       sendError(res, 401, ONESUB_ERROR_CODE.INVALID_ADMIN_SECRET, 'INVALID_ADMIN_SECRET');
       return;
     }
     next();
-  });
+  };
+  router.use('/onesub/purchase/admin', adminAuth);
+  router.use('/onesub/admin', adminAuth);
 
   // DELETE /onesub/purchase/admin/:userId/:productId
   // Express 5 types route params as `string | string[]` — narrow via zod.
@@ -122,6 +137,54 @@ export function createAdminRouter(
     };
     await purchaseStore.savePurchase(purchase);
     res.json({ ok: true, purchase });
+  });
+
+  // GET /onesub/admin/subscriptions?userId=&status=&productId=&platform=&limit=&offset=
+  // Filtered + paginated subscription list. Backs the dashboard's
+  // subscriptions page and ad-hoc operational scripts.
+  const listQuerySchema = z.object({
+    userId: z.string().min(1).max(256).optional(),
+    status: z.enum([
+      SUBSCRIPTION_STATUS.ACTIVE,
+      SUBSCRIPTION_STATUS.GRACE_PERIOD,
+      SUBSCRIPTION_STATUS.ON_HOLD,
+      SUBSCRIPTION_STATUS.PAUSED,
+      SUBSCRIPTION_STATUS.EXPIRED,
+      SUBSCRIPTION_STATUS.CANCELED,
+      SUBSCRIPTION_STATUS.NONE,
+    ] as [SubscriptionStatus, ...SubscriptionStatus[]]).optional(),
+    productId: z.string().min(1).max(256).optional(),
+    platform: z.enum(['apple', 'google'] as [Platform, ...Platform[]]).optional(),
+    // Cap at 200 server-side so a runaway dashboard query can't tip the DB.
+    limit: z.coerce.number().int().positive().max(200).optional(),
+    offset: z.coerce.number().int().nonnegative().optional(),
+  });
+
+  router.get(ROUTES.ADMIN_SUBSCRIPTIONS, async (req: Request, res: Response) => {
+    let query: z.infer<typeof listQuerySchema>;
+    try {
+      query = listQuerySchema.parse(req.query);
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        sendZodError(res, err);
+        return;
+      }
+      throw err;
+    }
+
+    try {
+      const result = await store.listFiltered(query);
+      const response: ListSubscriptionsResponse = {
+        items: result.items,
+        total: result.total,
+        limit: result.limit,
+        offset: result.offset,
+      };
+      res.status(200).json(response);
+    } catch (err) {
+      // Bubble the message up but not the stack — admin clients log status code
+      sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, (err as Error).message ?? 'list error');
+    }
   });
 
   return router;

--- a/packages/server/src/store.ts
+++ b/packages/server/src/store.ts
@@ -1,4 +1,25 @@
-import type { SubscriptionInfo, PurchaseInfo } from '@onesub/shared';
+import type { SubscriptionInfo, PurchaseInfo, SubscriptionStatus, Platform } from '@onesub/shared';
+
+/** Filter options for SubscriptionStore.listFiltered. All fields optional. */
+export interface ListFilteredOptions {
+  userId?: string;
+  status?: SubscriptionStatus;
+  productId?: string;
+  platform?: Platform;
+  /** Max items to return. Defaults to 50, capped at 200 by the route handler. */
+  limit?: number;
+  /** Pagination cursor. Defaults to 0. */
+  offset?: number;
+}
+
+/** Result of SubscriptionStore.listFiltered. */
+export interface ListFilteredResult {
+  items: SubscriptionInfo[];
+  /** Total matches before limit/offset — used for pagination UI. */
+  total: number;
+  limit: number;
+  offset: number;
+}
 
 /**
  * Pluggable subscription store interface.
@@ -20,6 +41,16 @@ export interface SubscriptionStore {
    * the built-in `/onesub/metrics/*` endpoints gate it behind `adminSecret`.
    */
   listAll(): Promise<SubscriptionInfo[]>;
+  /**
+   * Filtered, paginated subscription list. Used by the dashboard's
+   * subscriptions page and any admin tool that needs to enumerate records
+   * without pulling the entire table.
+   *
+   * Filter semantics: each non-undefined field is an AND condition.
+   * Sorting: most-recently-updated first (PostgresStore uses `updated_at DESC`;
+   * InMemoryStore approximates via insertion order with newest at the front).
+   */
+  listFiltered(opts: ListFilteredOptions): Promise<ListFilteredResult>;
   /**
    * Returns every subscription record for the user (across all productIds),
    * ordered most-recent-first. Used by entitlement evaluation, which needs to
@@ -69,6 +100,31 @@ export class InMemorySubscriptionStore implements SubscriptionStore {
 
   async listAll(): Promise<SubscriptionInfo[]> {
     return [...this.byTransactionId.values()];
+  }
+
+  async listFiltered(opts: ListFilteredOptions): Promise<ListFilteredResult> {
+    const limit = opts.limit ?? 50;
+    const offset = opts.offset ?? 0;
+    // Iterate via byUserId so insertion-order is "newest first" within each
+    // user (matches PostgresStore's `updated_at DESC` semantic). Across users
+    // we collect in Map iteration order — stable for a given run.
+    const all: SubscriptionInfo[] = [];
+    for (const list of this.byUserId.values()) {
+      for (const s of list) all.push(s);
+    }
+    const filtered = all.filter((s) => {
+      if (opts.userId && s.userId !== opts.userId) return false;
+      if (opts.status && s.status !== opts.status) return false;
+      if (opts.productId && s.productId !== opts.productId) return false;
+      if (opts.platform && s.platform !== opts.platform) return false;
+      return true;
+    });
+    return {
+      items: filtered.slice(offset, offset + limit),
+      total: filtered.length,
+      limit,
+      offset,
+    };
   }
 }
 

--- a/packages/server/src/stores/postgres.ts
+++ b/packages/server/src/stores/postgres.ts
@@ -1,5 +1,10 @@
 import type { SubscriptionInfo, PurchaseInfo } from '@onesub/shared';
-import type { SubscriptionStore, PurchaseStore } from '../store.js';
+import type {
+  SubscriptionStore,
+  PurchaseStore,
+  ListFilteredOptions,
+  ListFilteredResult,
+} from '../store.js';
 import { SUBSCRIPTIONS_SCHEMA_SQL, PURCHASES_SCHEMA_SQL } from './schema.js';
 
 /**
@@ -147,6 +152,56 @@ export class PostgresSubscriptionStore implements SubscriptionStore {
     const pool = await this.getPool();
     const result = await pool.query<DbRow>(`SELECT * FROM onesub_subscriptions`);
     return result.rows.map(rowToSubscriptionInfo);
+  }
+
+  async listFiltered(opts: ListFilteredOptions): Promise<ListFilteredResult> {
+    const pool = await this.getPool();
+    const limit = opts.limit ?? 50;
+    const offset = opts.offset ?? 0;
+
+    // Build the WHERE clause incrementally. Each non-undefined filter adds an
+    // AND condition with a parameterised value (no SQL injection surface).
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+    if (opts.userId) {
+      params.push(opts.userId);
+      conditions.push(`user_id = $${params.length}`);
+    }
+    if (opts.status) {
+      params.push(opts.status);
+      conditions.push(`status = $${params.length}`);
+    }
+    if (opts.productId) {
+      params.push(opts.productId);
+      conditions.push(`product_id = $${params.length}`);
+    }
+    if (opts.platform) {
+      params.push(opts.platform);
+      conditions.push(`platform = $${params.length}`);
+    }
+    const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+
+    // Run the count + page in parallel — both queries hit the same WHERE clause
+    // so they share the index plan, and we save a round-trip.
+    const [countResult, pageResult] = await Promise.all([
+      pool.query<{ total: string }>(
+        `SELECT COUNT(*)::text AS total FROM onesub_subscriptions ${where}`,
+        params,
+      ),
+      pool.query<DbRow>(
+        `SELECT * FROM onesub_subscriptions ${where}
+           ORDER BY updated_at DESC
+           LIMIT $${params.length + 1} OFFSET $${params.length + 2}`,
+        [...params, limit, offset],
+      ),
+    ]);
+
+    return {
+      items: pageResult.rows.map(rowToSubscriptionInfo),
+      total: parseInt(countResult.rows[0]?.total ?? '0', 10),
+      limit,
+      offset,
+    };
   }
 
   /** Gracefully close the underlying connection pool. */

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -11,6 +11,7 @@ export const ROUTES = {
   METRICS_ACTIVE: '/onesub/metrics/active',
   METRICS_STARTED: '/onesub/metrics/started',
   METRICS_EXPIRED: '/onesub/metrics/expired',
+  ADMIN_SUBSCRIPTIONS: '/onesub/admin/subscriptions',
 } as const;
 
 /** Default server port */

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -411,6 +411,31 @@ export interface MetricsActiveResponse {
 }
 
 /**
+ * Filter options for `GET /onesub/admin/subscriptions`. All optional —
+ * unspecified fields are ignored. `limit` defaults to 50 (max 200).
+ *
+ * Used by the dashboard's subscriptions list page; can be called directly by
+ * any admin tool that needs to enumerate or page through subscription records.
+ */
+export interface ListSubscriptionsQuery {
+  userId?: string;
+  status?: SubscriptionStatus;
+  productId?: string;
+  platform?: Platform;
+  limit?: number;
+  offset?: number;
+}
+
+/** Response from `GET /onesub/admin/subscriptions`. */
+export interface ListSubscriptionsResponse {
+  items: SubscriptionInfo[];
+  /** Total matches before limit/offset — used by the dashboard for pagination. */
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+/**
  * Count of records that started or ended within the given window.
  * Used for cohort / churn analysis.
  */


### PR DESCRIPTION
## Summary

Dashboard `/dashboard/subscriptions` 페이지 + 백엔드 admin list endpoint. Phase 1a(overview)에 이어 운영자가 실제 구독 record를 조회·필터링·페이지네이션할 수 있는 기본기.

## 서버 측

### `GET /onesub/admin/subscriptions?userId=&status=&productId=&platform=&limit=&offset=`

- `adminSecret` 헤더 필수 (`X-Admin-Secret`)
- 모든 query 파라미터 옵션. AND 조합
- `limit` default 50, **server-side cap 200**
- 응답: `{ items: SubscriptionInfo[], total, limit, offset }` (count + page를 Postgres에서 병렬 쿼리)

### `SubscriptionStore.listFiltered(opts)`

- **InMemory**: byUserId map iterate → filter → slice
- **Postgres**: 동적 WHERE + `ORDER BY updated_at DESC LIMIT/OFFSET`. `Promise.all`로 count + page 병렬

### Auth scope 확장

`createAdminRouter`의 middleware를 두 prefix에 적용:
- `/onesub/purchase/admin/*` (기존 — purchase 작업)
- `/onesub/admin/*` (신규 — subscription read-only)

`createAdminRouter` 시그니처에 `SubscriptionStore` 추가. 호출자(`index.ts`) 갱신.

## Dashboard 측

### `/dashboard/subscriptions`

- Server component, **GET form**으로 필터 → URL params로 sync → 페이지 re-render
- 필터 4개: `userId` text, `status` select (7 values), `productId` text, `platform` select (apple/google)
- `Clear` 링크: 모든 필터 reset
- 테이블 컬럼: userId, productId, status (색상 badge), platform, expiresAt (YYYY-MM-DD, hover로 full ISO), willRenew, originalTransactionId
- Pagination: prev/next 버튼 + "X-Y of total" 카운터
- 401 발생 시 cookie clear + `/login` redirect

### Status badge 색상

| status | 색 |
|---|---|
| active | emerald (entitlement valid) |
| grace_period | amber (at-risk) |
| on_hold | rose (revoked) |
| paused | sky (user-voluntary) |
| expired/canceled | slate (terminal) |

### 사이드바

`Subscriptions` 링크 활성화 (Phase 1a의 placeholder 제거).

## Test plan

- [x] `npm run build` (root, server) + `npm run build -w @onesub/dashboard` 통과
- [x] `npm test` — **354/354** (이전 340 + 14 신규)
- [x] auth 2 케이스 (router 미마운트 / 헤더 누락·틀림)
- [x] 필터 조합 5 케이스 (none / userId / status / 4-filter AND / 잘못된 status·platform 400)
- [x] pagination 3 케이스 (limit/offset / cap 200 / negative offset reject)
- [x] store.listFiltered 직접 2 케이스 (AND 조합 / defaults)
- [ ] (수동) 로컬에서 `npm run dev -w @onesub/dashboard` + 서버 띄워 인터랙션 확인

## Breaking changes

`createAdminRouter` 시그니처 — 마지막 인자 `SubscriptionStore` 추가. **외부 export 아님** (index.ts 내부 사용만, public API에서 호출 안 됨). 호스트 사용자 영향 없음.

## 분량

10 files, +755/-17

## 다음

- **Phase 2**: 시계열 차트 (recharts) — `/onesub/metrics/started|expired` 활용
- **Phase 3**: customer search / audit log / manual grant UI / token-exchange auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)