### PR TITLE
feat(dashboard): subscription detail page

### DIFF
--- a/packages/dashboard/app/dashboard/subscriptions/[transactionId]/page.tsx
+++ b/packages/dashboard/app/dashboard/subscriptions/[transactionId]/page.tsx
@@ -1,0 +1,147 @@
+import Link from 'next/link';
+import { notFound, redirect } from 'next/navigation';
+import type { SubscriptionInfo } from '@onesub/shared';
+import { requireClient, clearAdminSecret } from '../../../../lib/auth';
+import { OneSubFetchError } from '../../../../lib/onesub-client';
+
+export const dynamic = 'force-dynamic';
+
+interface PageProps {
+  params: Promise<{ transactionId: string }>;
+}
+
+function StatusBadge({ status }: { status: SubscriptionInfo['status'] }) {
+  const styles: Record<SubscriptionInfo['status'], string> = {
+    active:        'bg-emerald-100 text-emerald-800',
+    grace_period:  'bg-amber-100 text-amber-800',
+    on_hold:       'bg-rose-100 text-rose-800',
+    paused:        'bg-sky-100 text-sky-800',
+    expired:       'bg-slate-200 text-slate-600',
+    canceled:      'bg-slate-200 text-slate-600',
+    none:          'bg-slate-100 text-slate-500',
+  };
+  return (
+    <span className={`inline-block rounded px-2.5 py-1 text-xs font-medium ${styles[status]}`}>
+      {status}
+    </span>
+  );
+}
+
+// Returns "in 14 days" / "12 days ago" / "today". Operators eyeball the table
+// faster with a relative anchor next to the absolute timestamp.
+function relativeFromNow(iso: string): string {
+  const target = new Date(iso).getTime();
+  if (!Number.isFinite(target)) return '';
+  const diffMs = target - Date.now();
+  const days = Math.round(diffMs / 86_400_000);
+  if (days === 0) return 'today';
+  if (days > 0)  return `in ${days} day${days === 1 ? '' : 's'}`;
+  return `${-days} day${days === -1 ? '' : 's'} ago`;
+}
+
+export default async function SubscriptionDetailPage({ params }: PageProps) {
+  const { transactionId } = await params;
+
+  const client = await requireClient();
+  let sub: SubscriptionInfo;
+  try {
+    sub = await client.getSubscription(transactionId);
+  } catch (err) {
+    if (err instanceof OneSubFetchError && err.status === 401) {
+      await clearAdminSecret();
+      redirect('/login');
+    }
+    if (err instanceof OneSubFetchError && err.status === 404) {
+      notFound();
+    }
+    throw err;
+  }
+
+  // Pre-build the "all subs for this user" link so operators can pivot from
+  // one record back to the full per-user history.
+  const userSubsHref = `/dashboard/subscriptions?userId=${encodeURIComponent(sub.userId)}`;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          href="/dashboard/subscriptions"
+          className="text-sm text-slate-500 underline-offset-2 hover:underline"
+        >
+          ← Subscriptions
+        </Link>
+        <div className="mt-2 flex flex-wrap items-center gap-3">
+          <h1 className="text-2xl font-semibold tracking-tight">Subscription detail</h1>
+          <StatusBadge status={sub.status} />
+        </div>
+        <p className="mt-1 font-mono text-xs text-slate-500">{sub.originalTransactionId}</p>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <DetailCard title="Identity">
+          <Row label="userId">
+            <span className="font-mono">{sub.userId}</span>
+            <Link
+              href={userSubsHref}
+              className="ml-2 text-xs text-brand-600 underline-offset-2 hover:underline"
+            >
+              모두 보기
+            </Link>
+          </Row>
+          <Row label="productId">{sub.productId}</Row>
+          <Row label="platform">{sub.platform}</Row>
+          <Row label="originalTransactionId">
+            <span className="font-mono text-xs">{sub.originalTransactionId}</span>
+          </Row>
+        </DetailCard>
+
+        <DetailCard title="Lifecycle">
+          <Row label="status"><StatusBadge status={sub.status} /></Row>
+          <Row label="willRenew">{sub.willRenew ? 'yes' : 'no'}</Row>
+          <Row label="purchasedAt">
+            <span className="font-mono tabular-nums">{sub.purchasedAt}</span>
+            <span className="ml-2 text-xs text-slate-400">{relativeFromNow(sub.purchasedAt)}</span>
+          </Row>
+          <Row label="expiresAt">
+            <span className="font-mono tabular-nums">{sub.expiresAt}</span>
+            <span className="ml-2 text-xs text-slate-400">{relativeFromNow(sub.expiresAt)}</span>
+          </Row>
+        </DetailCard>
+      </div>
+
+      {(sub.linkedPurchaseToken || sub.autoResumeTime) ? (
+        <DetailCard title="Google-only fields">
+          {sub.linkedPurchaseToken ? (
+            <Row label="linkedPurchaseToken">
+              <span className="font-mono text-xs">{sub.linkedPurchaseToken}</span>
+            </Row>
+          ) : null}
+          {sub.autoResumeTime ? (
+            <Row label="autoResumeTime">
+              <span className="font-mono tabular-nums">{sub.autoResumeTime}</span>
+              <span className="ml-2 text-xs text-slate-400">{relativeFromNow(sub.autoResumeTime)}</span>
+            </Row>
+          ) : null}
+        </DetailCard>
+      ) : null}
+    </div>
+  );
+}
+
+function DetailCard({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white shadow-sm">
+      <div className="border-b border-slate-100 px-5 py-3 text-sm font-semibold text-slate-700">{title}</div>
+      <div className="divide-y divide-slate-50">{children}</div>
+    </div>
+  );
+}
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-baseline justify-between gap-4 px-5 py-3 text-sm">
+      <span className="shrink-0 text-xs font-medium uppercase tracking-wide text-slate-500">{label}</span>
+      <span className="text-right text-slate-900">{children}</span>
+    </div>
+  );
+}

