### PR TITLE
Add Unity purchasing adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,13 @@
       "version": "0.1.0",
       "license": "MIT",
       "workspaces": [
-        "packages/*"
+        "packages/cli",
+        "packages/dashboard",
+        "packages/mcp-server",
+        "packages/providers",
+        "packages/sdk",
+        "packages/server",
+        "packages/shared"
       ],
       "devDependencies": {
         "@changesets/cli": "^2.31.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,13 @@
   "private": true,
   "description": "One subscription. That's it. AI-native subscription + paywall for mobile apps.",
   "workspaces": [
-    "packages/*"
+    "packages/cli",
+    "packages/dashboard",
+    "packages/mcp-server",
+    "packages/providers",
+    "packages/sdk",
+    "packages/server",
+    "packages/shared"
   ],
   "scripts": {
     "build": "npm run build -w @onesub/shared && npm run build -w @onesub/providers && npm run build -w @onesub/server && npm run build -w @jeonghwanko/onesub-sdk && npm run build -w @onesub/mcp-server && npm run build -w @onesub/cli",

--- a/packages/unity/Editor.meta
+++ b/packages/unity/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 05a8a433cb63bc14580873119ef58683
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/unity/Editor/OneSubDependencies.xml
+++ b/packages/unity/Editor/OneSubDependencies.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dependencies>
+  <androidPackages>
+    <androidPackage spec="com.google.android.play:review:2.0.2" />
+  </androidPackages>
+</dependencies>

--- a/packages/unity/Editor/OneSubDependencies.xml.meta
+++ b/packages/unity/Editor/OneSubDependencies.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5029555c6bb4eec4ba720ca8226afcb9
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/unity/README.md
+++ b/packages/unity/README.md
@@ -1,0 +1,12 @@
+# onesub Unity SDK
+
+Unity IAP purchases are sent to a self-hosted onesub server before the store
+transaction is confirmed. This prevents content from being granted when server
+validation fails and lets unconfirmed purchases be retried after reconnecting.
+
+The host game must set `OneSubPurchasing.UserIdProvider` and configure a non-empty
+server URL before making production purchases.
+
+`OneSubPlatformServices` is the optional game-services/review/sharing adapter used
+by PenguinRun. Sharing requires `com.unitynative.sharing` to be installed by the
+host project because that Git package is not available from Unity's registry.

--- a/packages/unity/README.md.meta
+++ b/packages/unity/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b3d8901bde847914596d413bf6437eec
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/unity/Runtime.meta
+++ b/packages/unity/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 16e4344173df38842bb8b2d1d3730380
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/unity/Runtime/OneSub.Unity.asmdef
+++ b/packages/unity/Runtime/OneSub.Unity.asmdef
@@ -1,0 +1,9 @@
+{
+  "name": "OneSub.Unity",
+  "rootNamespace": "OneSub.Unity",
+  "references": [
+    "Unity.Purchasing",
+    "UnityNative.Sharing"
+  ],
+  "autoReferenced": true
+}

--- a/packages/unity/Runtime/OneSub.Unity.asmdef.meta
+++ b/packages/unity/Runtime/OneSub.Unity.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d86a812d6cb87eb499dfe0c823344307
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/unity/Runtime/OneSubClient.cs
+++ b/packages/unity/Runtime/OneSubClient.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace OneSub.Unity
+{
+    public sealed class OneSubClient
+    {
+        [Serializable]
+        private sealed class ValidationRequest
+        {
+            public string platform;
+            public string receipt;
+            public string userId;
+            public string productId;
+            public string type;
+        }
+
+        public string ServerUrl { get; set; }
+        public int TimeoutSeconds { get; set; } = 15;
+
+        public OneSubClient(string serverUrl)
+        {
+            ServerUrl = (serverUrl ?? string.Empty).TrimEnd('/');
+        }
+
+        public IEnumerator Validate(
+            string receipt,
+            string userId,
+            string productId,
+            OneSubProductType productType,
+            Action<OneSubValidationResult> completed)
+        {
+            if (string.IsNullOrWhiteSpace(ServerUrl))
+            {
+                completed?.Invoke(Failure("ONESUB_NOT_CONFIGURED", "onesub server URL is empty."));
+                yield break;
+            }
+
+            if (string.IsNullOrWhiteSpace(userId))
+            {
+                completed?.Invoke(Failure("USER_ID_REQUIRED", "A stable signed-in user ID is required."));
+                yield break;
+            }
+
+            if (string.IsNullOrWhiteSpace(receipt))
+            {
+                completed?.Invoke(Failure("NO_RECEIPT_DATA", "The store returned no receipt or purchase token."));
+                yield break;
+            }
+
+            var request = new ValidationRequest
+            {
+                platform = PlatformName,
+                receipt = receipt,
+                userId = userId,
+                productId = productId,
+                type = ApiType(productType)
+            };
+            var path = productType == OneSubProductType.Subscription
+                ? "/onesub/validate"
+                : "/onesub/purchase/validate";
+            var json = JsonUtility.ToJson(request);
+
+            using var webRequest = new UnityWebRequest(ServerUrl + path, UnityWebRequest.kHttpVerbPOST);
+            webRequest.uploadHandler = new UploadHandlerRaw(System.Text.Encoding.UTF8.GetBytes(json));
+            webRequest.downloadHandler = new DownloadHandlerBuffer();
+            webRequest.timeout = TimeoutSeconds;
+            webRequest.SetRequestHeader("Content-Type", "application/json");
+
+            yield return webRequest.SendWebRequest();
+
+            if (webRequest.result != UnityWebRequest.Result.Success)
+            {
+                var body = webRequest.downloadHandler.text;
+                var serverFailure = Parse(body);
+                completed?.Invoke(serverFailure ?? Failure(
+                    "NETWORK_ERROR",
+                    string.IsNullOrWhiteSpace(body) ? webRequest.error : body));
+                yield break;
+            }
+
+            completed?.Invoke(Parse(webRequest.downloadHandler.text) ??
+                Failure("INVALID_SERVER_RESPONSE", "onesub returned an invalid or empty response."));
+        }
+
+        private static string PlatformName
+        {
+            get
+            {
+#if UNITY_IOS
+                return "apple";
+#else
+                return "google";
+#endif
+            }
+        }
+
+        private static string ApiType(OneSubProductType type)
+        {
+            return type switch
+            {
+                OneSubProductType.Consumable => "consumable",
+                OneSubProductType.NonConsumable => "non_consumable",
+                _ => "subscription"
+            };
+        }
+
+        private static OneSubValidationResult Failure(string code, string message)
+        {
+            return new OneSubValidationResult { valid = false, errorCode = code, error = message };
+        }
+
+        private static OneSubValidationResult Parse(string json)
+        {
+            if (string.IsNullOrWhiteSpace(json)) return null;
+            try
+            {
+                return JsonUtility.FromJson<OneSubValidationResult>(json);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/packages/unity/Runtime/OneSubClient.cs.meta
+++ b/packages/unity/Runtime/OneSubClient.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d63a1b7088017fc41b722e065b5142aa

--- a/packages/unity/Runtime/OneSubPlatformServices.cs
+++ b/packages/unity/Runtime/OneSubPlatformServices.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections;
+using System.IO;
+using UnityEngine;
+using UnityEngine.SocialPlatforms;
+using UnityNative.Sharing;
+
+namespace OneSub.Unity
+{
+    public sealed class OneSubPlatformServices : MonoBehaviour
+    {
+        private static OneSubPlatformServices instance;
+
+        public static OneSubPlatformServices Instance
+        {
+            get
+            {
+                if (instance != null) return instance;
+                var gameObject = new GameObject("OneSubPlatformServices");
+                instance = gameObject.AddComponent<OneSubPlatformServices>();
+                DontDestroyOnLoad(gameObject);
+                return instance;
+            }
+        }
+
+        public bool IsAuthenticated => Social.localUser.authenticated;
+
+        public void Authenticate(Action<bool> completed)
+        {
+            if (IsAuthenticated)
+            {
+                completed?.Invoke(true);
+                return;
+            }
+            Social.localUser.Authenticate(completed);
+        }
+
+        public void ReportScore(string leaderboardId, long score, Action<bool> completed = null)
+        {
+            Social.ReportScore(score, leaderboardId, completed);
+        }
+
+        public void ReportAchievement(string achievementId, double progress, Action<bool> completed = null)
+        {
+            Social.ReportProgress(achievementId, progress, completed);
+        }
+
+        public void ShowLeaderboards() => Social.ShowLeaderboardUI();
+        public void ShowAchievements() => Social.ShowAchievementsUI();
+
+        public void ShareText(string text)
+        {
+            UnityNativeSharing.Create().ShareText(text ?? string.Empty);
+        }
+
+        public void ShareScreenshot(string text, string url, Action completed = null, Action<string> failed = null)
+        {
+            StartCoroutine(CaptureAndShare(text, url, completed, failed));
+        }
+
+        public void RequestReview(string storeUrl = null)
+        {
+#if UNITY_IOS && !UNITY_EDITOR
+            UnityEngine.iOS.Device.RequestStoreReview();
+#elif UNITY_ANDROID && !UNITY_EDITOR
+            RequestGooglePlayReview(storeUrl);
+#else
+            if (!string.IsNullOrWhiteSpace(storeUrl)) Application.OpenURL(storeUrl);
+#endif
+        }
+
+#if UNITY_ANDROID && !UNITY_EDITOR
+        private void RequestGooglePlayReview(string fallbackUrl)
+        {
+            try
+            {
+                using var unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer");
+                var activity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity");
+                using var factory = new AndroidJavaClass("com.google.android.play.core.review.ReviewManagerFactory");
+                var manager = factory.CallStatic<AndroidJavaObject>("create", activity);
+                var requestTask = manager.Call<AndroidJavaObject>("requestReviewFlow");
+                requestTask.Call<AndroidJavaObject>("addOnCompleteListener",
+                    new ReviewTaskListener(task =>
+                    {
+                        if (!task.Call<bool>("isSuccessful"))
+                        {
+                            if (!string.IsNullOrWhiteSpace(fallbackUrl)) Application.OpenURL(fallbackUrl);
+                            return;
+                        }
+                        var reviewInfo = task.Call<AndroidJavaObject>("getResult");
+                        var launchTask = manager.Call<AndroidJavaObject>("launchReviewFlow", activity, reviewInfo);
+                        launchTask.Call<AndroidJavaObject>("addOnCompleteListener",
+                            new ReviewTaskListener(_ => { }));
+                    }));
+            }
+            catch (Exception exception)
+            {
+                Debug.LogWarning($"[onesub] In-app review unavailable: {exception.Message}");
+                if (!string.IsNullOrWhiteSpace(fallbackUrl)) Application.OpenURL(fallbackUrl);
+            }
+        }
+
+        private sealed class ReviewTaskListener : AndroidJavaProxy
+        {
+            private readonly Action<AndroidJavaObject> completed;
+
+            public ReviewTaskListener(Action<AndroidJavaObject> completed)
+                : base("com.google.android.gms.tasks.OnCompleteListener")
+            {
+                this.completed = completed;
+            }
+
+            public void onComplete(AndroidJavaObject task) => completed?.Invoke(task);
+        }
+#endif
+
+        private static IEnumerator CaptureAndShare(string text, string url, Action completed, Action<string> failed)
+        {
+            yield return new WaitForEndOfFrame();
+            var path = Path.Combine(Application.temporaryCachePath, "onesub-share.png");
+            try
+            {
+                var texture = ScreenCapture.CaptureScreenshotAsTexture();
+                File.WriteAllBytes(path, texture.EncodeToPNG());
+                Destroy(texture);
+                var body = string.IsNullOrWhiteSpace(url) ? text : $"{text}\n{url}";
+                UnityNativeSharing.Create().ShareScreenshotAndText(body, path);
+                completed?.Invoke();
+            }
+            catch (Exception exception)
+            {
+                failed?.Invoke(exception.Message);
+            }
+        }
+    }
+}

--- a/packages/unity/Runtime/OneSubPlatformServices.cs.meta
+++ b/packages/unity/Runtime/OneSubPlatformServices.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ec9ab742c3e5cfc4ebfa30e3d015d72b

--- a/packages/unity/Runtime/OneSubPurchasing.cs
+++ b/packages/unity/Runtime/OneSubPurchasing.cs
@@ -1,0 +1,278 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.Purchasing;
+
+namespace OneSub.Unity
+{
+    public sealed class OneSubPurchasing : MonoBehaviour
+    {
+        private static OneSubPurchasing instance;
+        private readonly Dictionary<string, OneSubProductType> productTypes = new();
+        private readonly HashSet<string> validationsInFlight = new();
+        private StoreController storeController;
+        private OneSubClient client;
+
+        public static OneSubPurchasing Instance
+        {
+            get
+            {
+                if (instance != null) return instance;
+                var gameObject = new GameObject("OneSubPurchasing");
+                instance = gameObject.AddComponent<OneSubPurchasing>();
+                DontDestroyOnLoad(gameObject);
+                return instance;
+            }
+        }
+
+        public static OneSubPurchasing ExistingInstance => instance;
+
+        public Func<string> UserIdProvider { get; set; }
+        public bool IsInitialized { get; private set; }
+        public event Action<bool> Initialized;
+        public event Action<string, OneSubValidationResult> PurchaseSucceeded;
+        public event Action<string, string> PurchaseFailed;
+        public event Action<string, bool> SubscriptionChanged;
+
+        public async void Initialize(
+            IEnumerable<OneSubProductDefinition> products,
+            string serverUrl,
+            Func<string> userIdProvider)
+        {
+            UserIdProvider = userIdProvider;
+            client = new OneSubClient(serverUrl);
+            productTypes.Clear();
+            foreach (var definition in products ?? Array.Empty<OneSubProductDefinition>())
+            {
+                if (!string.IsNullOrWhiteSpace(definition?.id))
+                    productTypes[definition.id] = definition.type;
+            }
+
+            DetachStoreEvents();
+            storeController = UnityIAPServices.StoreController();
+            AttachStoreEvents();
+            storeController.ProcessPendingOrdersOnPurchasesFetched(true);
+
+            try
+            {
+                await storeController.Connect();
+            }
+            catch (Exception exception)
+            {
+                FailInitialization(exception.Message);
+            }
+        }
+
+        public void Buy(string productId)
+        {
+            if (!IsInitialized || storeController == null)
+            {
+                PurchaseFailed?.Invoke(productId, "The store is not initialized.");
+                return;
+            }
+            if (GetProduct(productId) == null)
+            {
+                PurchaseFailed?.Invoke(productId, $"Product '{productId}' was not returned by the store.");
+                return;
+            }
+            if (string.IsNullOrWhiteSpace(UserIdProvider?.Invoke()))
+            {
+                PurchaseFailed?.Invoke(productId, "Sign in before purchasing so onesub can bind the receipt to an account.");
+                return;
+            }
+            storeController.PurchaseProduct(productId);
+        }
+
+        public void RestorePurchases()
+        {
+            if (storeController == null)
+            {
+                PurchaseFailed?.Invoke(string.Empty, "The store is not initialized.");
+                return;
+            }
+            storeController.FetchPurchases();
+        }
+
+        public Product GetProduct(string productId)
+        {
+            return storeController?.GetProducts().FirstOrDefault(product =>
+                string.Equals(product.definition.id, productId, StringComparison.Ordinal));
+        }
+
+        public string GetLocalizedPrice(string productId)
+        {
+            return GetProduct(productId)?.metadata?.localizedPriceString;
+        }
+
+        private void OnStoreConnected()
+        {
+            var products = productTypes.Select(pair =>
+                new ProductDefinition(pair.Key, ToUnityType(pair.Value))).ToList();
+            storeController.FetchProducts(products);
+        }
+
+        private void OnProductsFetched(List<Product> products)
+        {
+            IsInitialized = true;
+            Initialized?.Invoke(true);
+            storeController.FetchPurchases();
+        }
+
+        private void OnProductsFetchFailed(ProductFetchFailed failure)
+        {
+            FailInitialization(failure.FailureReason.ToString());
+        }
+
+        private void OnStoreDisconnected(StoreConnectionFailureDescription failure)
+        {
+            if (!IsInitialized) FailInitialization(failure.message);
+        }
+
+        private void OnPurchasePending(PendingOrder order)
+        {
+            ValidateOrder(order, true);
+        }
+
+        private void OnPurchasesFetched(Orders orders)
+        {
+            foreach (var order in orders?.ConfirmedOrders ?? Array.Empty<ConfirmedOrder>())
+            {
+                var productId = ProductId(order);
+                if (productTypes.TryGetValue(productId, out var type) && type != OneSubProductType.Consumable)
+                    ValidateOrder(order, false);
+            }
+        }
+
+        private void OnPurchasesFetchFailed(PurchasesFetchFailureDescription failure)
+        {
+            PurchaseFailed?.Invoke(string.Empty, failure.Message);
+        }
+
+        private void OnPurchaseFailed(FailedOrder order)
+        {
+            PurchaseFailed?.Invoke(ProductId(order), $"{order.FailureReason}: {order.Details}");
+        }
+
+        private void OnPurchaseDeferred(DeferredOrder order)
+        {
+            PurchaseFailed?.Invoke(ProductId(order), "Purchase is pending store or parental approval.");
+        }
+
+        private void ValidateOrder(Order order, bool confirmAfterValidation)
+        {
+            var productId = ProductId(order);
+            if (!productTypes.TryGetValue(productId, out var type))
+            {
+                PurchaseFailed?.Invoke(productId, "The order contains an unknown product.");
+                return;
+            }
+
+            var receipt = ReceiptToken(order);
+            var key = string.IsNullOrWhiteSpace(order.Info.TransactionID)
+                ? $"{productId}:{receipt}"
+                : order.Info.TransactionID;
+            if (!validationsInFlight.Add(key)) return;
+            StartCoroutine(ValidateOrderCoroutine(order, type, receipt, key, confirmAfterValidation));
+        }
+
+        private IEnumerator ValidateOrderCoroutine(
+            Order order,
+            OneSubProductType type,
+            string receipt,
+            string validationKey,
+            bool confirmAfterValidation)
+        {
+            OneSubValidationResult result = null;
+            yield return client.Validate(
+                receipt,
+                UserIdProvider?.Invoke(),
+                ProductId(order),
+                type,
+                value => result = value);
+            validationsInFlight.Remove(validationKey);
+
+            var productId = ProductId(order);
+            if (type == OneSubProductType.Subscription && result != null)
+                SubscriptionChanged?.Invoke(productId, result.IsEntitled);
+
+            if (result == null || !result.IsEntitled)
+            {
+                PurchaseFailed?.Invoke(productId, result?.error ?? "onesub rejected the receipt.");
+                yield break;
+            }
+
+            if (confirmAfterValidation && order is PendingOrder pendingOrder)
+            {
+                PurchaseSucceeded?.Invoke(productId, result);
+                storeController.ConfirmPurchase(pendingOrder);
+            }
+        }
+
+        private static string ProductId(Order order)
+        {
+            return order?.CartOrdered?.Items().FirstOrDefault()?.Product?.definition?.id ?? string.Empty;
+        }
+
+        private static string ReceiptToken(Order order)
+        {
+#if UNITY_IOS && !UNITY_EDITOR
+            return order?.Info?.Apple?.jwsRepresentation ?? string.Empty;
+#else
+            // Unity IAP uses the Google purchase token as TransactionID.
+            return order?.Info?.TransactionID ?? string.Empty;
+#endif
+        }
+
+        private static ProductType ToUnityType(OneSubProductType type)
+        {
+            return type switch
+            {
+                OneSubProductType.Consumable => ProductType.Consumable,
+                OneSubProductType.NonConsumable => ProductType.NonConsumable,
+                _ => ProductType.Subscription
+            };
+        }
+
+        private void FailInitialization(string message)
+        {
+            IsInitialized = false;
+            Debug.LogError($"[onesub] Store initialization failed: {message}");
+            Initialized?.Invoke(false);
+        }
+
+        private void AttachStoreEvents()
+        {
+            storeController.OnStoreConnected += OnStoreConnected;
+            storeController.OnStoreDisconnected += OnStoreDisconnected;
+            storeController.OnProductsFetched += OnProductsFetched;
+            storeController.OnProductsFetchFailed += OnProductsFetchFailed;
+            storeController.OnPurchasesFetched += OnPurchasesFetched;
+            storeController.OnPurchasesFetchFailed += OnPurchasesFetchFailed;
+            storeController.OnPurchasePending += OnPurchasePending;
+            storeController.OnPurchaseFailed += OnPurchaseFailed;
+            storeController.OnPurchaseDeferred += OnPurchaseDeferred;
+        }
+
+        private void DetachStoreEvents()
+        {
+            if (storeController == null) return;
+            storeController.OnStoreConnected -= OnStoreConnected;
+            storeController.OnStoreDisconnected -= OnStoreDisconnected;
+            storeController.OnProductsFetched -= OnProductsFetched;
+            storeController.OnProductsFetchFailed -= OnProductsFetchFailed;
+            storeController.OnPurchasesFetched -= OnPurchasesFetched;
+            storeController.OnPurchasesFetchFailed -= OnPurchasesFetchFailed;
+            storeController.OnPurchasePending -= OnPurchasePending;
+            storeController.OnPurchaseFailed -= OnPurchaseFailed;
+            storeController.OnPurchaseDeferred -= OnPurchaseDeferred;
+        }
+
+        private void OnDestroy()
+        {
+            DetachStoreEvents();
+            if (instance == this) instance = null;
+        }
+    }
+}

--- a/packages/unity/Runtime/OneSubPurchasing.cs.meta
+++ b/packages/unity/Runtime/OneSubPurchasing.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d367e8096f5f52b458275fb99bd32e82

--- a/packages/unity/Runtime/OneSubTypes.cs
+++ b/packages/unity/Runtime/OneSubTypes.cs
@@ -1,0 +1,63 @@
+using System;
+
+namespace OneSub.Unity
+{
+    public enum OneSubProductType
+    {
+        Consumable,
+        NonConsumable,
+        Subscription
+    }
+
+    [Serializable]
+    public sealed class OneSubProductDefinition
+    {
+        public string id;
+        public OneSubProductType type;
+
+        public OneSubProductDefinition(string id, OneSubProductType type)
+        {
+            this.id = id;
+            this.type = type;
+        }
+    }
+
+    [Serializable]
+    public sealed class OneSubSubscription
+    {
+        public string userId;
+        public string productId;
+        public string platform;
+        public string status;
+        public string expiresAt;
+        public string originalTransactionId;
+        public string purchasedAt;
+        public bool willRenew;
+    }
+
+    [Serializable]
+    public sealed class OneSubPurchase
+    {
+        public string userId;
+        public string productId;
+        public string platform;
+        public string type;
+        public string transactionId;
+        public string purchasedAt;
+        public int quantity;
+    }
+
+    [Serializable]
+    public sealed class OneSubValidationResult
+    {
+        public bool valid;
+        public OneSubSubscription subscription;
+        public OneSubPurchase purchase;
+        public string action;
+        public string error;
+        public string errorCode;
+
+        public bool IsEntitled => valid &&
+            (subscription == null || subscription.status == "active" || subscription.status == "grace_period");
+    }
+}

--- a/packages/unity/Runtime/OneSubTypes.cs.meta
+++ b/packages/unity/Runtime/OneSubTypes.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2014f3acde503d74e86f6bd16e258add

--- a/packages/unity/Tests.meta
+++ b/packages/unity/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1d4b871acf1ee7d438a6d630ae1aaa1b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/unity/Tests/Editor.meta
+++ b/packages/unity/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 62049dd4bccd94f4da29dfd49faf6944
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/unity/Tests/Editor/OneSub.Unity.Tests.asmdef
+++ b/packages/unity/Tests/Editor/OneSub.Unity.Tests.asmdef
@@ -1,0 +1,12 @@
+{
+  "name": "OneSub.Unity.Tests",
+  "references": [
+    "OneSub.Unity"
+  ],
+  "optionalUnityReferences": [
+    "TestAssemblies"
+  ],
+  "includePlatforms": [
+    "Editor"
+  ]
+}

--- a/packages/unity/Tests/Editor/OneSub.Unity.Tests.asmdef.meta
+++ b/packages/unity/Tests/Editor/OneSub.Unity.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d5a679e762a9f7645ab74f5b66ab7fcc
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/packages/unity/Tests/Editor/OneSubValidationResultTests.cs
+++ b/packages/unity/Tests/Editor/OneSubValidationResultTests.cs
@@ -1,0 +1,36 @@
+using NUnit.Framework;
+
+namespace OneSub.Unity.Tests
+{
+    public class OneSubValidationResultTests
+    {
+        [TestCase("active", true)]
+        [TestCase("grace_period", true)]
+        [TestCase("expired", false)]
+        [TestCase("canceled", false)]
+        [TestCase("on_hold", false)]
+        [TestCase("paused", false)]
+        public void SubscriptionEntitlementMatchesServerLifecycle(string status, bool expected)
+        {
+            var result = new OneSubValidationResult
+            {
+                valid = true,
+                subscription = new OneSubSubscription { status = status }
+            };
+
+            Assert.That(result.IsEntitled, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void InvalidOneTimePurchaseIsNotEntitled()
+        {
+            var result = new OneSubValidationResult
+            {
+                valid = false,
+                purchase = new OneSubPurchase()
+            };
+
+            Assert.That(result.IsEntitled, Is.False);
+        }
+    }
+}

--- a/packages/unity/Tests/Editor/OneSubValidationResultTests.cs.meta
+++ b/packages/unity/Tests/Editor/OneSubValidationResultTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2ec6c1b19db852e4390fcf95415f738a

--- a/packages/unity/package.json
+++ b/packages/unity/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "com.onesub.unity",
+  "version": "0.1.0",
+  "displayName": "onesub Unity SDK",
+  "description": "Unity IAP adapter with server-side receipt validation for onesub.",
+  "unity": "2022.3",
+  "author": {
+    "name": "onesub"
+  },
+  "dependencies": {
+    "com.unity.purchasing": "5.4.0"
+  }
+}

--- a/packages/unity/package.json.meta
+++ b/packages/unity/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5560977ab0ef52b43afd8fccd6c5bdd8
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds a Unity 2022.3+ adapter around Unity IAP 5.4 with fail-closed onesub receipt validation, purchase restore handling, platform service wrappers, Android review dependency resolution, and EditMode tests. Excludes the Unity package from npm workspaces so npm does not interpret UPM dependencies. Validation: 68 focused server/SDK tests passed; Unity package tests are exercised in the consuming PenguinRun PR.