### PR TITLE
feat(dashboard): admin write actions on customer detail

### DIFF
--- a/packages/dashboard/app/dashboard/customers/[userId]/_components/grant-form.tsx
+++ b/packages/dashboard/app/dashboard/customers/[userId]/_components/grant-form.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useActionState } from 'react';
+import { useFormStatus } from 'react-dom';
+import { grantPurchaseAction, type ActionResult } from '../../../../../lib/admin-actions';
+
+interface GrantFormProps {
+  userId: string;
+}
+
+export function GrantForm({ userId }: GrantFormProps) {
+  const [state, formAction] = useActionState<ActionResult | null, FormData>(grantPurchaseAction, null);
+
+  return (
+    <details className="rounded-lg border border-slate-200 bg-white shadow-sm">
+      <summary className="cursor-pointer px-5 py-3 text-sm font-semibold text-slate-700 hover:bg-slate-50">
+        Grant non-consumable purchase
+        <span className="ml-2 text-xs font-normal text-slate-400">
+          영수증 검증 우회. 환불 보상 / 굿윌 / 베타 지급용
+        </span>
+      </summary>
+      <form action={formAction} className="space-y-3 border-t border-slate-100 px-5 py-4">
+        <input type="hidden" name="userId" value={userId} />
+        <div className="grid gap-3 sm:grid-cols-2">
+          <Field label="productId" name="productId" placeholder="lifetime_pass" required />
+          <Field label="platform">
+            <select
+              name="platform"
+              required
+              defaultValue="apple"
+              className="mt-1 w-full rounded-md border border-slate-300 bg-white px-2 py-1.5 text-sm shadow-sm focus:border-brand-600 focus:outline-none focus:ring-1 focus:ring-brand-600"
+            >
+              <option value="apple">apple</option>
+              <option value="google">google</option>
+            </select>
+          </Field>
+          <Field label="type">
+            <select
+              name="type"
+              defaultValue="non_consumable"
+              className="mt-1 w-full rounded-md border border-slate-300 bg-white px-2 py-1.5 text-sm shadow-sm focus:border-brand-600 focus:outline-none focus:ring-1 focus:ring-brand-600"
+            >
+              <option value="non_consumable">non_consumable</option>
+              <option value="consumable">consumable</option>
+            </select>
+          </Field>
+          <Field
+            label="transactionId (optional)"
+            name="transactionId"
+            placeholder="비우면 admin_grant_<랜덤> 생성"
+          />
+        </div>
+        <ResultBanner state={state} successMessage="grant 완료 — 페이지가 갱신됩니다" />
+        <div className="flex items-center justify-end gap-3 border-t border-slate-100 pt-3">
+          <span className="text-xs text-slate-500">
+            ⚠ 영수증 없이 entitlement을 부여합니다. CS 결정 후에만 사용.
+          </span>
+          <SubmitButton label="Grant" />
+        </div>
+      </form>
+    </details>
+  );
+}
+
+interface FieldProps {
+  label: string;
+  name?: string;
+  placeholder?: string;
+  required?: boolean;
+  children?: React.ReactNode;
+}
+function Field({ label, name, placeholder, required, children }: FieldProps) {
+  return (
+    <label className="block text-xs font-medium text-slate-600">
+      <span>{label}</span>
+      {children ?? (
+        <input
+          type="text"
+          name={name}
+          placeholder={placeholder}
+          required={required}
+          autoComplete="off"
+          className="mt-1 block w-full rounded-md border border-slate-300 bg-white px-2 py-1.5 font-mono text-xs shadow-sm focus:border-brand-600 focus:outline-none focus:ring-1 focus:ring-brand-600"
+        />
+      )}
+    </label>
+  );
+}
+
+export function ResultBanner({ state, successMessage }: { state: ActionResult | null; successMessage: string }) {
+  if (!state) return null;
+  if (state.ok) {
+    return (
+      <div className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-800">
+        ✓ {successMessage}
+      </div>
+    );
+  }
+  return (
+    <div className="rounded-md border border-rose-200 bg-rose-50 px-3 py-2 text-xs text-rose-800">
+      ✕ {state.error ?? '실패'}
+    </div>
+  );
+}
+
+export function SubmitButton({ label, danger }: { label: string; danger?: boolean }) {
+  const { pending } = useFormStatus();
+  const tone = danger
+    ? 'bg-rose-600 hover:bg-rose-700 disabled:bg-rose-300'
+    : 'bg-brand-600 hover:bg-brand-700 disabled:bg-brand-300';
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      className={`rounded-md ${tone} px-4 py-1.5 text-sm font-medium text-white shadow-sm disabled:cursor-not-allowed`}
+    >
+      {pending ? '처리 중…' : label}
+    </button>
+  );
+}