--- a/packages/dashboard/app/dashboard/subscriptions/page.tsx
+++ b/packages/dashboard/app/dashboard/subscriptions/page.tsx
@@ -147,17 +147,28 @@ export default async function SubscriptionsPage({ searchParams }: PageProps) {
                 </td>
               </tr>
             ) : (
-              result.items.map((s) => (
-                <tr key={s.originalTransactionId} className="border-t border-slate-100" title={s.expiresAt}>
-                  <Td className="font-mono text-xs">{s.userId}</Td>
-                  <Td>{s.productId}</Td>
-                  <Td><StatusBadge status={s.status} /></Td>
-                  <Td>{s.platform}</Td>
-                  <Td className="font-mono tabular-nums">{formatExpiry(s.expiresAt)}</Td>
-                  <Td>{s.willRenew ? 'yes' : 'no'}</Td>
-                  <Td className="font-mono text-xs text-slate-500">{s.originalTransactionId}</Td>
-                </tr>
-              ))
+              result.items.map((s) => {
+                const detailHref = `/dashboard/subscriptions/${encodeURIComponent(s.originalTransactionId)}`;
+                return (
+                  <tr
+                    key={s.originalTransactionId}
+                    className="border-t border-slate-100 hover:bg-slate-50"
+                    title={s.expiresAt}
+                  >
+                    <Td className="font-mono text-xs">
+                      <Link href={detailHref} className="hover:underline">{s.userId}</Link>
+                    </Td>
+                    <Td><Link href={detailHref} className="hover:underline">{s.productId}</Link></Td>
+                    <Td><StatusBadge status={s.status} /></Td>
+                    <Td>{s.platform}</Td>
+                    <Td className="font-mono tabular-nums">{formatExpiry(s.expiresAt)}</Td>
+                    <Td>{s.willRenew ? 'yes' : 'no'}</Td>
+                    <Td className="font-mono text-xs text-slate-500">
+                      <Link href={detailHref} className="hover:underline">{s.originalTransactionId}</Link>
+                    </Td>
+                  </tr>
+                );
+              })
             )}
           </tbody>
         </table>

