### PR TITLE
chore: change changeset bump to patch (0.7.1 / 0.11.1)

### DIFF
--- a/.changeset/admin-list-subscriptions.md
+++ b/.changeset/admin-list-subscriptions.md
@@ -1,6 +1,6 @@
 ---
-"@onesub/shared": minor
-"@onesub/server": minor
+"@onesub/shared": patch
+"@onesub/server": patch
 ---
 
 Add admin endpoint for filtered/paginated subscription listing — backs the dashboard's subscriptions page and ad-hoc operational scripts.


### PR DESCRIPTION
## Summary

#53 was merged with `minor` bumps but should be `patch` — admin list endpoint is additive, no breaking changes, doesn't warrant a minor on its own.

- `@onesub/shared`: 0.7.0 → 0.7.1 (patch)
- `@onesub/server`: 0.11.0 → 0.11.1 (patch)

The Version Packages PR opened by changesets will refresh once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)