### PR TITLE
feat(dashboard): growth chart on overview page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2437,6 +2437,42 @@
         }
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
@@ -2811,6 +2847,18 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -2887,6 +2935,69 @@
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
       "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -3074,6 +3185,12 @@
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -3967,6 +4084,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4190,6 +4316,127 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -4198,6 +4445,12 @@
       "dependencies": {
         "ms": "2.0.0"
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -4413,6 +4666,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.0.tgz",
+      "integrity": "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
@@ -4519,6 +4782,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
@@ -5321,6 +5590,16 @@
         "node": ">=16.x"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -5346,6 +5625,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/invariant": {
       "version": "2.2.4",
@@ -7289,7 +7577,8 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-native": {
       "version": "0.84.1",
@@ -7346,6 +7635,30 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
           "optional": true
         }
       }
@@ -7408,6 +7721,52 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
@@ -7431,6 +7790,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.12",
@@ -8315,6 +8680,12 @@
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "license": "MIT"
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -8571,6 +8942,15 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -8594,6 +8974,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {
@@ -8995,11 +9397,11 @@
     },
     "packages/cli": {
       "name": "@onesub/cli",
-      "version": "0.1.11",
+      "version": "0.1.13",
       "license": "MIT",
       "dependencies": {
-        "@onesub/server": "0.11.0",
-        "@onesub/shared": "0.7.0",
+        "@onesub/server": "0.11.2",
+        "@onesub/shared": "0.7.2",
         "express": "^5.2.1"
       },
       "bin": {
@@ -9015,12 +9417,13 @@
     },
     "packages/dashboard": {
       "name": "@onesub/dashboard",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "dependencies": {
-        "@onesub/shared": "0.7.0",
+        "@onesub/shared": "0.7.2",
         "next": "^15.0.0",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "recharts": "^3.8.1"
       },
       "devDependencies": {
         "@types/node": "^20.17.0",
@@ -9037,11 +9440,11 @@
     },
     "packages/mcp-server": {
       "name": "@onesub/mcp-server",
-      "version": "0.3.9",
+      "version": "0.3.11",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
-        "@onesub/shared": "0.7.0",
+        "@onesub/shared": "0.7.2",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -9057,10 +9460,10 @@
     },
     "packages/sdk": {
       "name": "@jeonghwanko/onesub-sdk",
-      "version": "0.6.1",
+      "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
-        "@onesub/shared": "0.7.0"
+        "@onesub/shared": "0.7.2"
       },
       "devDependencies": {
         "@types/react": "^19.0.0",
@@ -9083,10 +9486,10 @@
     },
     "packages/server": {
       "name": "@onesub/server",
-      "version": "0.11.0",
+      "version": "0.11.2",
       "license": "MIT",
       "dependencies": {
-        "@onesub/shared": "0.7.0",
+        "@onesub/shared": "0.7.2",
         "jose": "^6.2.2",
         "zod": "^4.3.6"
       },
@@ -9112,7 +9515,7 @@
     },
     "packages/shared": {
       "name": "@onesub/shared",
-      "version": "0.7.0",
+      "version": "0.7.2",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.0"

--- a/packages/dashboard/app/dashboard/_components/growth-chart.tsx
+++ b/packages/dashboard/app/dashboard/_components/growth-chart.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { MetricsBucket } from '@onesub/shared';
+
+interface GrowthChartProps {
+  /** Daily started counts, sorted ascending. Server-fetched in the parent. */
+  started: MetricsBucket[];
+  /** Daily expired counts, same length and date alignment as `started`. */
+  expired: MetricsBucket[];
+}
+
+interface ChartRow {
+  date: string;
+  /** Compact label for the X axis — drops the year to fit ~30 ticks. */
+  label: string;
+  started: number;
+  expired: number;
+  net: number;
+}
+
+function joinBuckets(started: MetricsBucket[], expired: MetricsBucket[]): ChartRow[] {
+  // Both series come zero-filled across the same window; map by date so a
+  // missing day on one side (defensive) just lands as 0.
+  const byDate = new Map<string, ChartRow>();
+  for (const b of started) {
+    byDate.set(b.date, {
+      date: b.date,
+      label: b.date.slice(5),  // MM-DD
+      started: b.count,
+      expired: 0,
+      net: b.count,
+    });
+  }
+  for (const b of expired) {
+    const row = byDate.get(b.date);
+    if (row) {
+      row.expired = b.count;
+      row.net = row.started - b.count;
+    } else {
+      byDate.set(b.date, {
+        date: b.date,
+        label: b.date.slice(5),
+        started: 0,
+        expired: b.count,
+        net: -b.count,
+      });
+    }
+  }
+  return [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date));
+}
+
+export function GrowthChart({ started, expired }: GrowthChartProps) {
+  const data = joinBuckets(started, expired);
+  const total = data.reduce(
+    (acc, r) => ({ started: acc.started + r.started, expired: acc.expired + r.expired }),
+    { started: 0, expired: 0 },
+  );
+  const net = total.started - total.expired;
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <div>
+          <div className="text-sm font-semibold text-slate-700">Growth — last 30 days</div>
+          <div className="text-xs text-slate-500">
+            UTC daily; bars = subscriptions started vs ended in the day
+          </div>
+        </div>
+        <div className="flex gap-4 text-xs text-slate-500">
+          <span>started <span className="ml-1 font-mono tabular-nums text-emerald-700">{total.started}</span></span>
+          <span>expired <span className="ml-1 font-mono tabular-nums text-rose-700">{total.expired}</span></span>
+          <span>net <span className={`ml-1 font-mono tabular-nums ${net >= 0 ? 'text-emerald-700' : 'text-rose-700'}`}>{net >= 0 ? `+${net}` : net}</span></span>
+        </div>
+      </div>
+      <div className="mt-4 h-64">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data} margin={{ top: 8, right: 12, left: 0, bottom: 0 }}>
+            <CartesianGrid stroke="#e2e8f0" strokeDasharray="3 3" vertical={false} />
+            <XAxis dataKey="label" tick={{ fontSize: 11, fill: '#64748b' }} interval="preserveStartEnd" />
+            <YAxis allowDecimals={false} tick={{ fontSize: 11, fill: '#64748b' }} width={32} />
+            <Tooltip
+              cursor={{ fill: '#f1f5f9' }}
+              contentStyle={{ fontSize: 12, borderRadius: 6, borderColor: '#cbd5e1' }}
+              labelFormatter={(label, payload) => {
+                const row = payload?.[0]?.payload as ChartRow | undefined;
+                return row?.date ?? String(label);
+              }}
+            />
+            <Legend wrapperStyle={{ fontSize: 12 }} iconType="circle" />
+            <Bar dataKey="started" name="started" fill="#10b981" radius={[2, 2, 0, 0]} />
+            <Bar dataKey="expired" name="expired" fill="#f43f5e" radius={[2, 2, 0, 0]} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/app/dashboard/page.tsx
+++ b/packages/dashboard/app/dashboard/page.tsx
@@ -1,7 +1,10 @@
 import { requireClient } from '../../lib/auth';
 import { OneSubFetchError } from '../../lib/onesub-client';
+import { GrowthChart } from './_components/growth-chart';
 
 export const dynamic = 'force-dynamic';
+
+const GROWTH_WINDOW_DAYS = 30;
 
 interface StatCardProps {
   label: string;
@@ -54,9 +57,20 @@ function DistributionTable({ title, data, empty }: DistributionTableProps) {
 export default async function DashboardOverview() {
   const client = await requireClient();
 
+  // 30d rolling window — `to` is now, `from` is 29 days back so the chart
+  // shows 30 inclusive UTC buckets (today + 29 prior days).
+  const to = new Date();
+  const from = new Date(to.getTime() - (GROWTH_WINDOW_DAYS - 1) * 86_400_000);
+
   let metrics;
+  let started;
+  let expired;
   try {
-    metrics = await client.getActiveMetrics();
+    [metrics, started, expired] = await Promise.all([
+      client.getActiveMetrics(),
+      client.getStartedMetrics(from, to, { groupBy: 'day' }),
+      client.getExpiredMetrics(from, to, { groupBy: 'day' }),
+    ]);
   } catch (err) {
     // 401 from the upstream server means the cookie is stale — clear it and
     // bounce to login. (Edge middleware can't probe the upstream itself, so
@@ -102,6 +116,8 @@ export default async function DashboardOverview() {
           hint="lifetime products"
         />
       </div>
+
+      <GrowthChart started={started.buckets ?? []} expired={expired.buckets ?? []} />
 
       <div className="grid gap-6 lg:grid-cols-2">
         <DistributionTable

--- a/packages/dashboard/lib/onesub-client.ts
+++ b/packages/dashboard/lib/onesub-client.ts
@@ -12,13 +12,19 @@ import type {
   ListSubscriptionsResponse,
   MetricsActiveResponse,
   MetricsCountResponse,
+  MetricsGroupBy,
   SubscriptionInfo,
 } from '@onesub/shared';
 
+export interface MetricsRangeOptions {
+  /** When set, response includes a daily `buckets` array (zero-filled). */
+  groupBy?: MetricsGroupBy;
+}
+
 export interface OneSubClient {
   getActiveMetrics(): Promise<MetricsActiveResponse>;
-  getStartedMetrics(from: Date, to: Date): Promise<MetricsCountResponse>;
-  getExpiredMetrics(from: Date, to: Date): Promise<MetricsCountResponse>;
+  getStartedMetrics(from: Date, to: Date, opts?: MetricsRangeOptions): Promise<MetricsCountResponse>;
+  getExpiredMetrics(from: Date, to: Date, opts?: MetricsRangeOptions): Promise<MetricsCountResponse>;
   listSubscriptions(query: ListSubscriptionsQuery): Promise<ListSubscriptionsResponse>;
   /**
    * Fetch a single subscription record by `originalTransactionId`. Throws
@@ -55,16 +61,18 @@ export function createClient(serverUrl: string, adminSecret: string): OneSubClie
     return (await response.json()) as T;
   }
 
+  function rangePath(base: string, from: Date, to: Date, opts?: MetricsRangeOptions): string {
+    const params = new URLSearchParams({ from: from.toISOString(), to: to.toISOString() });
+    if (opts?.groupBy) params.set('groupBy', opts.groupBy);
+    return `${base}?${params.toString()}`;
+  }
+
   return {
     getActiveMetrics: () => get<MetricsActiveResponse>('/onesub/metrics/active'),
-    getStartedMetrics: (from, to) =>
-      get<MetricsCountResponse>(
-        `/onesub/metrics/started?from=${from.toISOString()}&to=${to.toISOString()}`,
-      ),
-    getExpiredMetrics: (from, to) =>
-      get<MetricsCountResponse>(
-        `/onesub/metrics/expired?from=${from.toISOString()}&to=${to.toISOString()}`,
-      ),
+    getStartedMetrics: (from, to, opts) =>
+      get<MetricsCountResponse>(rangePath('/onesub/metrics/started', from, to, opts)),
+    getExpiredMetrics: (from, to, opts) =>
+      get<MetricsCountResponse>(rangePath('/onesub/metrics/expired', from, to, opts)),
     listSubscriptions: (query) => {
       const params = new URLSearchParams();
       if (query.userId)    params.set('userId', query.userId);

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -15,7 +15,8 @@
     "@onesub/shared": "0.7.2",
     "next": "^15.0.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@types/node": "^20.17.0",

--- a/packages/server/src/__tests__/metrics.test.ts
+++ b/packages/server/src/__tests__/metrics.test.ts
@@ -282,6 +282,90 @@ describe('GET /onesub/metrics/expired', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// /onesub/metrics/{started,expired}?groupBy=day — daily bucketing
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /onesub/metrics/started?groupBy=day', () => {
+  it('omits buckets when groupBy is not set (backwards compatible)', async () => {
+    const { store, server } = buildServer({ adminSecret: SECRET });
+    await store.save(sub({ purchasedAt: '2026-04-15T00:00:00Z' }));
+
+    const resp = await server.get<MetricsCountResponse>(
+      '/onesub/metrics/started?from=2026-04-01T00:00:00Z&to=2026-04-30T23:59:59Z',
+      AUTH,
+    );
+
+    expect(resp.body.total).toBe(1);
+    expect(resp.body.buckets).toBeUndefined();
+  });
+
+  it('returns one zero-filled bucket per UTC day across the window', async () => {
+    const { store, server } = buildServer({ adminSecret: SECRET });
+    // 3-day window: 2026-04-01 .. 2026-04-03 inclusive
+    await store.save(sub({ userId: 'a', purchasedAt: '2026-04-01T03:00:00Z', originalTransactionId: 't1' }));
+    await store.save(sub({ userId: 'b', purchasedAt: '2026-04-01T18:00:00Z', originalTransactionId: 't2' }));
+    await store.save(sub({ userId: 'c', purchasedAt: '2026-04-03T12:00:00Z', originalTransactionId: 't3' }));
+
+    const resp = await server.get<MetricsCountResponse>(
+      '/onesub/metrics/started?from=2026-04-01T00:00:00Z&to=2026-04-03T23:59:59Z&groupBy=day',
+      AUTH,
+    );
+
+    expect(resp.body.total).toBe(3);
+    expect(resp.body.buckets).toEqual([
+      { date: '2026-04-01', count: 2 },
+      { date: '2026-04-02', count: 0 }, // gap day, zero-filled
+      { date: '2026-04-03', count: 1 },
+    ]);
+  });
+
+  it('snaps the first bucket to UTC midnight even when from is mid-day', async () => {
+    const { store, server } = buildServer({ adminSecret: SECRET });
+    await store.save(sub({ purchasedAt: '2026-04-01T20:00:00Z' }));
+
+    const resp = await server.get<MetricsCountResponse>(
+      // from is 2026-04-01T15:00:00Z — same UTC day as the record
+      '/onesub/metrics/started?from=2026-04-01T15:00:00Z&to=2026-04-02T15:00:00Z&groupBy=day',
+      AUTH,
+    );
+
+    expect(resp.body.buckets?.[0]?.date).toBe('2026-04-01');
+    expect(resp.body.buckets?.[0]?.count).toBe(1);
+  });
+
+  it('400 when groupBy is not one of the allowed values', async () => {
+    const { server } = buildServer({ adminSecret: SECRET });
+    const resp = await server.get<{ errorCode: string }>(
+      '/onesub/metrics/started?from=2026-04-01T00:00:00Z&to=2026-04-02T00:00:00Z&groupBy=hour',
+      AUTH,
+    );
+    expect(resp.status).toBe(400);
+  });
+});
+
+describe('GET /onesub/metrics/expired?groupBy=day', () => {
+  it('buckets expired/canceled by expiresAt UTC date', async () => {
+    const { store, server } = buildServer({ adminSecret: SECRET });
+    await store.save(sub({ userId: 'e1', status: 'expired', expiresAt: '2026-04-01T03:00:00Z', originalTransactionId: 'x1' }));
+    await store.save(sub({ userId: 'e2', status: 'canceled', expiresAt: '2026-04-03T20:00:00Z', originalTransactionId: 'x2' }));
+    // active record in window — not counted
+    await store.save(sub({ userId: 'a', status: 'active', expiresAt: '2026-04-02T00:00:00Z', originalTransactionId: 'x3' }));
+
+    const resp = await server.get<MetricsCountResponse>(
+      '/onesub/metrics/expired?from=2026-04-01T00:00:00Z&to=2026-04-03T23:59:59Z&groupBy=day',
+      AUTH,
+    );
+
+    expect(resp.body.total).toBe(2);
+    expect(resp.body.buckets).toEqual([
+      { date: '2026-04-01', count: 1 },
+      { date: '2026-04-02', count: 0 },
+      { date: '2026-04-03', count: 1 },
+    ]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Store listAll regression
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/packages/server/src/routes/metrics.ts
+++ b/packages/server/src/routes/metrics.ts
@@ -3,6 +3,7 @@ import type { Request, Response } from 'express';
 import { z } from 'zod';
 import type {
   MetricsActiveResponse,
+  MetricsBucket,
   MetricsCountResponse,
   OneSubServerConfig,
   PurchaseInfo,
@@ -114,14 +115,15 @@ export function createMetricsRouter(
     }
   });
 
-  // ── GET /onesub/metrics/started?from=&to= ────────────────────────────────
+  // ── GET /onesub/metrics/started?from=&to=&groupBy= ───────────────────────
 
   const rangeSchema = z.object({
     from: z.string().min(1),
     to: z.string().min(1),
+    groupBy: z.enum(['none', 'day']).optional(),
   });
 
-  type Range = { fromMs: number; toMs: number };
+  type Range = { fromMs: number; toMs: number; groupBy: 'none' | 'day' };
 
   function parseRange(req: Request): Range | { error: string } {
     const parsed = rangeSchema.safeParse(req.query);
@@ -132,7 +134,34 @@ export function createMetricsRouter(
       return { error: 'from / to must be ISO 8601 timestamps' };
     }
     if (fromMs > toMs) return { error: 'from must be ≤ to' };
-    return { fromMs, toMs };
+    return { fromMs, toMs, groupBy: parsed.data.groupBy ?? 'none' };
+  }
+
+  // UTC `YYYY-MM-DD` for a given epoch-ms. Used to assign each record to a
+  // calendar-day bucket; UTC keeps the result deterministic regardless of
+  // server timezone (Postgres `updated_at` is UTC; SubscriptionInfo dates are
+  // ISO with explicit zone offsets).
+  function utcDateKey(ms: number): string {
+    const d = new Date(ms);
+    const yyyy = d.getUTCFullYear();
+    const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
+    const dd = String(d.getUTCDate()).padStart(2, '0');
+    return `${yyyy}-${mm}-${dd}`;
+  }
+
+  // Zero-fill a daily series across [fromMs, toMs] (inclusive of both
+  // boundary days). The route handler then increments the counts.
+  function emptyDailyBuckets(fromMs: number, toMs: number): MetricsBucket[] {
+    const out: MetricsBucket[] = [];
+    // Snap `from` to UTC midnight so iteration steps land on calendar boundaries.
+    const start = new Date(fromMs);
+    start.setUTCHours(0, 0, 0, 0);
+    let cur = start.getTime();
+    while (cur <= toMs) {
+      out.push({ date: utcDateKey(cur), count: 0 });
+      cur += 86_400_000;
+    }
+    return out;
   }
 
   router.get(ROUTES.METRICS_STARTED, async (req: Request, res: Response) => {
@@ -147,12 +176,23 @@ export function createMetricsRouter(
       const byPlatform: Record<string, number> = {};
       let total = 0;
 
+      // Build a date→index map only when bucketing is requested — keeps the
+      // non-bucketed path identical to the previous implementation.
+      const buckets =
+        range.groupBy === 'day' ? emptyDailyBuckets(range.fromMs, range.toMs) : null;
+      const bucketIndex =
+        buckets ? new Map(buckets.map((b, i) => [b.date, i])) : null;
+
       for (const sub of subs) {
         const purchasedMs = new Date(sub.purchasedAt).getTime();
         if (purchasedMs < range.fromMs || purchasedMs > range.toMs) continue;
         total++;
         bump(byProduct, sub.productId);
         bump(byPlatform, sub.platform);
+        if (buckets && bucketIndex) {
+          const idx = bucketIndex.get(utcDateKey(purchasedMs));
+          if (idx !== undefined) buckets[idx]!.count++;
+        }
       }
 
       const response: MetricsCountResponse = {
@@ -161,6 +201,7 @@ export function createMetricsRouter(
         total,
         byProduct,
         byPlatform,
+        ...(buckets ? { buckets } : {}),
       };
       res.status(200).json(response);
     } catch (err) {
@@ -183,6 +224,11 @@ export function createMetricsRouter(
       const byPlatform: Record<string, number> = {};
       let total = 0;
 
+      const buckets =
+        range.groupBy === 'day' ? emptyDailyBuckets(range.fromMs, range.toMs) : null;
+      const bucketIndex =
+        buckets ? new Map(buckets.map((b, i) => [b.date, i])) : null;
+
       for (const sub of subs) {
         // Counted only if currently expired or canceled — a record that's
         // still active doesn't qualify even if its expiresAt happened to fall
@@ -196,6 +242,10 @@ export function createMetricsRouter(
         total++;
         bump(byProduct, sub.productId);
         bump(byPlatform, sub.platform);
+        if (buckets && bucketIndex) {
+          const idx = bucketIndex.get(utcDateKey(expiredMs));
+          if (idx !== undefined) buckets[idx]!.count++;
+        }
       }
 
       const response: MetricsCountResponse = {
@@ -204,6 +254,7 @@ export function createMetricsRouter(
         total,
         byProduct,
         byPlatform,
+        ...(buckets ? { buckets } : {}),
       };
       res.status(200).json(response);
     } catch (err) {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -436,6 +436,25 @@ export interface ListSubscriptionsResponse {
 }
 
 /**
+ * One day in a `MetricsCountResponse.buckets` series. Date is ISO 8601
+ * `YYYY-MM-DD` interpreted as UTC midnight; count is the number of records
+ * whose anchor timestamp (purchasedAt for started, expiresAt for expired)
+ * fell within that calendar day.
+ */
+export interface MetricsBucket {
+  /** UTC calendar day in `YYYY-MM-DD` form. */
+  date: string;
+  count: number;
+}
+
+/**
+ * Aggregation granularity for metrics endpoints. `'none'` (default) returns
+ * window totals only; `'day'` additionally fills in `buckets` with one entry
+ * per UTC day in the window (zero-filled).
+ */
+export type MetricsGroupBy = 'none' | 'day';
+
+/**
  * Count of records that started or ended within the given window.
  * Used for cohort / churn analysis.
  */
@@ -447,6 +466,12 @@ export interface MetricsCountResponse {
   total: number;
   byProduct: Record<string, number>;
   byPlatform: Record<string, number>;
+  /**
+   * Daily breakdown — only present when the request was made with
+   * `?groupBy=day`. One entry per UTC day in the window, zero-filled. Sorted
+   * ascending by date. Used by the dashboard's growth chart.
+   */
+  buckets?: MetricsBucket[];
 }
 
 /** SDK config (client-side) */


### PR DESCRIPTION
## Summary

Phase 2 of the dashboard — Overview에 최근 30일 started vs expired 막대 차트를 추가합니다. 기존 metrics 엔드포인트에 `groupBy=day` 옵션을 더해 일자별 버킷을 받고, Next.js 클라이언트 컴포넌트(recharts)로 그립니다.

### Server / Shared

- `GET /onesub/metrics/started?groupBy=day` 와 `GET /onesub/metrics/expired?groupBy=day` 옵션 추가. 응답에 `buckets: { date, count }[]` (zero-filled, UTC 기준).
- `groupBy`가 없을 때 응답 shape 그대로 — backwards compatible.
- 새 타입: `MetricsBucket`, `MetricsGroupBy`. `MetricsCountResponse.buckets?` 추가.
- 5개 신규 테스트: groupBy 미지정 시 `buckets` 부재 / zero-fill / UTC midnight snap / expired+canceled 필터 / groupBy validation. 365/365 전체 통과.

### Dashboard

- `recharts` ^3.8.1 의존성 추가.
- `app/dashboard/_components/growth-chart.tsx` — `'use client'` 컴포넌트. BarChart로 started(emerald) + expired(rose) 그리고 헤더에 totals + net.
- Overview 페이지에서 `Promise.all`로 active metrics + 30d started + 30d expired 병렬 fetch. 401 처리는 기존과 동일.
- 차트 렌더링 비용: `/dashboard` First Load JS 130 B → 213 kB (recharts 코어). 운영자 한정 페이지라 허용 범위로 판단.

## Test plan

- [x] `npm run build` (5 packages) + `npx tsc --noEmit -p packages/dashboard`
- [x] `npm test` — 365/365 passing (28 files)
- [x] `next build` — 새 chunk 정상 생성
- [ ] CI green
- [ ] 시각 확인: `npm run dev -w @onesub/dashboard`로 차트 데이터 채워지는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)