--- a/packages/dashboard/app/dashboard/customers/[userId]/_components/purchase-actions.tsx
+++ b/packages/dashboard/app/dashboard/customers/[userId]/_components/purchase-actions.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { useActionState, useState } from 'react';
+import type { PurchaseInfo } from '@onesub/shared';
+import {
+  deletePurchasesAction,
+  transferPurchaseAction,
+  type ActionResult,
+} from '../../../../../lib/admin-actions';
+import { ResultBanner, SubmitButton } from './grant-form';
+
+interface PurchaseActionsProps {
+  purchase: PurchaseInfo;
+  /** Current page's userId — used to redirect/revalidate the right path. */
+  currentUserId: string;
+}
+
+export function PurchaseActions({ purchase, currentUserId }: PurchaseActionsProps) {
+  const [open, setOpen] = useState<'transfer' | 'delete' | null>(null);
+
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        type="button"
+        onClick={() => setOpen(open === 'transfer' ? null : 'transfer')}
+        className="rounded border border-slate-300 bg-white px-2 py-0.5 text-xs text-slate-700 hover:bg-slate-50"
+      >
+        Transfer
+      </button>
+      <button
+        type="button"
+        onClick={() => setOpen(open === 'delete' ? null : 'delete')}
+        className="rounded border border-rose-300 bg-white px-2 py-0.5 text-xs text-rose-700 hover:bg-rose-50"
+      >
+        Delete
+      </button>
+
+      {open === 'transfer' ? (
+        <TransferDialog purchase={purchase} currentUserId={currentUserId} onClose={() => setOpen(null)} />
+      ) : null}
+      {open === 'delete' ? (
+        <DeleteDialog purchase={purchase} onClose={() => setOpen(null)} />
+      ) : null}
+    </div>
+  );
+}
+
+function TransferDialog({
+  purchase,
+  currentUserId,
+  onClose,
+}: {
+  purchase: PurchaseInfo;
+  currentUserId: string;
+  onClose: () => void;
+}) {
+  const [state, formAction] = useActionState<ActionResult | null, FormData>(transferPurchaseAction, null);
+
+  return (
+    <Backdrop onClose={onClose}>
+      <h2 className="text-base font-semibold text-slate-900">Transfer purchase</h2>
+      <p className="mt-1 text-xs text-slate-500">
+        디바이스 마이그레이션 / 계정 병합 시 transactionId의 소유자를 다른 userId로 이전.
+      </p>
+      <dl className="mt-3 space-y-1 text-xs text-slate-600">
+        <Pair label="transactionId" value={purchase.transactionId} />
+        <Pair label="productId" value={purchase.productId} />
+        <Pair label="현재 owner" value={purchase.userId} />
+      </dl>
+      <form action={formAction} className="mt-4 space-y-3">
+        <input type="hidden" name="transactionId" value={purchase.transactionId} />
+        <input type="hidden" name="fromUserId" value={currentUserId} />
+        <label className="block text-xs font-medium text-slate-600">
+          <span>새 userId</span>
+          <input
+            type="text"
+            name="newUserId"
+            required
+            autoFocus
+            autoComplete="off"
+            className="mt-1 block w-full rounded-md border border-slate-300 bg-white px-2 py-1.5 font-mono text-xs shadow-sm focus:border-brand-600 focus:outline-none focus:ring-1 focus:ring-brand-600"
+          />
+        </label>
+        <ResultBanner state={state} successMessage="transfer 완료 — 페이지가 갱신됩니다" />
+        <div className="flex items-center justify-end gap-2 border-t border-slate-100 pt-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50"
+          >
+            Cancel
+          </button>
+          <SubmitButton label="Transfer" />
+        </div>
+      </form>
+    </Backdrop>
+  );
+}
+
+function DeleteDialog({ purchase, onClose }: { purchase: PurchaseInfo; onClose: () => void }) {
+  const [state, formAction] = useActionState<ActionResult | null, FormData>(deletePurchasesAction, null);
+
+  return (
+    <Backdrop onClose={onClose}>
+      <h2 className="text-base font-semibold text-slate-900">Delete purchases</h2>
+      <p className="mt-1 text-xs text-slate-500">
+        이 user의 <strong className="text-slate-700">{purchase.productId}</strong> 모든 purchase row가 삭제됩니다 (non-consumable 재테스트용).
+      </p>
+      <dl className="mt-3 space-y-1 text-xs text-slate-600">
+        <Pair label="userId" value={purchase.userId} />
+        <Pair label="productId" value={purchase.productId} />
+      </dl>
+      <form action={formAction} className="mt-4 space-y-3">
+        <input type="hidden" name="userId" value={purchase.userId} />
+        <input type="hidden" name="productId" value={purchase.productId} />
+        <ResultBanner state={state} successMessage="삭제 완료 — 페이지가 갱신됩니다" />
+        <div className="flex items-center justify-end gap-2 border-t border-slate-100 pt-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50"
+          >
+            Cancel
+          </button>
+          <SubmitButton label="Delete" danger />
+        </div>
+      </form>
+    </Backdrop>
+  );
+}
+
+function Backdrop({ children, onClose }: { children: React.ReactNode; onClose: () => void }) {
+  return (
+    <div
+      // Click-outside to close — onClose is the user's intent. The inner panel
+      // stops propagation so clicking inside doesn't dismiss.
+      onClick={onClose}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 px-4"
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="w-full max-w-md rounded-lg border border-slate-200 bg-white p-5 shadow-xl"
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function Pair({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between gap-3">
+      <dt className="text-slate-500">{label}</dt>
+      <dd className="font-mono text-slate-800">{value}</dd>
+    </div>
+  );
+}

--- a/packages/dashboard/app/dashboard/customers/[userId]/page.tsx
+++ b/packages/dashboard/app/dashboard/customers/[userId]/page.tsx
@@ -8,6 +8,8 @@ import type {
 } from '@onesub/shared';
 import { requireClient, clearAdminSecret } from '../../../../lib/auth';
 import { OneSubFetchError } from '../../../../lib/onesub-client';
+import { GrantForm } from './_components/grant-form';
+import { PurchaseActions } from './_components/purchase-actions';
 
 export const dynamic = 'force-dynamic';
 
@@ -75,6 +77,8 @@ export default async function CustomerDetailPage({ params }: PageProps) {
         </div>
       ) : null}
 
+      <GrantForm userId={profile.userId} />
+
       {profile.entitlements ? <EntitlementsCard entitlements={profile.entitlements} /> : null}
 
       {profile.subscriptions.length > 0 ? (
@@ -82,7 +86,7 @@ export default async function CustomerDetailPage({ params }: PageProps) {
       ) : null}
 
       {profile.purchases.length > 0 ? (
-        <PurchasesCard purchases={profile.purchases} />
+        <PurchasesCard purchases={profile.purchases} currentUserId={profile.userId} />
       ) : null}
     </div>
   );
@@ -176,7 +180,7 @@ function SubscriptionsCard({ subscriptions }: { subscriptions: SubscriptionInfo[
   );
 }
 
-function PurchasesCard({ purchases }: { purchases: PurchaseInfo[] }) {
+function PurchasesCard({ purchases, currentUserId }: { purchases: PurchaseInfo[]; currentUserId: string }) {
   return (
     <div className="rounded-lg border border-slate-200 bg-white shadow-sm">
       <div className="border-b border-slate-100 px-5 py-3 text-sm font-semibold text-slate-700">
@@ -191,6 +195,7 @@ function PurchasesCard({ purchases }: { purchases: PurchaseInfo[] }) {
             <Th>quantity</Th>
             <Th>purchasedAt</Th>
             <Th>transactionId</Th>
+            <Th>actions</Th>
           </tr>
         </thead>
         <tbody>
@@ -204,6 +209,7 @@ function PurchasesCard({ purchases }: { purchases: PurchaseInfo[] }) {
                 {p.purchasedAt.slice(0, 10)} <span className="text-slate-400">({relativeFromNow(p.purchasedAt)})</span>
               </Td>
               <Td className="font-mono text-xs text-slate-500">{p.transactionId}</Td>
+              <Td><PurchaseActions purchase={p} currentUserId={currentUserId} /></Td>
             </tr>
           ))}
         </tbody>

--- a/packages/dashboard/lib/admin-actions.ts
+++ b/packages/dashboard/lib/admin-actions.ts
@@ -1,0 +1,128 @@
+'use server';
+
+/**
+ * Server actions for admin write operations on the customer detail page.
+ *
+ * All three call into `OneSubClient` (which carries the admin secret server-side
+ * via the cookie) then `revalidatePath` so the UI re-renders with fresh data.
+ * On 401 we clear the cookie + redirect — same fallback pattern as the read
+ * pages have for stale sessions.
+ */
+
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import type { Platform, PurchaseType } from '@onesub/shared';
+import { clearAdminSecret, requireClient } from './auth';
+import { OneSubFetchError } from './onesub-client';
+
+export interface ActionResult {
+  ok: boolean;
+  /** Operator-friendly error message when ok is false. */
+  error?: string;
+}
+
+async function withClient<T>(fn: (client: Awaited<ReturnType<typeof requireClient>>) => Promise<T>): Promise<T> {
+  const client = await requireClient();
+  try {
+    return await fn(client);
+  } catch (err) {
+    if (err instanceof OneSubFetchError && err.status === 401) {
+      await clearAdminSecret();
+      redirect('/login');
+    }
+    throw err;
+  }
+}
+
+function asString(v: FormDataEntryValue | null): string | null {
+  if (typeof v !== 'string') return null;
+  const trimmed = v.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Grant — manually create a purchase row for `userId + productId`. Used for
+ * goodwill grants, refund recovery, beta gifts. Skips the store's receipt
+ * validation entirely; the operator is asserting entitlement.
+ */
+export async function grantPurchaseAction(_prev: ActionResult | null, formData: FormData): Promise<ActionResult> {
+  const userId = asString(formData.get('userId'));
+  const productId = asString(formData.get('productId'));
+  const platformRaw = asString(formData.get('platform'));
+  const typeRaw = asString(formData.get('type'));
+  const transactionId = asString(formData.get('transactionId')) ?? undefined;
+
+  if (!userId || !productId) return { ok: false, error: 'userId / productId 누락' };
+  if (platformRaw !== 'apple' && platformRaw !== 'google') {
+    return { ok: false, error: 'platform은 apple/google 중 하나' };
+  }
+  // Default to non-consumable since that's the realistic CS use case (consumable
+  // grants are usually a different code path — coin balances etc).
+  const type: PurchaseType = typeRaw === 'consumable' ? 'consumable' : 'non_consumable';
+
+  try {
+    await withClient((client) =>
+      client.grantPurchase({
+        userId,
+        productId,
+        platform: platformRaw as Platform,
+        type,
+        transactionId,
+      }),
+    );
+  } catch (err) {
+    return { ok: false, error: (err as Error).message ?? 'grant failed' };
+  }
+
+  revalidatePath(`/dashboard/customers/${userId}`);
+  return { ok: true };
+}
+
+/**
+ * Transfer — reassign a purchase's ownership to another userId. Server 404s if
+ * the transactionId is unknown.
+ */
+export async function transferPurchaseAction(_prev: ActionResult | null, formData: FormData): Promise<ActionResult> {
+  const transactionId = asString(formData.get('transactionId'));
+  const newUserId = asString(formData.get('newUserId'));
+  const fromUserId = asString(formData.get('fromUserId'));  // for revalidation only
+
+  if (!transactionId || !newUserId) return { ok: false, error: 'transactionId / newUserId 누락' };
+  if (newUserId === fromUserId) return { ok: false, error: '같은 userId로의 transfer는 의미 없습니다' };
+
+  try {
+    await withClient((client) => client.transferPurchase(transactionId, newUserId));
+  } catch (err) {
+    if (err instanceof OneSubFetchError && err.status === 404) {
+      return { ok: false, error: 'TRANSACTION_NOT_FOUND — 해당 transactionId가 존재하지 않습니다' };
+    }
+    return { ok: false, error: (err as Error).message ?? 'transfer failed' };
+  }
+
+  // The old userId's customer page no longer owns the row → refresh it.
+  // We don't redirect to the new owner: the operator might want to verify the
+  // old page is now empty before navigating.
+  if (fromUserId) revalidatePath(`/dashboard/customers/${fromUserId}`);
+  revalidatePath(`/dashboard/customers/${newUserId}`);
+  return { ok: true };
+}
+
+/**
+ * Delete — drop every purchase row matching `userId + productId`. Used for
+ * non-consumable re-test / refund cleanup.
+ */
+export async function deletePurchasesAction(_prev: ActionResult | null, formData: FormData): Promise<ActionResult> {
+  const userId = asString(formData.get('userId'));
+  const productId = asString(formData.get('productId'));
+
+  if (!userId || !productId) return { ok: false, error: 'userId / productId 누락' };
+
+  try {
+    await withClient((client) => client.deletePurchases(userId, productId));
+  } catch (err) {
+    return { ok: false, error: (err as Error).message ?? 'delete failed' };
+  }
+
+  revalidatePath(`/dashboard/customers/${userId}`);
+  return { ok: true };
+}

--- a/packages/dashboard/lib/onesub-client.ts
+++ b/packages/dashboard/lib/onesub-client.ts
@@ -14,6 +14,9 @@ import type {
   MetricsActiveResponse,
   MetricsCountResponse,
   MetricsGroupBy,
+  Platform,
+  PurchaseInfo,
+  PurchaseType,
   SubscriptionInfo,
 } from '@onesub/shared';
 
@@ -44,6 +47,32 @@ export interface OneSubClient {
    * configured). Always 200 — unknown userIds return empty arrays.
    */
   getCustomer(userId: string): Promise<CustomerProfileResponse>;
+  /**
+   * Manually grant a purchase row (typically non-consumable). Skips store
+   * receipt verification entirely — only meaningful for CS workflows where
+   * the operator has decided the user is entitled (refund recovery, gift,
+   * issue compensation). Generates a synthetic transactionId if none provided.
+   */
+  grantPurchase(input: GrantPurchaseInput): Promise<{ ok: true; purchase: PurchaseInfo }>;
+  /**
+   * Reassign a transactionId's owner to a new userId — for legitimate device
+   * migrations / account merges. Server returns 404 TRANSACTION_NOT_FOUND if
+   * the transactionId doesn't exist.
+   */
+  transferPurchase(transactionId: string, newUserId: string): Promise<{ ok: true; purchase: PurchaseInfo }>;
+  /**
+   * Delete every purchase row matching `userId + productId`. Used to let a
+   * user re-test a non-consumable flow. Returns the number of rows deleted.
+   */
+  deletePurchases(userId: string, productId: string): Promise<{ ok: true; deleted: number }>;
+}
+
+export interface GrantPurchaseInput {
+  userId: string;
+  productId: string;
+  platform: Platform;
+  type?: PurchaseType;
+  transactionId?: string;
 }
 
 export class OneSubFetchError extends Error {
@@ -69,6 +98,20 @@ export function createClient(serverUrl: string, adminSecret: string): OneSubClie
     });
     if (!response.ok) {
       throw new OneSubFetchError(response.status, `${path} → ${response.status} ${response.statusText}`);
+    }
+    return (await response.json()) as T;
+  }
+
+  async function send<T>(method: 'POST' | 'DELETE', path: string, body?: unknown): Promise<T> {
+    const response = await fetch(`${base}${path}`, {
+      method,
+      headers,
+      cache: 'no-store',
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new OneSubFetchError(response.status, `${method} ${path} → ${response.status} ${text || response.statusText}`);
     }
     return (await response.json()) as T;
   }
@@ -102,5 +145,17 @@ export function createClient(serverUrl: string, adminSecret: string): OneSubClie
       get<SubscriptionInfo>(`/onesub/admin/subscriptions/${encodeURIComponent(transactionId)}`),
     getCustomer: (userId) =>
       get<CustomerProfileResponse>(`/onesub/admin/customers/${encodeURIComponent(userId)}`),
+    grantPurchase: (input) =>
+      send<{ ok: true; purchase: PurchaseInfo }>('POST', '/onesub/purchase/admin/grant', input),
+    transferPurchase: (transactionId, newUserId) =>
+      send<{ ok: true; purchase: PurchaseInfo }>('POST', '/onesub/purchase/admin/transfer', {
+        transactionId,
+        newUserId,
+      }),
+    deletePurchases: (userId, productId) =>
+      send<{ ok: true; deleted: number }>(
+        'DELETE',
+        `/onesub/purchase/admin/${encodeURIComponent(userId)}/${encodeURIComponent(productId)}`,
+      ),
   };
 }


### PR DESCRIPTION
## Summary

`/dashboard/customers/[userId]`에 CS 워크플로 직결 admin write action 3개. 모두 **기존 서버 endpoint** 사용 — 서버 변경 0개. 사이드바 변경 없음.

### 액션

- **Grant non-consumable** — customer detail 상단 collapsible 폼. productId / platform / type / optional transactionId. `POST /onesub/purchase/admin/grant`. 환불 보상 / 굿윌 / 베타 지급용. 영수증 검증 우회 — 운영자 책임.
- **Transfer purchase** — Purchases 테이블 row별 dialog. `POST /onesub/purchase/admin/transfer`로 transactionId 소유권을 새 userId로 이전. 디바이스 마이그레이션 / 계정 병합. 404 `TRANSACTION_NOT_FOUND` 사용자 친화 메시지.
- **Delete purchases** — Purchases row별 dialog. `DELETE /onesub/purchase/admin/:userId/:productId`. 비-consumable 재테스트용 (해당 user의 같은 productId 모든 row 삭제).

### 구현

- `lib/admin-actions.ts` — 세 개 server action. 각각 `OneSubClient` 호출 후 `revalidatePath('/dashboard/customers/{userId}')`. 401 fallback은 read 페이지와 동일 패턴 (cookie 클리어 + `/login` redirect).
- `lib/onesub-client.ts` — `grantPurchase` / `transferPurchase` / `deletePurchases` 메서드 + 공용 `send<T>(method, path, body)` 헬퍼 (POST/DELETE 통합).
- `_components/grant-form.tsx` — 상단 details/summary 폼. `useActionState` + `useFormStatus`로 inline 로딩/결과.
- `_components/purchase-actions.tsx` — 셀 안 Transfer/Delete 버튼 + native modal (backdrop click-outside).

### 미고려 사항 (의도)

- 구독에 대한 admin action은 없음 — 서버에 subscription manual grant endpoint이 없음 (구독은 receipt validation 흐름이 source of truth). 필요해지면 별개 PR.
- Audit log 미포함 — 다음 작업 후보로 남김.

### Test plan

- [x] `npx tsc --noEmit -p packages/dashboard` clean
- [x] `npm run build` 5 packages
- [x] `npm test` — 377/377 (서버 변경 없어 새 테스트 0)
- [x] `next build` — `/dashboard/customers/[userId]` First Load JS 106 → 108 kB
- [ ] CI green
- [ ] findthem prod 데이터로 시각 + 동작 확인 (Grant / Transfer / Delete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)