### PR TITLE
fix(dashboard): apply Next 16 tsconfig migration

### DIFF
--- a/packages/dashboard/next-env.d.ts
+++ b/packages/dashboard/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/dashboard/tsconfig.json
+++ b/packages/dashboard/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["dom", "dom.iterable", "ES2022"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "ES2022"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -11,13 +15,27 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
-    "plugins": [{ "name": "next" }],
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## What
Lands the `tsconfig.json` + `next-env.d.ts` changes that Next 16 generates on build.

#69 bumped `next` 15.5.15 → 16.2.x, but Dependabot only edits version ranges — it never touches app config. So `packages/dashboard/tsconfig.json` still carried Next 15's `jsx: "preserve"` while Next 16 **mandates** `jsx: "react-jsx"`. Every `next build` regenerated these files, leaving a dirty working tree.

## Changes
- `tsconfig.json`: `jsx: preserve` → `react-jsx`; add `.next/dev/types/**/*.ts` to `include`
- `next-env.d.ts`: route-types `/// <reference>` → `import`
- (remaining lib/plugins/paths reformatting is Next's JSON writer output)

## Verification (local, Windows, against merged master)
- `npm run build` ✅ · `npm test` **443/443** ✅
- dashboard `tsc --noEmit` ✅ · `next build` ✅ (all routes generate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)