### PR TITLE
harden(iap): account-binding for purchase validation (Apple + Google)

### DIFF
--- a/.changeset/purchase-account-binding.md
+++ b/.changeset/purchase-account-binding.md
@@ -1,0 +1,13 @@
+---
+'@onesub/server': patch
+---
+
+Bind product purchase validation to the receipt's `appAccountToken`. The
+`/purchase/validate` route now rejects saving or reassigning a validated
+non-consumable/consumable purchase to a `userId` that does not match the
+`appAccountToken` baked into the receipt at purchase time. This closes a path
+where a leaked or shared (but cryptographically valid) JWS could be attributed
+or reassigned to an attacker-chosen `userId`. Backward compatible: receipts made
+before the client sets `appAccountToken` carry no token and keep the previous
+behavior (including reinstall reassignment). Apple `AppleProductResult` now
+surfaces `appAccountToken`.

--- a/.changeset/purchase-account-binding.md
+++ b/.changeset/purchase-account-binding.md
@@ -1,13 +1,14 @@
 ---
-'@onesub/server': patch
+'@onesub/server': minor
 ---
 
-Bind product purchase validation to the receipt's `appAccountToken`. The
-`/purchase/validate` route now rejects saving or reassigning a validated
+Bind product purchase validation to the account identity baked into the receipt.
+The `/purchase/validate` route now rejects saving or reassigning a validated
 non-consumable/consumable purchase to a `userId` that does not match the
-`appAccountToken` baked into the receipt at purchase time. This closes a path
-where a leaked or shared (but cryptographically valid) JWS could be attributed
-or reassigned to an attacker-chosen `userId`. Backward compatible: receipts made
-before the client sets `appAccountToken` carry no token and keep the previous
-behavior (including reinstall reassignment). Apple `AppleProductResult` now
-surfaces `appAccountToken`.
+receipt's account token — Apple `appAccountToken` (surfaced on
+`AppleProductResult`) and Google `obfuscatedExternalAccountId` (surfaced on
+`GoogleProductResult`). This closes a path where a leaked or shared (but
+cryptographically valid) receipt could be attributed or reassigned to an
+attacker-chosen `userId`. Backward compatible: receipts made before the client
+sets an account token carry none and keep the previous behavior (including
+reinstall reassignment).

--- a/.changeset/sdk-account-token.md
+++ b/.changeset/sdk-account-token.md
@@ -1,0 +1,11 @@
+---
+'@jeonghwanko/onesub-sdk': minor
+---
+
+Add an optional `accountToken` prop to `OneSubProvider`. When set, it is passed
+to StoreKit as `appAccountToken` (iOS) and Google Play as
+`obfuscatedAccountIdAndroid` at purchase time, binding the purchase to a stable
+account identity. Pair it with the matching `@onesub/server` account-binding
+guard so a leaked receipt cannot be attributed to a different account. Omit it to
+keep the previous unbound behavior. Read via an internal ref so asynchronously
+resolved tokens are always current without re-creating the purchase callbacks.

--- a/.changeset/sdk-account-token.md
+++ b/.changeset/sdk-account-token.md
@@ -3,8 +3,8 @@
 ---
 
 Add an optional `accountToken` prop to `OneSubProvider`. When set, it is passed
-to StoreKit as `appAccountToken` (iOS) and Google Play as
-`obfuscatedAccountIdAndroid` at purchase time, binding the purchase to a stable
+to StoreKit as `appAccountToken` (iOS) and Google Play as `obfuscatedAccountId`
+at purchase time, binding the purchase to a stable
 account identity. Pair it with the matching `@onesub/server` account-binding
 guard so a leaked receipt cannot be attributed to a different account. Omit it to
 keep the previous unbound behavior. Read via an internal ref so asynchronously