--- a/packages/dashboard/lib/onesub-client.ts
+++ b/packages/dashboard/lib/onesub-client.ts
@@ -12,6 +12,7 @@ import type {
   ListSubscriptionsResponse,
   MetricsActiveResponse,
   MetricsCountResponse,
+  SubscriptionInfo,
 } from '@onesub/shared';
 
 export interface OneSubClient {
@@ -19,6 +20,12 @@ export interface OneSubClient {
   getStartedMetrics(from: Date, to: Date): Promise<MetricsCountResponse>;
   getExpiredMetrics(from: Date, to: Date): Promise<MetricsCountResponse>;
   listSubscriptions(query: ListSubscriptionsQuery): Promise<ListSubscriptionsResponse>;
+  /**
+   * Fetch a single subscription record by `originalTransactionId`. Throws
+   * `OneSubFetchError` with `status: 404` when the id is unknown — callers
+   * should branch on that to render a "not found" page.
+   */
+  getSubscription(transactionId: string): Promise<SubscriptionInfo>;
 }
 
 export class OneSubFetchError extends Error {
@@ -69,5 +76,7 @@ export function createClient(serverUrl: string, adminSecret: string): OneSubClie
       const qs = params.toString();
       return get<ListSubscriptionsResponse>(`/onesub/admin/subscriptions${qs ? `?${qs}` : ''}`);
     },
+    getSubscription: (transactionId) =>
+      get<SubscriptionInfo>(`/onesub/admin/subscriptions/${encodeURIComponent(transactionId)}`),
   };
 }

