### PR TITLE
chore(dashboard): polish — README, lockfile warning, mobile layout

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -1,8 +1,6 @@
 # @onesub/dashboard
 
-Self-hosted operations dashboard for [`@onesub/server`](https://www.npmjs.com/package/@onesub/server). View active subscriptions, lifecycle distribution, and operational state without standing up Grafana.
-
-> **Status: 0.1 (Phase 1a)** — overview metrics page only. Subscriptions list, charts, and customer search ship in subsequent phases.
+Self-hosted operations dashboard for [`@onesub/server`](https://www.npmjs.com/package/@onesub/server). View active subscriptions, lifecycle distribution, daily growth, per-customer state, and run common CS write actions — without standing up Grafana or wiring up a third-party admin service.
 
 ## Quick start (Docker)
 
@@ -33,33 +31,58 @@ cd packages/dashboard
 ONESUB_SERVER_URL=http://localhost:4100 npm run dev
 ```
 
-The dev server listens on port 4101 and proxies metric calls to `ONESUB_SERVER_URL`.
+The dev server listens on port 4101 and proxies admin/metrics calls to `ONESUB_SERVER_URL`.
+
+For a `.env.local`-style setup, drop `ONESUB_SERVER_URL=http://localhost:4100` into `packages/dashboard/.env.local` (the file is gitignored) and just run `npm run dev -w @onesub/dashboard` from the monorepo root.
 
 ## Configuration
 
 | Env var | Required | Notes |
 |---|---|---|
-| `ONESUB_SERVER_URL` | yes | Base URL of your `@onesub/server` (e.g. `http://localhost:4100`) |
+| `ONESUB_SERVER_URL` | yes | Base URL of your `@onesub/server` mount (e.g. `http://localhost:4100`, or `https://api.example.com/api` when onesub is mounted under a path prefix) |
 | `NODE_ENV=production` | recommended | Enables `Secure` cookie flag — required when serving over HTTPS |
 
 The dashboard does **not** persist anything itself — every page render fetches fresh state from the onesub server. The browser cookie holds your `adminSecret` (HTTP-only, 8h sliding window); no other state is kept.
 
 ## Auth model
 
-- The dashboard reuses your server's `adminSecret`. If the server doesn't have one set, mount it first (`createOneSubMiddleware({ ..., adminSecret: process.env.ADMIN_SECRET })`) — the metrics endpoints depend on it.
-- After successful login, the secret is stored as an `HttpOnly` cookie on this dashboard's domain. It never travels to the browser; only server components read it.
-- Phase 3 introduces a token-exchange layer (cookie holds an opaque session id, secret stays server-side) for multi-operator deployments. v0.1 is single-operator by design.
+- The dashboard reuses your server's `adminSecret`. If the server doesn't have one set, mount it first (`createOneSubMiddleware({ ..., adminSecret: process.env.ADMIN_SECRET })`) — every dashboard page depends on the admin scope being mounted.
+- After successful login, the secret is stored as an `HttpOnly` cookie on the dashboard's domain. It never travels to the browser; only server components and server actions read it.
+- Single-operator by design — a token-exchange layer (cookie holds an opaque session id, secret stays env-only) is on the roadmap when multi-operator + audit log land.
 
-## Pages (current)
+## Pages
 
-- `/login` — operator login
-- `/dashboard` — overview: total entitled, active subs, grace_period (at risk), non-consumable purchases, distribution by product + platform
+| Path | What it shows |
+|---|---|
+| `/login` | Operator login. Probes the upstream onesub server with the candidate secret before setting the cookie. |
+| `/dashboard` | **Overview** — total entitled, active subs, `grace_period` (at-risk), non-consumable purchases. Two charts (started-vs-expired subscriptions and non-consumable purchases over the last 30 UTC days) + three distribution panels (by product / by non-consumable product / by platform). |
+| `/dashboard/subscriptions` | **Subscription list** — filter by userId / status / productId / platform; URL-driven pagination (50 per page, capped at 200 server-side). Row userId → customer detail; productId / transactionId → subscription detail. |
+| `/dashboard/subscriptions/[transactionId]` | **Subscription detail** — every field from `SubscriptionInfo`, with relative-time anchors next to absolute timestamps and a Google-only card for `linkedPurchaseToken` / `autoResumeTime` when present. |
+| `/dashboard/customers` | **Customer search** — server-action search form (userId → redirect to detail). |
+| `/dashboard/customers/[userId]` | **Customer detail** — three tables (Entitlements when configured / Subscriptions / Purchases) plus admin write actions (see below). |
+
+## Admin write actions
+
+Available on the customer detail page:
+
+| Action | What it does | Server endpoint |
+|---|---|---|
+| **Grant non-consumable** | Manually create a purchase row for a `userId + productId`. Skips receipt verification — operator asserts entitlement (refund recovery, goodwill, beta gift). | `POST /onesub/purchase/admin/grant` |
+| **Transfer purchase** | Reassign a `transactionId`'s owner to a new userId. For legitimate device migration / account merge. | `POST /onesub/purchase/admin/transfer` |
+| **Delete purchases** | Drop every purchase row matching `userId + productId`. Used to let a user re-test a non-consumable flow. | `DELETE /onesub/purchase/admin/:userId/:productId` |
+
+All three are server actions that revalidate the customer detail page after success. Subscriptions cannot be granted directly from the dashboard — receipt validation is the source of truth for subs.
+
+## Mounting onesub behind a path prefix
+
+If your host app mounts onesub under a sub-path (e.g. `app.use('/api', createRouter())` so the routes are at `/api/onesub/*`), point `ONESUB_SERVER_URL` at the prefix and the dashboard will reach the right paths automatically.
 
 ## Roadmap
 
-- Phase 1b: `/dashboard/subscriptions` — list, filter, search by userId
-- Phase 2: time-series charts (started / churned over selectable windows)
-- Phase 3: customer search, audit log, manual grant UI
+- Audit log of admin write actions (who / when / what)
+- Token-exchange auth for multi-operator setups
+- Subscription manual grant (paired with a `subscriptionStore.save` admin endpoint)
+- Mobile-friendly layout polish
 
 ## License
 

--- a/packages/dashboard/app/dashboard/customers/[userId]/page.tsx
+++ b/packages/dashboard/app/dashboard/customers/[userId]/page.tsx
@@ -101,7 +101,8 @@ function EntitlementsCard({ entitlements }: { entitlements: Record<string, Entit
       <div className="border-b border-slate-100 px-5 py-3 text-sm font-semibold text-slate-700">
         Entitlements
       </div>
-      <table className="w-full text-sm">
+      <div className="overflow-x-auto">
+      <table className="w-full min-w-[640px] text-sm">
         <thead className="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
           <tr>
             <Th>id</Th>
@@ -133,6 +134,7 @@ function EntitlementsCard({ entitlements }: { entitlements: Record<string, Entit
           ))}
         </tbody>
       </table>
+      </div>
     </div>
   );
 }
@@ -143,7 +145,8 @@ function SubscriptionsCard({ subscriptions }: { subscriptions: SubscriptionInfo[
       <div className="border-b border-slate-100 px-5 py-3 text-sm font-semibold text-slate-700">
         Subscriptions <span className="ml-1 text-xs font-normal text-slate-400">({subscriptions.length})</span>
       </div>
-      <table className="w-full text-sm">
+      <div className="overflow-x-auto">
+      <table className="w-full min-w-[640px] text-sm">
         <thead className="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
           <tr>
             <Th>productId</Th>
@@ -176,6 +179,7 @@ function SubscriptionsCard({ subscriptions }: { subscriptions: SubscriptionInfo[
           })}
         </tbody>
       </table>
+      </div>
     </div>
   );
 }
@@ -186,7 +190,8 @@ function PurchasesCard({ purchases, currentUserId }: { purchases: PurchaseInfo[]
       <div className="border-b border-slate-100 px-5 py-3 text-sm font-semibold text-slate-700">
         Purchases <span className="ml-1 text-xs font-normal text-slate-400">({purchases.length})</span>
       </div>
-      <table className="w-full text-sm">
+      <div className="overflow-x-auto">
+      <table className="w-full min-w-[640px] text-sm">
         <thead className="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
           <tr>
             <Th>productId</Th>
@@ -214,6 +219,7 @@ function PurchasesCard({ purchases, currentUserId }: { purchases: PurchaseInfo[]
           ))}
         </tbody>
       </table>
+      </div>
     </div>
   );
 }

--- a/packages/dashboard/app/dashboard/layout.tsx
+++ b/packages/dashboard/app/dashboard/layout.tsx
@@ -2,41 +2,40 @@ import Link from 'next/link';
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex min-h-screen">
-      <aside className="w-56 shrink-0 border-r border-slate-200 bg-white px-4 py-6">
-        <Link href="/dashboard" className="block text-lg font-semibold tracking-tight">
-          onesub
-        </Link>
-        <nav className="mt-8 space-y-1 text-sm">
-          <Link
-            href="/dashboard"
-            className="block rounded-md px-3 py-2 font-medium text-slate-700 hover:bg-slate-100"
-          >
-            Overview
+    <div className="flex min-h-screen flex-col lg:flex-row">
+      {/* Sidebar — horizontal nav strip on mobile (top), vertical rail on lg+. */}
+      <aside className="border-b border-slate-200 bg-white lg:w-56 lg:shrink-0 lg:border-b-0 lg:border-r">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 px-4 py-3 lg:block lg:px-4 lg:py-6">
+          <Link href="/dashboard" className="block text-lg font-semibold tracking-tight">
+            onesub
           </Link>
-          <Link
-            href="/dashboard/subscriptions"
-            className="block rounded-md px-3 py-2 font-medium text-slate-700 hover:bg-slate-100"
-          >
-            Subscriptions
-          </Link>
-          <Link
-            href="/dashboard/customers"
-            className="block rounded-md px-3 py-2 font-medium text-slate-700 hover:bg-slate-100"
-          >
-            Customers
-          </Link>
-        </nav>
-        <form action="/api/logout" method="post" className="mt-12">
-          <button
-            type="submit"
-            className="block w-full rounded-md px-3 py-2 text-left text-sm text-slate-500 hover:bg-slate-100 hover:text-slate-700"
-          >
-            Sign out
-          </button>
-        </form>
+          <nav className="flex flex-wrap gap-1 text-sm lg:mt-8 lg:flex-col lg:gap-0 lg:space-y-1">
+            <NavLink href="/dashboard">Overview</NavLink>
+            <NavLink href="/dashboard/subscriptions">Subscriptions</NavLink>
+            <NavLink href="/dashboard/customers">Customers</NavLink>
+          </nav>
+          <form action="/api/logout" method="post" className="ml-auto lg:ml-0 lg:mt-12">
+            <button
+              type="submit"
+              className="block rounded-md px-3 py-2 text-sm text-slate-500 hover:bg-slate-100 hover:text-slate-700 lg:w-full lg:text-left"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
       </aside>
-      <main className="flex-1 px-8 py-8">{children}</main>
+      <main className="flex-1 px-4 py-6 lg:px-8 lg:py-8">{children}</main>
     </div>
+  );
+}
+
+function NavLink({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <Link
+      href={href}
+      className="rounded-md px-3 py-2 font-medium text-slate-700 hover:bg-slate-100"
+    >
+      {children}
+    </Link>
   );
 }