--- a/packages/sdk/src/OneSubProvider.tsx
+++ b/packages/sdk/src/OneSubProvider.tsx
@@ -108,6 +108,8 @@ function isUserCancelled(err: unknown): boolean {
 // ---------------------------------------------------------------------------
 // Helper — build platform-scoped requestPurchase args for react-native-iap v15
 // ---------------------------------------------------------------------------
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 function buildRequestPurchaseArgs(
   sku: string,
   platform: 'ios' | 'android',
@@ -116,12 +118,27 @@ function buildRequestPurchaseArgs(
 ) {
   // accountToken binds the purchase to a stable account identity: Apple bakes it
   // into the signed transaction as `appAccountToken` (must be a UUID), Android
-  // carries it as `obfuscatedAccountIdAndroid`. The server's validate route
-  // rejects attributing/reassigning the purchase to a different userId, so a
-  // leaked receipt cannot be claimed by another account. Optional — omitted when
-  // the host doesn't pass an `accountToken`.
-  const apple = accountToken ? { sku, appAccountToken: accountToken } : { sku };
-  const androidExtra = accountToken ? { obfuscatedAccountIdAndroid: accountToken } : {};
+  // carries it as `obfuscatedAccountId` (the react-native-iap v15 REQUEST field —
+  // note the purchase RESULT uses the suffixed `obfuscatedAccountIdAndroid`, do
+  // not confuse them). The server's validate route rejects attributing/reassigning
+  // the purchase to a different userId, so a leaked receipt cannot be claimed by
+  // another account. Optional — omitted when the host doesn't pass `accountToken`.
+  //
+  // Each store rejects malformed tokens at purchase time (Apple: non-UUID;
+  // Google: obfuscatedAccountId > 64 chars → DEVELOPER_ERROR), which would break
+  // the purchase sheet itself. Degrade an invalid token to an unbound purchase
+  // rather than let it break checkout.
+  const iosToken = accountToken && UUID_RE.test(accountToken) ? accountToken : undefined;
+  const androidToken = accountToken && accountToken.length <= 64 ? accountToken : undefined;
+  if (accountToken && typeof console !== 'undefined') {
+    if (platform === 'ios' && !iosToken) {
+      console.warn('[onesub] accountToken is not a UUID — omitted on iOS; purchase will be unbound');
+    } else if (platform === 'android' && !androidToken) {
+      console.warn('[onesub] accountToken exceeds 64 chars — omitted on Android; purchase will be unbound');
+    }
+  }
+  const apple = iosToken ? { sku, appAccountToken: iosToken } : { sku };
+  const androidExtra = androidToken ? { obfuscatedAccountId: androidToken } : {};
   const request =
     platform === 'ios'
       ? { ios: apple }
@@ -176,7 +193,7 @@ export interface OneSubProviderProps {
   userId: string;
   /**
    * Stable account identity baked into each purchase (Apple `appAccountToken`,
-   * Android `obfuscatedAccountIdAndroid`). Bind this to an identity that survives
+   * Android `obfuscatedAccountId`). Bind this to an identity that survives
    * reinstall (e.g. a UUID derived from a hardware id hash) and is the SAME value
    * you pass as `userId`, so the server's validate route accepts the purchase.
    * Apple requires a UUID string. Omit to keep the previous unbound behavior.

--- a/packages/sdk/src/OneSubProvider.tsx
+++ b/packages/sdk/src/OneSubProvider.tsx
@@ -112,13 +112,22 @@ function buildRequestPurchaseArgs(
   sku: string,
   platform: 'ios' | 'android',
   type: 'in-app' | 'subs',
+  accountToken?: string,
 ) {
+  // accountToken binds the purchase to a stable account identity: Apple bakes it
+  // into the signed transaction as `appAccountToken` (must be a UUID), Android
+  // carries it as `obfuscatedAccountIdAndroid`. The server's validate route
+  // rejects attributing/reassigning the purchase to a different userId, so a
+  // leaked receipt cannot be claimed by another account. Optional — omitted when
+  // the host doesn't pass an `accountToken`.
+  const apple = accountToken ? { sku, appAccountToken: accountToken } : { sku };
+  const androidExtra = accountToken ? { obfuscatedAccountIdAndroid: accountToken } : {};
   const request =
     platform === 'ios'
-      ? { ios: { sku } }
+      ? { ios: apple }
       : type === 'subs'
-        ? { android: { skus: [sku], subscriptionOffers: [] } }
-        : { android: { skus: [sku] } };
+        ? { android: { skus: [sku], subscriptionOffers: [], ...androidExtra } }
+        : { android: { skus: [sku], ...androidExtra } };
 
   return { request, type };
 }
@@ -165,16 +174,29 @@ function buildRequestPurchaseArgs(
 export interface OneSubProviderProps {
   config: OneSubConfig;
   userId: string;
+  /**
+   * Stable account identity baked into each purchase (Apple `appAccountToken`,
+   * Android `obfuscatedAccountIdAndroid`). Bind this to an identity that survives
+   * reinstall (e.g. a UUID derived from a hardware id hash) and is the SAME value
+   * you pass as `userId`, so the server's validate route accepts the purchase.
+   * Apple requires a UUID string. Omit to keep the previous unbound behavior.
+   */
+  accountToken?: string;
   children: React.ReactNode;
 }
 
-export function OneSubProvider({ config, userId, children }: OneSubProviderProps) {
+export function OneSubProvider({ config, userId, accountToken, children }: OneSubProviderProps) {
   const [isActive, setIsActive] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [subscription, setSubscription] = useState<SubscriptionInfo | null>(null);
   const [entitlements, setEntitlements] = useState<Record<string, EntitlementStatus>>({});
 
   const isBusyRef = useRef(false);
+  // Read via ref so the stable purchase callbacks always see the latest token
+  // (it may resolve asynchronously on the host, e.g. after hashing a hardware id)
+  // without needing to be in their dependency arrays.
+  const accountTokenRef = useRef(accountToken);
+  accountTokenRef.current = accountToken;
   const inFlightRef = useRef<Map<string, InFlightEntry>>(new Map());
   // Recreate only when the relevant config fields change — referential
   // stability keeps re-mount effects from firing on every parent render.
@@ -417,7 +439,7 @@ export function OneSubProvider({ config, userId, children }: OneSubProviderProps
         undefined,
       );
       try {
-        await RNIap.requestPurchase(buildRequestPurchaseArgs(productId, platform, 'subs'));
+        await RNIap.requestPurchase(buildRequestPurchaseArgs(productId, platform, 'subs', accountTokenRef.current));
       } catch (err) {
         inFlightRef.current.delete(productId);
         if (isUserCancelled(err)) return;
@@ -531,7 +553,7 @@ export function OneSubProvider({ config, userId, children }: OneSubProviderProps
         }>(productId, 'purchase', type);
 
         try {
-          await RNIap.requestPurchase(buildRequestPurchaseArgs(productId, platform, 'in-app'));
+          await RNIap.requestPurchase(buildRequestPurchaseArgs(productId, platform, 'in-app', accountTokenRef.current));
         } catch (err) {
           inFlightRef.current.delete(productId);
           if (isUserCancelled(err)) return null;

--- a/packages/server/src/__tests__/mock-provider.test.ts
+++ b/packages/server/src/__tests__/mock-provider.test.ts
@@ -237,4 +237,33 @@ describe('full server in mockMode', () => {
     expect(res.status).toBe(409);
     expect(res.body.errorCode).toBe(ONESUB_ERROR_CODE.TRANSACTION_BELONGS_TO_OTHER_USER);
   });
+
+  it('account-binding: Google obfuscatedExternalAccountId matching userId is accepted', async () => {
+    const app = mockApp();
+    const res = await request(app).post('/onesub/purchase/validate').send({
+      platform: 'google',
+      receipt: 'MOCK_VALID_gbind_ok#token=acct-uuid-g1',
+      userId: 'acct-uuid-g1',
+      productId: 'premium',
+      type: 'non_consumable',
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.valid).toBe(true);
+    expect(res.body.action).toBe('new');
+  });
+
+  it('account-binding: Google obfuscatedExternalAccountId mismatch is rejected (payment-bypass guard)', async () => {
+    const app = mockApp();
+    // A leaked Google purchaseToken bound to acct-uuid-g1 cannot be attributed
+    // to a different userId — same guard as Apple, symmetric coverage.
+    const res = await request(app).post('/onesub/purchase/validate').send({
+      platform: 'google',
+      receipt: 'MOCK_VALID_gbind_mismatch#token=acct-uuid-g1',
+      userId: 'attacker-uuid-g2',
+      productId: 'premium',
+      type: 'non_consumable',
+    });
+    expect(res.status).toBe(409);
+    expect(res.body.errorCode).toBe(ONESUB_ERROR_CODE.TRANSACTION_BELONGS_TO_OTHER_USER);
+  });
 });

--- a/packages/server/src/__tests__/mock-provider.test.ts
+++ b/packages/server/src/__tests__/mock-provider.test.ts
@@ -204,7 +204,37 @@ describe('full server in mockMode', () => {
     // transactionId path.
     const second = await request(app).post('/onesub/purchase/validate').send({ ...body, userId: 'user_2' });
     // non-consumable with same transactionId but different userId → auto-reassigned (0.6.1+)
+    // (backward-compat: no appAccountToken on the receipt → binding guard skipped)
     expect(second.body.valid).toBe(true);
     expect(second.body.action).toBe('restored');
+  });
+
+  it('account-binding: receipt appAccountToken matching userId is accepted', async () => {
+    const app = mockApp();
+    const res = await request(app).post('/onesub/purchase/validate').send({
+      platform: 'apple',
+      receipt: 'MOCK_VALID_bind_ok#token=acct-uuid-1',
+      userId: 'acct-uuid-1',
+      productId: 'premium',
+      type: 'non_consumable',
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.valid).toBe(true);
+    expect(res.body.action).toBe('new');
+  });
+
+  it('account-binding: receipt appAccountToken not matching userId is rejected (payment-bypass guard)', async () => {
+    const app = mockApp();
+    // A valid receipt bound to acct-uuid-1 cannot be attributed to a different
+    // userId — blocks a leaked/valid JWS being planted on an attacker deviceId.
+    const res = await request(app).post('/onesub/purchase/validate').send({
+      platform: 'apple',
+      receipt: 'MOCK_VALID_bind_mismatch#token=acct-uuid-1',
+      userId: 'attacker-uuid-2',
+      productId: 'premium',
+      type: 'non_consumable',
+    });
+    expect(res.status).toBe(409);
+    expect(res.body.errorCode).toBe(ONESUB_ERROR_CODE.TRANSACTION_BELONGS_TO_OTHER_USER);
   });
 });

--- a/packages/server/src/providers/apple.ts
+++ b/packages/server/src/providers/apple.ts
@@ -236,6 +236,14 @@ export interface AppleProductResult {
   transactionId: string;
   productId: string;
   purchasedAt: string;
+  /**
+   * appAccountToken baked into the JWS at purchase time (UUID the client passed
+   * to StoreKit). When present it binds the purchase to a stable account
+   * identity; the validate route rejects attributing/reassigning the purchase to
+   * a userId that doesn't match it. Absent for purchases made before the client
+   * started setting appAccountToken (backward-compatible).
+   */
+  appAccountToken?: string;
 }
 
 /**
@@ -331,6 +339,7 @@ export async function validateAppleConsumableReceipt(
     purchasedAt: tx.purchaseDate
       ? new Date(tx.purchaseDate).toISOString()
       : new Date().toISOString(),
+    appAccountToken: tx.appAccountToken ?? undefined,
   };
 }
 

--- a/packages/server/src/providers/google.ts
+++ b/packages/server/src/providers/google.ts
@@ -139,6 +139,8 @@ interface GoogleProductPurchase {
   purchaseState?: number;       // 0 = Purchased, 1 = Canceled, 2 = Pending
   consumptionState?: number;    // 0 = Not consumed, 1 = Consumed
   orderId?: string;
+  /** Account identity set by the client at purchase time (obfuscatedAccountIdAndroid). */
+  obfuscatedExternalAccountId?: string;
   [key: string]: unknown;
 }
 
@@ -581,6 +583,14 @@ export interface GoogleProductResult {
   /** orderId — unique per Google Play transaction, safe deduplication key */
   transactionId: string;
   purchasedAt: string;
+  /**
+   * Account identity the client baked in at purchase time
+   * (`obfuscatedAccountIdAndroid` → Play `obfuscatedExternalAccountId`). When
+   * present the validate route rejects attributing/reassigning the purchase to
+   * a non-matching userId. Absent for purchases made before the client set it
+   * (backward-compatible).
+   */
+  obfuscatedExternalAccountId?: string;
 }
 
 /**
@@ -650,6 +660,7 @@ export async function validateGoogleProductReceipt(
     purchasedAt: purchase.purchaseTimeMillis
       ? new Date(parseInt(purchase.purchaseTimeMillis, 10)).toISOString()
       : new Date().toISOString(),
+    obfuscatedExternalAccountId: purchase.obfuscatedExternalAccountId,
   };
 }
 

--- a/packages/server/src/providers/mock.ts
+++ b/packages/server/src/providers/mock.ts
@@ -125,11 +125,15 @@ export function mockValidateGoogleSubscription(
 export function mockValidateGoogleProduct(
   receipt: string,
   productId: string,
-): { transactionId: string; purchasedAt: string } | null {
+): { transactionId: string; purchasedAt: string; obfuscatedExternalAccountId?: string } | null {
   const outcome = classifyMockReceipt(receipt);
   if (!outcomePasses(outcome, 'google')) return null;
+  // Test convention: `...#token=<value>` surfaces an obfuscatedExternalAccountId,
+  // exercising the account-binding guard in the validate route (mirrors Apple).
+  const tokenMatch = receipt.match(/#token=([^#]+)/);
   return {
     transactionId: deterministicTransactionId(`mock_google_${productId}`, receipt),
     purchasedAt: new Date().toISOString(),
+    ...(tokenMatch ? { obfuscatedExternalAccountId: tokenMatch[1] } : {}),
   };
 }

--- a/packages/server/src/providers/mock.ts
+++ b/packages/server/src/providers/mock.ts
@@ -87,14 +87,18 @@ export function mockValidateAppleSubscription(receipt: string): SubscriptionInfo
 export function mockValidateAppleProduct(
   receipt: string,
   expectedProductId?: string,
-): { transactionId: string; productId: string; purchasedAt: string } | null {
+): { transactionId: string; productId: string; purchasedAt: string; appAccountToken?: string } | null {
   const outcome = classifyMockReceipt(receipt);
   if (!outcomePasses(outcome, 'apple')) return null;
   const productId = expectedProductId ?? 'mock_product';
+  // Test convention: `...#token=<value>` in the mock receipt surfaces an
+  // appAccountToken, exercising the account-binding guard in the validate route.
+  const tokenMatch = receipt.match(/#token=([^#]+)/);
   return {
     transactionId: deterministicTransactionId(`mock_apple_${productId}`, receipt),
     productId,
     purchasedAt: new Date().toISOString(),
+    ...(tokenMatch ? { appAccountToken: tokenMatch[1] } : {}),
   };
 }
 

--- a/packages/server/src/routes/purchase.ts
+++ b/packages/server/src/routes/purchase.ts
@@ -133,6 +133,7 @@ export function createPurchaseRouter(
         if (result) {
           transactionId = result.transactionId;
           purchasedAt = result.purchasedAt;
+          boundAccountId = result.obfuscatedExternalAccountId ?? null;
         }
       }
 
@@ -149,7 +150,10 @@ export function createPurchaseRouter(
       // the request-body userId otherwise). Backward-compatible: purchases made
       // before the client set appAccountToken have no token → guard is skipped and
       // current behaviour (incl. reinstall reassignment) is unchanged.
-      if (boundAccountId && boundAccountId !== userId) {
+      // Case-insensitive compare: Apple normalizes appAccountToken to a lowercase
+      // UUID in the signed transaction, so a host passing the same UUID uppercased
+      // must not be rejected. Harmless for Google's verbatim account ids.
+      if (boundAccountId && boundAccountId.toLowerCase() !== userId.toLowerCase()) {
         log.warn(
           `[onesub/purchase] account binding mismatch for transaction ${transactionId}: token does not match userId ${userId}`,
         );

--- a/packages/server/src/routes/purchase.ts
+++ b/packages/server/src/routes/purchase.ts
@@ -103,6 +103,10 @@ export function createPurchaseRouter(
       // security checks (type validation, consumptionState, receipt age).
       let transactionId: string | null = null;
       let purchasedAt: string = new Date().toISOString();
+      // Account binding token baked into the receipt at purchase time (Apple
+      // appAccountToken / Google obfuscatedExternalAccountId). Null when the
+      // client didn't set one (legacy purchases / apps not yet on the bound SDK).
+      let boundAccountId: string | null = null;
 
       if (platform === 'apple') {
         if (!config.apple) {
@@ -113,6 +117,7 @@ export function createPurchaseRouter(
         if (result) {
           transactionId = result.transactionId;
           purchasedAt = result.purchasedAt;
+          boundAccountId = result.appAccountToken ?? null;
         }
       } else {
         if (!config.google) {
@@ -133,6 +138,28 @@ export function createPurchaseRouter(
 
       if (!transactionId) {
         sendError(res, 422, ONESUB_ERROR_CODE.RECEIPT_VALIDATION_FAILED, 'Receipt validation failed', NO_PURCHASE);
+        return;
+      }
+
+      // Account-binding guard (payment-bypass defense). If the receipt carries an
+      // appAccountToken (a stable account id the client baked in at purchase time),
+      // the purchase may ONLY be attributed to a matching userId. This blocks the
+      // core exploit: a leaked/valid JWS being SAVED or REASSIGNED to an
+      // attacker-chosen userId (both the fresh-save and reassign paths below trust
+      // the request-body userId otherwise). Backward-compatible: purchases made
+      // before the client set appAccountToken have no token → guard is skipped and
+      // current behaviour (incl. reinstall reassignment) is unchanged.
+      if (boundAccountId && boundAccountId !== userId) {
+        log.warn(
+          `[onesub/purchase] account binding mismatch for transaction ${transactionId}: token does not match userId ${userId}`,
+        );
+        sendError(
+          res,
+          409,
+          ONESUB_ERROR_CODE.TRANSACTION_BELONGS_TO_OTHER_USER,
+          'TRANSACTION_BELONGS_TO_OTHER_USER',
+          NO_PURCHASE,
+        );
         return;
       }
 


### PR DESCRIPTION
## What

Binds product purchase validation to a stable account identity so a leaked or
shared (but cryptographically valid) receipt can't be attributed or reassigned
to a different account.

- **Server**: `/purchase/validate` surfaces the receipt's account token — Apple
  `appAccountToken` (on `AppleProductResult`) and Google
  `obfuscatedExternalAccountId` (on `GoogleProductResult`) — and rejects
  saving/reassigning (409 `TRANSACTION_BELONGS_TO_OTHER_USER`) when it doesn't
  match the request `userId` (case-insensitive). No token → legacy behavior
  (incl. reinstall reassignment) unchanged.
- **SDK**: `OneSubProvider` gains an optional `accountToken` prop → threaded into
  `requestPurchase` as `appAccountToken` (iOS) / `obfuscatedAccountId` (Android
  request field). Non-UUID (iOS) / >64-char (Android) tokens degrade to unbound
  rather than break checkout. Read via a ref so async-resolved tokens are current.

## Backward compatibility

Zero impact on consumers that don't pass `accountToken` (speakreward, speakmoney,
current coffee build): no token on the receipt → guard skipped. The server change
is inert for all current traffic and only "arms" once a client ships bound tokens.

## Review

An adversarial review caught a blocker: the Android **request** field is
`obfuscatedAccountId` (react-native-iap v15) — `obfuscatedAccountIdAndroid` is the
purchase **result** field and was silently dropped. Fixed + documented. Google
coverage was added symmetric to Apple. Guard compares case-insensitively (Apple
lowercases the UUID in the signed transaction).

## Tests

Server 352 + SDK 52 pass; 6 new route tests cover match (accepted) / mismatch
(409) on both platforms via a mock `#token=` convention.

## Deploy note

Server reaches prod only after publish + `findthem` bumping `@onesub/server`. SDK
is inert until coffee passes `accountToken` (a later client change / app rebuild).