### PR TITLE
feat(dashboard): customer detail + non-consumable insights

### DIFF
--- a/packages/dashboard/app/dashboard/_components/purchases-chart.tsx
+++ b/packages/dashboard/app/dashboard/_components/purchases-chart.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { MetricsBucket } from '@onesub/shared';
+
+interface PurchasesChartProps {
+  /** Daily non-consumable purchase counts, sorted ascending. */
+  buckets: MetricsBucket[];
+}
+
+interface ChartRow {
+  date: string;
+  /** MM-DD label — same compaction as growth chart. */
+  label: string;
+  count: number;
+}
+
+function toRows(buckets: MetricsBucket[]): ChartRow[] {
+  return buckets.map((b) => ({ date: b.date, label: b.date.slice(5), count: b.count }));
+}
+
+export function PurchasesChart({ buckets }: PurchasesChartProps) {
+  const data = toRows(buckets);
+  const total = data.reduce((acc, r) => acc + r.count, 0);
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <div>
+          <div className="text-sm font-semibold text-slate-700">Purchases — last 30 days</div>
+          <div className="text-xs text-slate-500">
+            UTC daily; non-consumable (lifetime) purchases by purchasedAt
+          </div>
+        </div>
+        <div className="text-xs text-slate-500">
+          total <span className="ml-1 font-mono tabular-nums text-slate-900">{total}</span>
+        </div>
+      </div>
+      <div className="mt-4 h-56">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data} margin={{ top: 8, right: 12, left: 0, bottom: 0 }}>
+            <CartesianGrid stroke="#e2e8f0" strokeDasharray="3 3" vertical={false} />
+            <XAxis dataKey="label" tick={{ fontSize: 11, fill: '#64748b' }} interval="preserveStartEnd" />
+            <YAxis allowDecimals={false} tick={{ fontSize: 11, fill: '#64748b' }} width={32} />
+            <Tooltip
+              cursor={{ fill: '#f1f5f9' }}
+              contentStyle={{ fontSize: 12, borderRadius: 6, borderColor: '#cbd5e1' }}
+              labelFormatter={(label, payload) => {
+                const row = payload?.[0]?.payload as ChartRow | undefined;
+                return row?.date ?? String(label);
+              }}
+            />
+            <Bar dataKey="count" name="purchases" fill="#6366f1" radius={[2, 2, 0, 0]} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/app/dashboard/customers/[userId]/page.tsx
+++ b/packages/dashboard/app/dashboard/customers/[userId]/page.tsx
@@ -1,0 +1,220 @@
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import type {
+  CustomerProfileResponse,
+  EntitlementStatus,
+  PurchaseInfo,
+  SubscriptionInfo,
+} from '@onesub/shared';
+import { requireClient, clearAdminSecret } from '../../../../lib/auth';
+import { OneSubFetchError } from '../../../../lib/onesub-client';
+
+export const dynamic = 'force-dynamic';
+
+interface PageProps {
+  params: Promise<{ userId: string }>;
+}
+
+function StatusBadge({ status }: { status: SubscriptionInfo['status'] }) {
+  const styles: Record<SubscriptionInfo['status'], string> = {
+    active:        'bg-emerald-100 text-emerald-800',
+    grace_period:  'bg-amber-100 text-amber-800',
+    on_hold:       'bg-rose-100 text-rose-800',
+    paused:        'bg-sky-100 text-sky-800',
+    expired:       'bg-slate-200 text-slate-600',
+    canceled:      'bg-slate-200 text-slate-600',
+    none:          'bg-slate-100 text-slate-500',
+  };
+  return (
+    <span className={`inline-block rounded px-2 py-0.5 text-xs font-medium ${styles[status]}`}>
+      {status}
+    </span>
+  );
+}
+
+function relativeFromNow(iso: string): string {
+  const target = new Date(iso).getTime();
+  if (!Number.isFinite(target)) return '';
+  const diffMs = target - Date.now();
+  const days = Math.round(diffMs / 86_400_000);
+  if (days === 0) return 'today';
+  if (days > 0)  return `in ${days}d`;
+  return `${-days}d ago`;
+}
+
+export default async function CustomerDetailPage({ params }: PageProps) {
+  const { userId } = await params;
+
+  const client = await requireClient();
+  let profile: CustomerProfileResponse;
+  try {
+    profile = await client.getCustomer(userId);
+  } catch (err) {
+    if (err instanceof OneSubFetchError && err.status === 401) {
+      await clearAdminSecret();
+      redirect('/login');
+    }
+    throw err;
+  }
+
+  const isEmpty = profile.subscriptions.length === 0 && profile.purchases.length === 0;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link href="/dashboard/customers" className="text-sm text-slate-500 underline-offset-2 hover:underline">
+          ← Customers
+        </Link>
+        <h1 className="mt-2 text-2xl font-semibold tracking-tight">Customer</h1>
+        <p className="mt-1 font-mono text-xs text-slate-500">{profile.userId}</p>
+      </div>
+
+      {isEmpty ? (
+        <div className="rounded-lg border border-dashed border-slate-200 bg-white p-8 text-center text-sm text-slate-400">
+          이 userId로 등록된 구독·구매가 없습니다.
+        </div>
+      ) : null}
+
+      {profile.entitlements ? <EntitlementsCard entitlements={profile.entitlements} /> : null}
+
+      {profile.subscriptions.length > 0 ? (
+        <SubscriptionsCard subscriptions={profile.subscriptions} />
+      ) : null}
+
+      {profile.purchases.length > 0 ? (
+        <PurchasesCard purchases={profile.purchases} />
+      ) : null}
+    </div>
+  );
+}
+
+// ─── Cards ──────────────────────────────────────────────────────────────────
+
+function EntitlementsCard({ entitlements }: { entitlements: Record<string, EntitlementStatus> }) {
+  const entries = Object.entries(entitlements);
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white shadow-sm">
+      <div className="border-b border-slate-100 px-5 py-3 text-sm font-semibold text-slate-700">
+        Entitlements
+      </div>
+      <table className="w-full text-sm">
+        <thead className="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+          <tr>
+            <Th>id</Th>
+            <Th>active</Th>
+            <Th>source</Th>
+            <Th>productId</Th>
+            <Th>expiresAt</Th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map(([id, e]) => (
+            <tr key={id} className="border-t border-slate-100">
+              <Td>{id}</Td>
+              <Td>
+                <span
+                  className={`inline-block rounded px-2 py-0.5 text-xs font-medium ${
+                    e.active ? 'bg-emerald-100 text-emerald-800' : 'bg-slate-200 text-slate-600'
+                  }`}
+                >
+                  {e.active ? 'yes' : 'no'}
+                </span>
+              </Td>
+              <Td className="text-slate-500">{e.source ?? '—'}</Td>
+              <Td className="font-mono text-xs">{e.productId ?? '—'}</Td>
+              <Td className="font-mono tabular-nums text-xs">
+                {e.expiresAt ? `${e.expiresAt.slice(0, 10)} (${relativeFromNow(e.expiresAt)})` : '—'}
+              </Td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function SubscriptionsCard({ subscriptions }: { subscriptions: SubscriptionInfo[] }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white shadow-sm">
+      <div className="border-b border-slate-100 px-5 py-3 text-sm font-semibold text-slate-700">
+        Subscriptions <span className="ml-1 text-xs font-normal text-slate-400">({subscriptions.length})</span>
+      </div>
+      <table className="w-full text-sm">
+        <thead className="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+          <tr>
+            <Th>productId</Th>
+            <Th>status</Th>
+            <Th>platform</Th>
+            <Th>expiresAt</Th>
+            <Th>willRenew</Th>
+            <Th>txId</Th>
+          </tr>
+        </thead>
+        <tbody>
+          {subscriptions.map((s) => {
+            const detailHref = `/dashboard/subscriptions/${encodeURIComponent(s.originalTransactionId)}`;
+            return (
+              <tr key={s.originalTransactionId} className="border-t border-slate-100 hover:bg-slate-50" title={s.expiresAt}>
+                <Td>
+                  <Link href={detailHref} className="hover:underline">{s.productId}</Link>
+                </Td>
+                <Td><StatusBadge status={s.status} /></Td>
+                <Td>{s.platform}</Td>
+                <Td className="font-mono tabular-nums text-xs">
+                  {s.expiresAt.slice(0, 10)} <span className="text-slate-400">({relativeFromNow(s.expiresAt)})</span>
+                </Td>
+                <Td>{s.willRenew ? 'yes' : 'no'}</Td>
+                <Td className="font-mono text-xs text-slate-500">
+                  <Link href={detailHref} className="hover:underline">{s.originalTransactionId}</Link>
+                </Td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function PurchasesCard({ purchases }: { purchases: PurchaseInfo[] }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white shadow-sm">
+      <div className="border-b border-slate-100 px-5 py-3 text-sm font-semibold text-slate-700">
+        Purchases <span className="ml-1 text-xs font-normal text-slate-400">({purchases.length})</span>
+      </div>
+      <table className="w-full text-sm">
+        <thead className="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+          <tr>
+            <Th>productId</Th>
+            <Th>type</Th>
+            <Th>platform</Th>
+            <Th>quantity</Th>
+            <Th>purchasedAt</Th>
+            <Th>transactionId</Th>
+          </tr>
+        </thead>
+        <tbody>
+          {purchases.map((p) => (
+            <tr key={p.transactionId} className="border-t border-slate-100">
+              <Td>{p.productId}</Td>
+              <Td className="text-xs text-slate-500">{p.type}</Td>
+              <Td>{p.platform}</Td>
+              <Td className="font-mono tabular-nums">{p.quantity}</Td>
+              <Td className="font-mono tabular-nums text-xs">
+                {p.purchasedAt.slice(0, 10)} <span className="text-slate-400">({relativeFromNow(p.purchasedAt)})</span>
+              </Td>
+              <Td className="font-mono text-xs text-slate-500">{p.transactionId}</Td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function Th({ children }: { children: React.ReactNode }) {
+  return <th className="px-4 py-3">{children}</th>;
+}
+function Td({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <td className={`px-4 py-3 align-middle ${className ?? ''}`}>{children}</td>;
+}

--- a/packages/dashboard/app/dashboard/customers/page.tsx
+++ b/packages/dashboard/app/dashboard/customers/page.tsx
@@ -1,0 +1,68 @@
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { requireClient } from '../../../lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+interface PageProps {
+  searchParams: Promise<{ userId?: string }>;
+}
+
+// Server action: GET form posts here, we redirect to the detail page.
+// (Form `method="get"` bakes userId into the URL — but we want a clean
+// /dashboard/customers/{userId} path, so handle the redirect server-side.)
+async function navigateToCustomer(formData: FormData): Promise<void> {
+  'use server';
+  const raw = formData.get('userId');
+  if (typeof raw !== 'string') return;
+  const userId = raw.trim();
+  if (!userId) return;
+  redirect(`/dashboard/customers/${encodeURIComponent(userId)}`);
+}
+
+export default async function CustomersPage({ searchParams }: PageProps) {
+  // Cookie probe — bounces to /login if not authenticated. The client itself
+  // isn't used on this page (no fetch needed for the empty search view).
+  await requireClient();
+
+  const { userId } = await searchParams;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Customers</h1>
+        <p className="mt-1 text-sm text-slate-500">
+          userId로 검색해 그 유저의 모든 구독·구매·entitlement을 한 화면에 봅니다.
+        </p>
+      </div>
+
+      <form action={navigateToCustomer} className="flex flex-wrap items-end gap-3 rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+        <label className="flex flex-col text-xs font-medium text-slate-600">
+          <span>userId</span>
+          <input
+            type="text"
+            name="userId"
+            defaultValue={userId ?? ''}
+            autoComplete="off"
+            autoFocus
+            placeholder="device id / user id"
+            className="mt-1 block w-80 rounded-md border border-slate-300 bg-white px-2 py-1.5 font-mono text-xs shadow-sm focus:border-brand-600 focus:outline-none focus:ring-1 focus:ring-brand-600"
+          />
+        </label>
+        <button
+          type="submit"
+          className="rounded-md bg-brand-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-brand-700"
+        >
+          Open
+        </button>
+      </form>
+
+      <div className="rounded-lg border border-dashed border-slate-200 bg-white p-8 text-center text-sm text-slate-400">
+        검색해 사용자 상세를 열어주세요. <br />
+        <Link href="/dashboard/subscriptions" className="mt-2 inline-block text-slate-500 underline-offset-2 hover:underline">
+          또는 구독 리스트에서 userId 클릭
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/app/dashboard/layout.tsx
+++ b/packages/dashboard/app/dashboard/layout.tsx
@@ -20,13 +20,12 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
           >
             Subscriptions
           </Link>
-          <span
-            aria-disabled
-            title="Coming in Phase 3"
-            className="block cursor-not-allowed rounded-md px-3 py-2 text-slate-400"
+          <Link
+            href="/dashboard/customers"
+            className="block rounded-md px-3 py-2 font-medium text-slate-700 hover:bg-slate-100"
           >
             Customers
-          </span>
+          </Link>
         </nav>
         <form action="/api/logout" method="post" className="mt-12">
           <button

--- a/packages/dashboard/app/dashboard/page.tsx
+++ b/packages/dashboard/app/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import { requireClient } from '../../lib/auth';
 import { OneSubFetchError } from '../../lib/onesub-client';
 import { GrowthChart } from './_components/growth-chart';
+import { PurchasesChart } from './_components/purchases-chart';
 
 export const dynamic = 'force-dynamic';
 
@@ -65,11 +66,13 @@ export default async function DashboardOverview() {
   let metrics;
   let started;
   let expired;
+  let purchasesStarted;
   try {
-    [metrics, started, expired] = await Promise.all([
+    [metrics, started, expired, purchasesStarted] = await Promise.all([
       client.getActiveMetrics(),
       client.getStartedMetrics(from, to, { groupBy: 'day' }),
       client.getExpiredMetrics(from, to, { groupBy: 'day' }),
+      client.getPurchasesStartedMetrics(from, to, { groupBy: 'day' }),
     ]);
   } catch (err) {
     // 401 from the upstream server means the cookie is stale — clear it and
@@ -117,13 +120,21 @@ export default async function DashboardOverview() {
         />
       </div>
 
-      <GrowthChart started={started.buckets ?? []} expired={expired.buckets ?? []} />
-
       <div className="grid gap-6 lg:grid-cols-2">
+        <GrowthChart started={started.buckets ?? []} expired={expired.buckets ?? []} />
+        <PurchasesChart buckets={purchasesStarted.buckets ?? []} />
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-3">
         <DistributionTable
           title="By product (active subscriptions)"
           data={metrics.byProduct}
           empty="활성 구독이 없습니다"
+        />
+        <DistributionTable
+          title="By product (non-consumable)"
+          data={metrics.byProductPurchases}
+          empty="lifetime 구매가 없습니다"
         />
         <DistributionTable
           title="By platform (subs + non-consumable)"

--- a/packages/dashboard/app/dashboard/subscriptions/[transactionId]/page.tsx
+++ b/packages/dashboard/app/dashboard/subscriptions/[transactionId]/page.tsx
@@ -57,9 +57,10 @@ export default async function SubscriptionDetailPage({ params }: PageProps) {
     throw err;
   }
 
-  // Pre-build the "all subs for this user" link so operators can pivot from
-  // one record back to the full per-user history.
-  const userSubsHref = `/dashboard/subscriptions?userId=${encodeURIComponent(sub.userId)}`;
+  // Pivot link to the per-customer view (subs + purchases + entitlements in one
+  // round-trip) — more useful than a filtered subs list when investigating
+  // a specific user's full state.
+  const customerHref = `/dashboard/customers/${encodeURIComponent(sub.userId)}`;
 
   return (
     <div className="space-y-6">
@@ -82,10 +83,10 @@ export default async function SubscriptionDetailPage({ params }: PageProps) {
           <Row label="userId">
             <span className="font-mono">{sub.userId}</span>
             <Link
-              href={userSubsHref}
+              href={customerHref}
               className="ml-2 text-xs text-brand-600 underline-offset-2 hover:underline"
             >
-              모두 보기
+              상세 보기
             </Link>
           </Row>
           <Row label="productId">{sub.productId}</Row>

--- a/packages/dashboard/app/dashboard/subscriptions/page.tsx
+++ b/packages/dashboard/app/dashboard/subscriptions/page.tsx
@@ -149,14 +149,17 @@ export default async function SubscriptionsPage({ searchParams }: PageProps) {
             ) : (
               result.items.map((s) => {
                 const detailHref = `/dashboard/subscriptions/${encodeURIComponent(s.originalTransactionId)}`;
+                const customerHref = `/dashboard/customers/${encodeURIComponent(s.userId)}`;
                 return (
                   <tr
                     key={s.originalTransactionId}
                     className="border-t border-slate-100 hover:bg-slate-50"
                     title={s.expiresAt}
                   >
+                    {/* userId points at the per-user view; productId / txId stay on the
+                        per-subscription detail. Lets operators pivot to either drill-down. */}
                     <Td className="font-mono text-xs">
-                      <Link href={detailHref} className="hover:underline">{s.userId}</Link>
+                      <Link href={customerHref} className="hover:underline">{s.userId}</Link>
                     </Td>
                     <Td><Link href={detailHref} className="hover:underline">{s.productId}</Link></Td>
                     <Td><StatusBadge status={s.status} /></Td>

--- a/packages/dashboard/lib/onesub-client.ts
+++ b/packages/dashboard/lib/onesub-client.ts
@@ -8,6 +8,7 @@
  */
 
 import type {
+  CustomerProfileResponse,
   ListSubscriptionsQuery,
   ListSubscriptionsResponse,
   MetricsActiveResponse,
@@ -32,6 +33,11 @@ export interface OneSubClient {
    * should branch on that to render a "not found" page.
    */
   getSubscription(transactionId: string): Promise<SubscriptionInfo>;
+  /**
+   * Fetch the full per-user profile (subs + purchases + entitlements when
+   * configured). Always 200 — unknown userIds return empty arrays.
+   */
+  getCustomer(userId: string): Promise<CustomerProfileResponse>;
 }
 
 export class OneSubFetchError extends Error {
@@ -86,5 +92,7 @@ export function createClient(serverUrl: string, adminSecret: string): OneSubClie
     },
     getSubscription: (transactionId) =>
       get<SubscriptionInfo>(`/onesub/admin/subscriptions/${encodeURIComponent(transactionId)}`),
+    getCustomer: (userId) =>
+      get<CustomerProfileResponse>(`/onesub/admin/customers/${encodeURIComponent(userId)}`),
   };
 }

--- a/packages/dashboard/lib/onesub-client.ts
+++ b/packages/dashboard/lib/onesub-client.ts
@@ -26,6 +26,12 @@ export interface OneSubClient {
   getActiveMetrics(): Promise<MetricsActiveResponse>;
   getStartedMetrics(from: Date, to: Date, opts?: MetricsRangeOptions): Promise<MetricsCountResponse>;
   getExpiredMetrics(from: Date, to: Date, opts?: MetricsRangeOptions): Promise<MetricsCountResponse>;
+  /**
+   * Non-consumable purchases started in the window. Use for the dashboard's
+   * Purchases timeseries — equivalent to getStartedMetrics but counts
+   * lifetime products instead of subscriptions.
+   */
+  getPurchasesStartedMetrics(from: Date, to: Date, opts?: MetricsRangeOptions): Promise<MetricsCountResponse>;
   listSubscriptions(query: ListSubscriptionsQuery): Promise<ListSubscriptionsResponse>;
   /**
    * Fetch a single subscription record by `originalTransactionId`. Throws
@@ -79,6 +85,8 @@ export function createClient(serverUrl: string, adminSecret: string): OneSubClie
       get<MetricsCountResponse>(rangePath('/onesub/metrics/started', from, to, opts)),
     getExpiredMetrics: (from, to, opts) =>
       get<MetricsCountResponse>(rangePath('/onesub/metrics/expired', from, to, opts)),
+    getPurchasesStartedMetrics: (from, to, opts) =>
+      get<MetricsCountResponse>(rangePath('/onesub/metrics/purchases/started', from, to, opts)),
     listSubscriptions: (query) => {
       const params = new URLSearchParams();
       if (query.userId)    params.set('userId', query.userId);

--- a/packages/server/src/__tests__/admin-customer-detail.test.ts
+++ b/packages/server/src/__tests__/admin-customer-detail.test.ts
@@ -1,0 +1,175 @@
+/**
+ * GET /onesub/admin/customers/:userId — per-user profile bundle.
+ *
+ * Backs the dashboard's customer detail page. Returns subscriptions +
+ * purchases + entitlements (when configured) for one userId in a single
+ * round-trip. Always 200 — unknown userIds yield empty arrays rather than
+ * 404, since "no records yet" is a normal CS scenario.
+ */
+
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import type {
+  CustomerProfileResponse,
+  EntitlementsConfig,
+  OneSubServerConfig,
+  PurchaseInfo,
+  SubscriptionInfo,
+} from '@onesub/shared';
+import { createOneSubMiddleware, InMemorySubscriptionStore, InMemoryPurchaseStore } from '../index.js';
+
+function sub(overrides?: Partial<SubscriptionInfo>): SubscriptionInfo {
+  return {
+    userId: 'u',
+    productId: 'pro_monthly',
+    platform: 'apple',
+    status: 'active',
+    expiresAt: '2099-01-01T00:00:00.000Z',
+    purchasedAt: '2026-04-01T00:00:00.000Z',
+    originalTransactionId: `orig_${Math.random()}`,
+    willRenew: true,
+    ...overrides,
+  };
+}
+
+function purchase(overrides?: Partial<PurchaseInfo>): PurchaseInfo {
+  return {
+    userId: 'u',
+    productId: 'lifetime_pass',
+    platform: 'apple',
+    type: 'non_consumable',
+    transactionId: `tx_${Math.random()}`,
+    purchasedAt: '2026-04-01T00:00:00.000Z',
+    quantity: 1,
+    ...overrides,
+  };
+}
+
+interface TestServer {
+  get: <T,>(path: string, headers?: Record<string, string>) => Promise<{ status: number; body: T }>;
+}
+
+function spinUp(handler: express.Express): TestServer {
+  return {
+    async get<T>(path: string, headers?: Record<string, string>): Promise<{ status: number; body: T }> {
+      const httpServer = handler.listen(0);
+      const port = (httpServer.address() as { port: number }).port;
+      try {
+        const resp = await fetch(`http://127.0.0.1:${port}${path}`, { headers });
+        const text = await resp.text();
+        let parsed: unknown = text;
+        try { parsed = JSON.parse(text); } catch { /* keep as text */ }
+        return { status: resp.status, body: parsed as T };
+      } finally {
+        await new Promise<void>((r) => httpServer.close(() => r()));
+      }
+    },
+  };
+}
+
+function buildServer(opts: { adminSecret?: string; entitlements?: EntitlementsConfig }) {
+  const store = new InMemorySubscriptionStore();
+  const purchaseStore = new InMemoryPurchaseStore();
+  const config: OneSubServerConfig = {
+    apple: { bundleId: 'com.example.app', skipJwsVerification: true },
+    database: { url: '' },
+    adminSecret: opts.adminSecret,
+    ...(opts.entitlements ? { entitlements: opts.entitlements } : {}),
+  };
+  const app = express();
+  app.use(createOneSubMiddleware({ ...config, store, purchaseStore }));
+  return { store, purchaseStore, server: spinUp(app) };
+}
+
+const SECRET = 's3cr3t';
+const AUTH = { 'x-admin-secret': SECRET };
+
+describe('GET /onesub/admin/customers/:userId auth', () => {
+  it('returns 404 when adminSecret is unset (router not mounted)', async () => {
+    const { server } = buildServer({});
+    const resp = await server.get('/onesub/admin/customers/u_x');
+    expect(resp.status).toBe(404);
+  });
+
+  it('returns 401 INVALID_ADMIN_SECRET when header is missing or wrong', async () => {
+    const { server } = buildServer({ adminSecret: SECRET });
+
+    const noHeader = await server.get<{ errorCode: string }>('/onesub/admin/customers/u_x');
+    expect(noHeader.status).toBe(401);
+    expect(noHeader.body.errorCode).toBe('INVALID_ADMIN_SECRET');
+  });
+});
+
+describe('GET /onesub/admin/customers/:userId basics', () => {
+  it('returns empty profile (200) for unknown userId', async () => {
+    const { server } = buildServer({ adminSecret: SECRET });
+    const resp = await server.get<CustomerProfileResponse>('/onesub/admin/customers/u_unknown', AUTH);
+
+    expect(resp.status).toBe(200);
+    expect(resp.body.userId).toBe('u_unknown');
+    expect(resp.body.subscriptions).toEqual([]);
+    expect(resp.body.purchases).toEqual([]);
+    expect(resp.body.entitlements).toBeUndefined();
+  });
+
+  it('combines subscriptions and purchases for the user', async () => {
+    const { store, purchaseStore, server } = buildServer({ adminSecret: SECRET });
+    await store.save(sub({ userId: 'alice', productId: 'pro_monthly', originalTransactionId: 't1' }));
+    await store.save(sub({ userId: 'alice', productId: 'pro_yearly',  originalTransactionId: 't2' }));
+    // unrelated user — must NOT leak
+    await store.save(sub({ userId: 'bob', originalTransactionId: 't_bob' }));
+    await purchaseStore.savePurchase(purchase({ userId: 'alice', productId: 'lifetime', transactionId: 'p1' }));
+
+    const resp = await server.get<CustomerProfileResponse>('/onesub/admin/customers/alice', AUTH);
+
+    expect(resp.status).toBe(200);
+    expect(resp.body.subscriptions).toHaveLength(2);
+    expect(resp.body.subscriptions.every((s) => s.userId === 'alice')).toBe(true);
+    expect(resp.body.purchases).toHaveLength(1);
+    expect(resp.body.purchases[0]?.userId).toBe('alice');
+  });
+});
+
+describe('GET /onesub/admin/customers/:userId entitlements', () => {
+  it('omits entitlements when config.entitlements is unset', async () => {
+    const { store, server } = buildServer({ adminSecret: SECRET });
+    await store.save(sub({ userId: 'alice', originalTransactionId: 't1' }));
+
+    const resp = await server.get<CustomerProfileResponse>('/onesub/admin/customers/alice', AUTH);
+
+    expect(resp.body.entitlements).toBeUndefined();
+  });
+
+  it('evaluates each configured entitlement when entitlements are set', async () => {
+    const { store, purchaseStore, server } = buildServer({
+      adminSecret: SECRET,
+      entitlements: {
+        premium: { productIds: ['pro_monthly', 'pro_yearly'] },
+        lifetime: { productIds: ['lifetime_pass'] },
+      },
+    });
+    // Active sub matches "premium"
+    await store.save(sub({ userId: 'alice', productId: 'pro_monthly', status: 'active', originalTransactionId: 't1' }));
+    // Non-consumable matches "lifetime"
+    await purchaseStore.savePurchase(purchase({ userId: 'alice', productId: 'lifetime_pass', transactionId: 'p1' }));
+
+    const resp = await server.get<CustomerProfileResponse>('/onesub/admin/customers/alice', AUTH);
+
+    expect(resp.body.entitlements?.premium?.active).toBe(true);
+    expect(resp.body.entitlements?.premium?.source).toBe('subscription');
+    expect(resp.body.entitlements?.lifetime?.active).toBe(true);
+    expect(resp.body.entitlements?.lifetime?.source).toBe('purchase');
+  });
+
+  it('reports inactive entitlements when nothing matches', async () => {
+    const { server } = buildServer({
+      adminSecret: SECRET,
+      entitlements: { premium: { productIds: ['pro_monthly'] } },
+    });
+
+    const resp = await server.get<CustomerProfileResponse>('/onesub/admin/customers/u_empty', AUTH);
+
+    expect(resp.body.entitlements?.premium?.active).toBe(false);
+    expect(resp.body.entitlements?.premium?.source).toBeNull();
+  });
+});

--- a/packages/server/src/__tests__/metrics.test.ts
+++ b/packages/server/src/__tests__/metrics.test.ts
@@ -123,6 +123,7 @@ describe('GET /onesub/metrics/active', () => {
       gracePeriodSubscriptions: 0,
       nonConsumablePurchases: 0,
       byProduct: {},
+      byProductPurchases: {},
       byPlatform: {},
     });
   });
@@ -357,6 +358,86 @@ describe('GET /onesub/metrics/expired?groupBy=day', () => {
     );
 
     expect(resp.body.total).toBe(2);
+    expect(resp.body.buckets).toEqual([
+      { date: '2026-04-01', count: 1 },
+      { date: '2026-04-02', count: 0 },
+      { date: '2026-04-03', count: 1 },
+    ]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// /onesub/metrics/active — byProductPurchases regression
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /onesub/metrics/active byProductPurchases', () => {
+  it('reports non-consumable purchases under byProductPurchases (separate from byProduct)', async () => {
+    const { store, purchaseStore, server } = buildServer({ adminSecret: SECRET });
+    // Active subscription — should land in byProduct (subs-only)
+    await store.save(sub({ userId: 'a', productId: 'pro_monthly', status: 'active' }));
+    // Non-consumable purchases — must land in byProductPurchases, NOT byProduct
+    await purchaseStore.savePurchase(purchase({ userId: 'b', productId: 'lifetime_pass', transactionId: 'p1' }));
+    await purchaseStore.savePurchase(purchase({ userId: 'c', productId: 'lifetime_pass', transactionId: 'p2' }));
+    await purchaseStore.savePurchase(purchase({ userId: 'd', productId: 'event_pack',    transactionId: 'p3' }));
+    // Consumable — must NOT show in byProductPurchases (consumables aren't entitlement-relevant)
+    await purchaseStore.savePurchase(purchase({ userId: 'e', productId: 'coin_500', type: 'consumable', transactionId: 'p4' }));
+
+    const resp = await server.get<MetricsActiveResponse>('/onesub/metrics/active', AUTH);
+
+    expect(resp.body.byProduct).toEqual({ pro_monthly: 1 });
+    expect(resp.body.byProductPurchases).toEqual({ lifetime_pass: 2, event_pack: 1 });
+  });
+
+  it('byProductPurchases empty when there are no non-consumable purchases', async () => {
+    const { server } = buildServer({ adminSecret: SECRET });
+    const resp = await server.get<MetricsActiveResponse>('/onesub/metrics/active', AUTH);
+    expect(resp.body.byProductPurchases).toEqual({});
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// /onesub/metrics/purchases/started — non-consumable purchase timeseries
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /onesub/metrics/purchases/started', () => {
+  it('counts non-consumable purchases with purchasedAt in window', async () => {
+    const { purchaseStore, server } = buildServer({ adminSecret: SECRET });
+    await purchaseStore.savePurchase(purchase({ userId: 'a', purchasedAt: '2026-03-15T00:00:00Z', transactionId: 'before' }));
+    await purchaseStore.savePurchase(purchase({ userId: 'b', purchasedAt: '2026-04-10T00:00:00Z', transactionId: 'in1' }));
+    await purchaseStore.savePurchase(purchase({ userId: 'c', purchasedAt: '2026-04-20T00:00:00Z', transactionId: 'in2' }));
+
+    const resp = await server.get<MetricsCountResponse>(
+      '/onesub/metrics/purchases/started?from=2026-04-01T00:00:00Z&to=2026-04-30T23:59:59Z',
+      AUTH,
+    );
+
+    expect(resp.body.total).toBe(2);
+  });
+
+  it('excludes consumables (entitlement-irrelevant)', async () => {
+    const { purchaseStore, server } = buildServer({ adminSecret: SECRET });
+    await purchaseStore.savePurchase(purchase({ userId: 'a', type: 'non_consumable', purchasedAt: '2026-04-10T00:00:00Z', transactionId: 'nc1' }));
+    await purchaseStore.savePurchase(purchase({ userId: 'b', type: 'consumable',     purchasedAt: '2026-04-15T00:00:00Z', transactionId: 'co1' }));
+
+    const resp = await server.get<MetricsCountResponse>(
+      '/onesub/metrics/purchases/started?from=2026-04-01T00:00:00Z&to=2026-04-30T23:59:59Z',
+      AUTH,
+    );
+
+    expect(resp.body.total).toBe(1);
+    expect(resp.body.byProduct).toEqual({ lifetime_pass: 1 });
+  });
+
+  it('returns zero-filled buckets with groupBy=day', async () => {
+    const { purchaseStore, server } = buildServer({ adminSecret: SECRET });
+    await purchaseStore.savePurchase(purchase({ userId: 'a', purchasedAt: '2026-04-01T05:00:00Z', transactionId: 't1' }));
+    await purchaseStore.savePurchase(purchase({ userId: 'b', purchasedAt: '2026-04-03T18:00:00Z', transactionId: 't2' }));
+
+    const resp = await server.get<MetricsCountResponse>(
+      '/onesub/metrics/purchases/started?from=2026-04-01T00:00:00Z&to=2026-04-03T23:59:59Z&groupBy=day',
+      AUTH,
+    );
+
     expect(resp.body.buckets).toEqual([
       { date: '2026-04-01', count: 1 },
       { date: '2026-04-02', count: 0 },

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -2,6 +2,8 @@ import { Router } from 'express';
 import type { Request, Response } from 'express';
 import { z } from 'zod';
 import type {
+  CustomerProfileResponse,
+  EntitlementStatus,
   OneSubServerConfig,
   PurchaseInfo,
   ListSubscriptionsResponse,
@@ -10,6 +12,7 @@ import type {
 } from '@onesub/shared';
 import { PURCHASE_TYPE, ONESUB_ERROR_CODE, ROUTES, SUBSCRIPTION_STATUS } from '@onesub/shared';
 import type { PurchaseStore, SubscriptionStore } from '../store.js';
+import { evaluateEntitlement } from './entitlements.js';
 import { sendError, sendZodError } from '../errors.js';
 
 const ADMIN_SECRET_HEADER = 'x-admin-secret';
@@ -35,6 +38,10 @@ const ADMIN_SECRET_HEADER = 'x-admin-secret';
  *
  *   GET /onesub/admin/subscriptions/:transactionId
  *     → single subscription record by originalTransactionId (dashboard detail page)
+ *
+ *   GET /onesub/admin/customers/:userId
+ *     → bundle of every record onesub knows for one user (subs + purchases +
+ *       entitlements when configured). Backs the dashboard customer detail page.
  */
 export function createAdminRouter(
   config: OneSubServerConfig,
@@ -212,6 +219,52 @@ export function createAdminRouter(
       res.status(200).json(sub);
     } catch (err) {
       sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, (err as Error).message ?? 'detail error');
+    }
+  });
+
+  // GET /onesub/admin/customers/:userId — full per-user profile. Combines the
+  // store calls a CS dashboard makes for "show me everything about this user"
+  // into a single round-trip.
+  //
+  // Always returns 200 (even for unknown userIds) — empty arrays + no
+  // entitlements means "we have no record of this user", which is a valid
+  // signal for the dashboard to render rather than an error condition.
+  const customerParamsSchema = z.object({
+    userId: z.string().min(1).max(256),
+  });
+  router.get('/onesub/admin/customers/:userId', async (req: Request, res: Response) => {
+    let params;
+    try {
+      params = customerParamsSchema.parse(req.params);
+    } catch {
+      sendError(res, 400, ONESUB_ERROR_CODE.INVALID_INPUT, 'userId required');
+      return;
+    }
+    try {
+      const [subscriptions, purchases] = await Promise.all([
+        store.getAllByUserId(params.userId),
+        purchaseStore.getPurchasesByUserId(params.userId),
+      ]);
+
+      // Evaluate entitlements only when configured. Hosts that don't use the
+      // entitlement abstraction get the field omitted (dashboard hides panel).
+      let entitlements: Record<string, EntitlementStatus> | undefined;
+      if (config.entitlements && Object.keys(config.entitlements).length > 0) {
+        entitlements = {};
+        for (const [id, def] of Object.entries(config.entitlements)) {
+          entitlements[id] = await evaluateEntitlement(params.userId, def, store, purchaseStore);
+        }
+      }
+
+      const response: CustomerProfileResponse = {
+        userId: params.userId,
+        subscriptions,
+        purchases,
+        ...(entitlements ? { entitlements } : {}),
+      };
+      res.status(200).json(response);
+    } catch (err) {
+      sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, (err as Error).message ?? 'customer error');
     }
   });
 

--- a/packages/server/src/routes/metrics.ts
+++ b/packages/server/src/routes/metrics.ts
@@ -78,6 +78,7 @@ export function createMetricsRouter(
       const now = Date.now();
 
       const byProduct: Record<string, number> = {};
+      const byProductPurchases: Record<string, number> = {};
       const byPlatform: Record<string, number> = {};
       let activeSubscriptions = 0;
       let gracePeriodSubscriptions = 0;
@@ -96,7 +97,10 @@ export function createMetricsRouter(
       for (const p of purchases) {
         if (p.type !== PURCHASE_TYPE.NON_CONSUMABLE) continue;
         nonConsumablePurchases++;
-        // Don't add to byProduct (subscription-only metric for product distribution)
+        // byProductPurchases is purchase-only; byProduct (subs-only) stays clean
+        // so dashboards can render distinct "subscription mix" vs "lifetime mix"
+        // panels without untangling them client-side.
+        bump(byProductPurchases, p.productId);
         bump(byPlatform, p.platform);
       }
 
@@ -106,6 +110,7 @@ export function createMetricsRouter(
         gracePeriodSubscriptions,
         nonConsumablePurchases,
         byProduct,
+        byProductPurchases,
         byPlatform,
       };
       res.status(200).json(response);
@@ -259,6 +264,59 @@ export function createMetricsRouter(
       res.status(200).json(response);
     } catch (err) {
       log.error('[onesub/metrics/expired] error:', err);
+      sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, 'Internal server error');
+    }
+  });
+
+  // ── GET /onesub/metrics/purchases/started?from=&to=&groupBy= ─────────────
+  // Counts non-consumable purchases (lifetime products) by purchasedAt within
+  // the window. Backs the dashboard's Purchases timeseries chart so hosts that
+  // sell only lifetime products (e.g. coffee's Welcome Pass) get a meaningful
+  // growth signal even when they have no subscription data.
+  //
+  // Consumables are excluded — they grant a one-time resource (coins, lives),
+  // not an ongoing entitlement, and would dominate the count noisily.
+  router.get(ROUTES.METRICS_PURCHASES_STARTED, async (req: Request, res: Response) => {
+    const range = parseRange(req);
+    if ('error' in range) {
+      sendError(res, 400, ONESUB_ERROR_CODE.INVALID_INPUT, range.error);
+      return;
+    }
+    try {
+      const purchases = await purchaseStore.listAll();
+      const byProduct: Record<string, number> = {};
+      const byPlatform: Record<string, number> = {};
+      let total = 0;
+
+      const buckets =
+        range.groupBy === 'day' ? emptyDailyBuckets(range.fromMs, range.toMs) : null;
+      const bucketIndex =
+        buckets ? new Map(buckets.map((b, i) => [b.date, i])) : null;
+
+      for (const p of purchases) {
+        if (p.type !== PURCHASE_TYPE.NON_CONSUMABLE) continue;
+        const purchasedMs = new Date(p.purchasedAt).getTime();
+        if (purchasedMs < range.fromMs || purchasedMs > range.toMs) continue;
+        total++;
+        bump(byProduct, p.productId);
+        bump(byPlatform, p.platform);
+        if (buckets && bucketIndex) {
+          const idx = bucketIndex.get(utcDateKey(purchasedMs));
+          if (idx !== undefined) buckets[idx]!.count++;
+        }
+      }
+
+      const response: MetricsCountResponse = {
+        from: req.query['from'] as string,
+        to: req.query['to'] as string,
+        total,
+        byProduct,
+        byPlatform,
+        ...(buckets ? { buckets } : {}),
+      };
+      res.status(200).json(response);
+    } catch (err) {
+      log.error('[onesub/metrics/purchases/started] error:', err);
       sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, 'Internal server error');
     }
   });

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -11,6 +11,8 @@ export const ROUTES = {
   METRICS_ACTIVE: '/onesub/metrics/active',
   METRICS_STARTED: '/onesub/metrics/started',
   METRICS_EXPIRED: '/onesub/metrics/expired',
+  /** Non-consumable purchases started in the window (purchasedAt-based). */
+  METRICS_PURCHASES_STARTED: '/onesub/metrics/purchases/started',
   ADMIN_SUBSCRIPTIONS: '/onesub/admin/subscriptions',
   /** Single-record detail; takes :transactionId path param. */
   ADMIN_SUBSCRIPTION_DETAIL: '/onesub/admin/subscriptions/:transactionId',

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -14,6 +14,8 @@ export const ROUTES = {
   ADMIN_SUBSCRIPTIONS: '/onesub/admin/subscriptions',
   /** Single-record detail; takes :transactionId path param. */
   ADMIN_SUBSCRIPTION_DETAIL: '/onesub/admin/subscriptions/:transactionId',
+  /** Per-user profile bundle (subs + purchases + entitlements); takes :userId path param. */
+  ADMIN_CUSTOMER_DETAIL: '/onesub/admin/customers/:userId',
 } as const;
 
 /** Default server port */

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -436,6 +436,24 @@ export interface ListSubscriptionsResponse {
 }
 
 /**
+ * Customer profile bundle — every record onesub knows about for a single
+ * `userId`. Returned by `GET /onesub/admin/customers/:userId`. Used by the
+ * dashboard's customer detail page so an operator can see subscriptions,
+ * purchases, and entitlements in one round-trip when handling support tickets.
+ *
+ * `entitlements` is `undefined` when the server has no `entitlements` config
+ * (the routes that depend on it return 503 ENTITLEMENTS_NOT_CONFIGURED).
+ * Hosts using only non-consumables / no entitlement abstraction will see this
+ * field omitted and should hide the entitlement panel.
+ */
+export interface CustomerProfileResponse {
+  userId: string;
+  subscriptions: SubscriptionInfo[];
+  purchases: PurchaseInfo[];
+  entitlements?: Record<string, EntitlementStatus>;
+}
+
+/**
  * One day in a `MetricsCountResponse.buckets` series. Date is ISO 8601
  * `YYYY-MM-DD` interpreted as UTC midnight; count is the number of records
  * whose anchor timestamp (purchasedAt for started, expiresAt for expired)

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -406,6 +406,13 @@ export interface MetricsActiveResponse {
   nonConsumablePurchases: number;
   /** Subscription product distribution. Counted from activeSubscriptions only. */
   byProduct: Record<string, number>;
+  /**
+   * Non-consumable purchase product distribution. Separate from `byProduct`
+   * (which is subs-only) so the dashboard can render two distinct panels for
+   * lifetime products vs subscriptions. Hosts that don't sell non-consumables
+   * see this as an empty object.
+   */
+  byProductPurchases: Record<string, number>;
   /** 'apple' | 'google' counts across both subs and purchases. */
   byPlatform: Record<string, number>;
 }


### PR DESCRIPTION
## Summary

Phase 3 시작 + non-consumable 가시성 개선을 한 PR로 묶음.

### Customer detail (1번)

userId로 그 유저의 모든 구독·구매·entitlement을 한 화면에 보는 페이지. CS 응대 워크플로 직결.

- Server: `GET /onesub/admin/customers/:userId` — `getAllByUserId` + `getPurchasesByUserId` 병렬 fetch, entitlements 설정돼 있으면 `evaluateEntitlement`로 채움. Unknown userId → 빈 배열 + 200.
- Shared: `CustomerProfileResponse`, `ROUTES.ADMIN_CUSTOMER_DETAIL`.
- Dashboard:
  - `/dashboard/customers` 검색 form (server action redirect)
  - `/dashboard/customers/[userId]` 3-card 상세 (Entitlements / Subscriptions / Purchases)
  - 사이드바 "Customers" 활성화
  - 구독 리스트 row의 userId 셀 → customer detail로 pivot
  - 구독 detail의 "상세 보기" → customer detail
- Tests: 7 cases.

### Non-consumable insights (2번)

coffee 같은 lifetime-only 호스트도 의미있는 데이터 보이게.

- Server:
  - `MetricsActiveResponse.byProductPurchases` 필드 추가 (subs-only `byProduct`와 분리해서 두 개의 distinct panel 가능)
  - 새 endpoint `GET /onesub/metrics/purchases/started?from=&to=&groupBy=day` — non-consumable, by purchasedAt. consumables는 entitlement-irrelevant라서 제외
- Dashboard:
  - 새 `PurchasesChart` (recharts single-series, indigo)
  - Overview row 2: GrowthChart + PurchasesChart 좌우 배치
  - Distribution row: 3-column (subs by product / non-consumable by product / by platform)
- Tests: 5 cases (boundaries, consumable 제외, gap day bucketing, byProductPurchases population).

### Combined test plan

- [x] `npm run build` 5 packages
- [x] `npx tsc --noEmit -p packages/dashboard` clean
- [x] `npm test` — 377/377 (29 files, +12 new)
- [x] `next build` — 2 새 라우트 + 새 chunk OK
- [ ] CI green
- [ ] findthem prod (7 non-consumable 데이터)로 시각 확인 — Overview에 PurchasesChart, "By product (non-consumable)" 채워져야 함

🤖 Generated with [Claude Code](https://claude.com/claude-code)