### PR TITLE
chore: changeset for subscription detail endpoint

### DIFF
--- a/.changeset/admin-subscription-detail.md
+++ b/.changeset/admin-subscription-detail.md
@@ -1,0 +1,15 @@
+---
+"@onesub/shared": patch
+"@onesub/server": patch
+---
+
+Add admin endpoint for fetching a single subscription record — backs the dashboard's subscription detail page.
+
+**Server**
+
+- New `GET /onesub/admin/subscriptions/:transactionId` route. Returns the matching `SubscriptionInfo`, or `404 TRANSACTION_NOT_FOUND` when the id is unknown. Gated by `X-Admin-Secret` like the rest of the admin scope.
+- Reuses the existing `SubscriptionStore.getByTransactionId` — no new store API surface.
+
+**Shared**
+
+- New `ROUTES.ADMIN_SUBSCRIPTION_DETAIL` constant.


### PR DESCRIPTION
## Summary

Changeset for #56 — admin subscription-detail endpoint.

- `@onesub/shared`: 0.7.1 → 0.7.2 (patch)
- `@onesub/server`: 0.11.1 → 0.11.2 (patch)

Additive route + new `ROUTES` constant; no breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)