### PR TITLE
chore: changeset for admin list-subscriptions endpoint

### DIFF
--- a/.changeset/admin-list-subscriptions.md
+++ b/.changeset/admin-list-subscriptions.md
@@ -1,0 +1,17 @@
+---
+"@onesub/shared": minor
+"@onesub/server": minor
+---
+
+Add admin endpoint for filtered/paginated subscription listing — backs the dashboard's subscriptions page and ad-hoc operational scripts.
+
+**Server**
+
+- New `GET /onesub/admin/subscriptions` route accepting `userId`, `status`, `productId`, `platform`, `limit` (max 200), `offset`. Gated by `X-Admin-Secret`.
+- `SubscriptionStore` interface gains `listFiltered(opts)`. InMemory and Postgres implementations both supported (Postgres uses `updated_at DESC` with parallel count + page query).
+- Admin auth middleware now also covers the `/onesub/admin` scope (was previously only `/onesub/purchase/admin`).
+
+**Shared**
+
+- New `ListSubscriptionsQuery` and `ListSubscriptionsResponse` types.
+- New `ROUTES.ADMIN_SUBSCRIPTIONS` constant.


### PR DESCRIPTION
## Summary

Changeset for PR #52 — admin filtered subscription list endpoint.

- `@onesub/shared` minor — `ListSubscriptionsQuery` / `ListSubscriptionsResponse` types + `ROUTES.ADMIN_SUBSCRIPTIONS`
- `@onesub/server` minor — `GET /onesub/admin/subscriptions` route, `listFiltered` on `SubscriptionStore` (InMemory + Postgres), admin auth on `/onesub/admin` scope

## Test plan

- [x] CI green on #52 (354/354 tests)
- [ ] Verify `Version Packages` PR auto-generated after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)