--- a/packages/dashboard/app/dashboard/subscriptions/page.tsx
+++ b/packages/dashboard/app/dashboard/subscriptions/page.tsx
@@ -126,8 +126,8 @@ export default async function SubscriptionsPage({ searchParams }: PageProps) {
         ) : null}
       </form>
 
-      <div className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
-        <table className="w-full text-sm">
+      <div className="overflow-x-auto rounded-lg border border-slate-200 bg-white shadow-sm">
+        <table className="w-full min-w-[800px] text-sm">
           <thead className="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
             <tr>
               <Th>userId</Th>

--- a/packages/dashboard/next.config.ts
+++ b/packages/dashboard/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from 'next';
+import path from 'node:path';
 
 const nextConfig: NextConfig = {
   // Required for the Docker image — Next.js produces a minimal standalone
@@ -6,6 +7,10 @@ const nextConfig: NextConfig = {
   output: 'standalone',
   // Reduce noise: we don't ship images via next/image at this stage.
   images: { unoptimized: true },
+  // Pin the workspace root so Next.js doesn't infer a parent directory's
+  // package-lock.json (e.g. when the user has multiple repos under their
+  // home dir). Resolves the "multiple lockfiles" warning at dev start.
+  outputFileTracingRoot: path.join(__dirname, '..', '..'),
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

3가지 작은 정리. 동작 변경 없음, 데스크탑 UX 그대로.

- **README** — 지금까지 머지된 모든 페이지 (Overview, Subs list/detail, Customers search/detail, admin write actions) 반영. "Phase 1a only" 같은 stale 상태 라인 제거. `.env.local` 셋업 / `ONESUB_SERVER_URL`이 path prefix(예: `/api`) 지원한다는 점 명시.
- **next.config.ts** — `outputFileTracingRoot`를 모노레포 루트로 pin. 부모 디렉토리의 `package-lock.json`을 잘못 잡아서 떴던 multi-lockfile 경고 제거.
- **Mobile** — 사이드바를 모바일에선 상단 가로 strip, `lg+`에선 기존 좌측 rail. 테이블들 (subs list / customer detail의 entitlements/subs/purchases)에 `overflow-x-auto` 래퍼 + `min-width` 적용해서 좁은 viewport에서 가로 스크롤 가능. 375px iPhone에서 확인됨.

## Test plan

- [x] `npx tsc --noEmit -p packages/dashboard` clean
- [x] `npm test` — 377/377
- [x] `next build` — 라우트/번들 사이즈 동일, 빌드 시 lockfile 경고 없음
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)