--- a/packages/server/src/__tests__/admin-subscription-detail.test.ts
+++ b/packages/server/src/__tests__/admin-subscription-detail.test.ts
@@ -1,0 +1,143 @@
+/**
+ * GET /onesub/admin/subscriptions/:transactionId — single-record detail.
+ *
+ * Backs the dashboard's subscription detail page. Same auth contract as the
+ * other /onesub/admin/* endpoints (X-Admin-Secret header).
+ */
+
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import type { OneSubServerConfig, SubscriptionInfo } from '@onesub/shared';
+import { createOneSubMiddleware, InMemorySubscriptionStore, InMemoryPurchaseStore } from '../index.js';
+
+function sub(overrides?: Partial<SubscriptionInfo>): SubscriptionInfo {
+  return {
+    userId: 'u',
+    productId: 'pro_monthly',
+    platform: 'apple',
+    status: 'active',
+    expiresAt: '2099-01-01T00:00:00.000Z',
+    purchasedAt: '2026-04-01T00:00:00.000Z',
+    originalTransactionId: 'orig_default',
+    willRenew: true,
+    ...overrides,
+  };
+}
+
+interface TestServer {
+  get: <T,>(path: string, headers?: Record<string, string>) => Promise<{ status: number; body: T }>;
+}
+
+function spinUp(handler: express.Express): TestServer {
+  return {
+    async get<T>(path: string, headers?: Record<string, string>): Promise<{ status: number; body: T }> {
+      const httpServer = handler.listen(0);
+      const port = (httpServer.address() as { port: number }).port;
+      try {
+        const resp = await fetch(`http://127.0.0.1:${port}${path}`, { headers });
+        const text = await resp.text();
+        let parsed: unknown = text;
+        try { parsed = JSON.parse(text); } catch { /* keep as text */ }
+        return { status: resp.status, body: parsed as T };
+      } finally {
+        await new Promise<void>((r) => httpServer.close(() => r()));
+      }
+    },
+  };
+}
+
+function buildServer(opts: { adminSecret?: string }) {
+  const store = new InMemorySubscriptionStore();
+  const purchaseStore = new InMemoryPurchaseStore();
+  const config: OneSubServerConfig = {
+    apple: { bundleId: 'com.example.app', skipJwsVerification: true },
+    database: { url: '' },
+    adminSecret: opts.adminSecret,
+  };
+  const app = express();
+  app.use(createOneSubMiddleware({ ...config, store, purchaseStore }));
+  return { store, server: spinUp(app) };
+}
+
+const SECRET = 's3cr3t';
+const AUTH = { 'x-admin-secret': SECRET };
+
+describe('GET /onesub/admin/subscriptions/:transactionId auth', () => {
+  it('returns 404 when adminSecret is unset (router not mounted)', async () => {
+    const { server } = buildServer({});
+    const resp = await server.get('/onesub/admin/subscriptions/orig_xyz');
+    expect(resp.status).toBe(404);
+  });
+
+  it('returns 401 INVALID_ADMIN_SECRET when header is missing or wrong', async () => {
+    const { server } = buildServer({ adminSecret: SECRET });
+
+    const noHeader = await server.get<{ errorCode: string }>('/onesub/admin/subscriptions/orig_xyz');
+    expect(noHeader.status).toBe(401);
+    expect(noHeader.body.errorCode).toBe('INVALID_ADMIN_SECRET');
+
+    const wrongHeader = await server.get<{ errorCode: string }>(
+      '/onesub/admin/subscriptions/orig_xyz',
+      { 'x-admin-secret': 'wrong' },
+    );
+    expect(wrongHeader.status).toBe(401);
+  });
+});
+
+describe('GET /onesub/admin/subscriptions/:transactionId basics', () => {
+  it('returns the matching subscription', async () => {
+    const { store, server } = buildServer({ adminSecret: SECRET });
+    const target = sub({ userId: 'alice', originalTransactionId: 'orig_42' });
+    await store.save(target);
+    await store.save(sub({ userId: 'bob', originalTransactionId: 'orig_other' }));
+
+    const resp = await server.get<SubscriptionInfo>(
+      '/onesub/admin/subscriptions/orig_42',
+      AUTH,
+    );
+    expect(resp.status).toBe(200);
+    expect(resp.body.originalTransactionId).toBe('orig_42');
+    expect(resp.body.userId).toBe('alice');
+  });
+
+  it('returns 404 TRANSACTION_NOT_FOUND when the id is unknown', async () => {
+    const { server } = buildServer({ adminSecret: SECRET });
+    const resp = await server.get<{ errorCode: string }>(
+      '/onesub/admin/subscriptions/orig_does_not_exist',
+      AUTH,
+    );
+    expect(resp.status).toBe(404);
+    expect(resp.body.errorCode).toBe('TRANSACTION_NOT_FOUND');
+  });
+
+  it('does not collide with the list endpoint (no :transactionId)', async () => {
+    const { store, server } = buildServer({ adminSecret: SECRET });
+    await store.save(sub({ userId: 'a', originalTransactionId: 'orig_1' }));
+
+    const list = await server.get<{ items: SubscriptionInfo[] }>(
+      '/onesub/admin/subscriptions',
+      AUTH,
+    );
+    expect(list.status).toBe(200);
+    expect(list.body.items).toHaveLength(1);
+  });
+
+  it('preserves Google-only fields (linkedPurchaseToken, autoResumeTime)', async () => {
+    const { store, server } = buildServer({ adminSecret: SECRET });
+    await store.save(sub({
+      platform: 'google',
+      status: 'paused',
+      originalTransactionId: 'orig_google',
+      linkedPurchaseToken: 'prev_token',
+      autoResumeTime: '2026-05-01T00:00:00.000Z',
+    }));
+
+    const resp = await server.get<SubscriptionInfo>(
+      '/onesub/admin/subscriptions/orig_google',
+      AUTH,
+    );
+    expect(resp.status).toBe(200);
+    expect(resp.body.linkedPurchaseToken).toBe('prev_token');
+    expect(resp.body.autoResumeTime).toBe('2026-05-01T00:00:00.000Z');
+  });
+});

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -32,6 +32,9 @@ const ADMIN_SECRET_HEADER = 'x-admin-secret';
  *
  *   GET /onesub/admin/subscriptions?userId=&status=&productId=&platform=&limit=&offset=
  *     → filtered/paginated subscription list (used by dashboard + scripts)
