### PR TITLE
chore: changeset for metrics daily bucketing

### DIFF
--- a/.changeset/growth-chart-bucketing.md
+++ b/.changeset/growth-chart-bucketing.md
@@ -1,0 +1,16 @@
+---
+"@onesub/shared": patch
+"@onesub/server": patch
+---
+
+Add daily bucketing to the metrics endpoints — backs the dashboard's growth chart.
+
+**Server**
+
+- `GET /onesub/metrics/started` and `GET /onesub/metrics/expired` accept an optional `groupBy=day` query param. When set, the response includes a `buckets: { date, count }[]` array — one entry per UTC calendar day in the window, zero-filled, sorted ascending.
+- Without `groupBy` the response shape is unchanged (backwards compatible).
+
+**Shared**
+
+- New `MetricsBucket` type and `MetricsGroupBy` union (`'none' | 'day'`).
+- `MetricsCountResponse.buckets?` optional field.


### PR DESCRIPTION
## Summary

Changeset for #59 — `groupBy=day` option on `/onesub/metrics/{started,expired}` + supporting types.

- `@onesub/shared`: 0.7.2 → 0.7.3 (patch)
- `@onesub/server`: 0.11.2 → 0.11.3 (patch)

Additive: existing callers without `groupBy` see the same response shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)