+ *
+ *   GET /onesub/admin/subscriptions/:transactionId
+ *     → single subscription record by originalTransactionId (dashboard detail page)
  */
 export function createAdminRouter(
   config: OneSubServerConfig,
@@ -184,6 +187,31 @@ export function createAdminRouter(
     } catch (err) {
       // Bubble the message up but not the stack — admin clients log status code
       sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, (err as Error).message ?? 'list error');
+    }
+  });
+
+  // GET /onesub/admin/subscriptions/:transactionId — single record by
+  // originalTransactionId. Backs the dashboard's subscription detail page.
+  const detailParamsSchema = z.object({
+    transactionId: z.string().min(1).max(256),
+  });
+  router.get('/onesub/admin/subscriptions/:transactionId', async (req: Request, res: Response) => {
+    let params;
+    try {
+      params = detailParamsSchema.parse(req.params);
+    } catch {
+      sendError(res, 400, ONESUB_ERROR_CODE.INVALID_INPUT, 'transactionId required');
+      return;
+    }
+    try {
+      const sub = await store.getByTransactionId(params.transactionId);
+      if (!sub) {
+        sendError(res, 404, ONESUB_ERROR_CODE.TRANSACTION_NOT_FOUND, 'TRANSACTION_NOT_FOUND');
+        return;
+      }
+      res.status(200).json(sub);
+    } catch (err) {
+      sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, (err as Error).message ?? 'detail error');
     }
   });
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -12,6 +12,8 @@ export const ROUTES = {
   METRICS_STARTED: '/onesub/metrics/started',
   METRICS_EXPIRED: '/onesub/metrics/expired',
   ADMIN_SUBSCRIPTIONS: '/onesub/admin/subscriptions',
+  /** Single-record detail; takes :transactionId path param. */
+  ADMIN_SUBSCRIPTION_DETAIL: '/onesub/admin/subscriptions/:transactionId',
 } as const;
 
 /** Default server port */


### PR DESCRIPTION
## Summary

리스트 → 상세 동선을 마무리합니다. 운영자가 행을 클릭하면 해당 구독의 모든 필드를 한 화면에서 검토할 수 있습니다.

- **Server** — `GET /onesub/admin/subscriptions/:transactionId` (gated by `X-Admin-Secret`). 기존 `store.getByTransactionId`만 사용, 새 store 메서드 없음. Unknown id → 404 `TRANSACTION_NOT_FOUND`.
- **Shared** — `ROUTES.ADMIN_SUBSCRIPTION_DETAIL` constant.
- **Dashboard client** — `getSubscription(txId)` 메서드 추가. 404를 `OneSubFetchError(status:404)`로 그대로 노출 → 페이지에서 `notFound()` 호출.
- **Dashboard page** — `/dashboard/subscriptions/[transactionId]/page.tsx`. Identity / Lifecycle / Google-only 3개 카드. `linkedPurchaseToken`, `autoResumeTime`은 값 있을 때만 렌더. `expiresAt`/`purchasedAt`/`autoResumeTime` 옆에 "in 14 days" / "12 days ago" 상대 시간 anchor.
- **List page** — row의 userId / productId / originalTransactionId 셀이 detail link. status badge / platform / willRenew는 평문 유지 (필터 가독성 우선).
- **Tests** — `admin-subscription-detail.test.ts` 6 cases (auth 2 + basic 4 — found/404/list-no-collide/google fields preserved). 360/360 전체 통과.

## Test plan

- [x] `npm run build` — 5 패키지 모두 성공
- [x] `npm test` — 360/360 (28 files)
- [x] `next build` — 새 라우트 `/dashboard/subscriptions/[transactionId]` 등록 확인
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)