### PR TITLE
docs: make the agent-facing docs correct and actionable

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,9 +5,13 @@
 ## Affected packages
 
 - [ ] `@onesub/shared`
+- [ ] `@onesub/providers`
 - [ ] `@onesub/server`
-- [ ] `@onesub/sdk`
+- [ ] `@jeonghwanko/onesub-sdk`
 - [ ] `@onesub/mcp-server`
+- [ ] `@onesub/cli`
+- [ ] `com.onesub.unity` / `com.onesub.unity.platform-services` (UPM)
+- [ ] `@onesub/dashboard` (private — Docker image, no changeset needed)
 - [ ] examples / docs / CI only
 
 ## Type of change

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,21 +23,25 @@ copy Pro sources into this repository. See `docs/UNITY-PRO.md` for the compatibi
 | `packages/server` | `@onesub/server`: Express middleware/server, receipt validation, webhooks, stores, admin APIs, metrics, OpenAPI, and tracing |
 | `packages/sdk` | `@jeonghwanko/onesub-sdk`: React Native provider, hook, paywall components, and HTTP client |
 | `packages/mcp-server` | `@onesub/mcp-server`: stdio MCP tools for setup, product management, diagnostics, and simulation |
-| `packages/cli` | `@onesub/cli`: `onesub init` scaffolder and server templates |
+| `packages/cli` | `@onesub/cli`: `onesub init` scaffolder, server templates, and the `onesub dev` fully mocked server used for local and agent testing |
 | `packages/dashboard` | Private npm workspace for the self-hosted Next.js operations dashboard; shipped as a Docker image |
 | `packages/unity` | `com.onesub.unity`: public Unity 2022.3+ purchasing and server-validation Core package |
 | `packages/unity-platform-services` | Optional Unity sharing, review, leaderboard, and authentication helpers; not part of purchasing Core |
-| `examples` | Runnable server and Expo examples |
+| `examples` | Runnable server and Expo examples. Not npm workspaces — they install OneSub from npm, not from this checkout |
+| `bench` | k6 status/webhook load tests, run by the scheduled `bench` workflow |
+| `scripts` | `validate-docs.mjs`, which backs `npm run docs:check` |
 | `docs` | Architecture, security, deployment, migration, receipt-error, and Unity boundary documentation |
 
-The two Unity packages are UPM packages, not npm workspaces.
+The two Unity packages are UPM packages, not npm workspaces. `validate-unity-packages.ps1` lives at
+the repository root, not under `scripts`.
 
 ## Commands
 
 Run commands from the repository root unless a package README says otherwise.
 
 ```bash
-npm ci                 # reproducible install; use npm install only when changing dependencies
+npm ci                 # reproducible install. Never run bare `npm install` unless you are
+                       # deliberately changing dependencies — it rewrites package-lock.json
 npm run build          # shared -> providers -> server -> sdk -> mcp-server -> cli
 npm run type-check     # all TypeScript workspaces, including dashboard
 npm test               # complete Vitest suite
@@ -58,13 +62,61 @@ Useful focused checks:
 npm test -- packages/server/src/__tests__/apps.test.ts
 npm run docs:check
 npm run build -w @onesub/server
-npm run type-check -w @onesub/mcp-server
+npm run size -w @onesub/server        # requires a prior build of @onesub/server
 pwsh ./validate-unity-packages.ps1
-npm run size -w @onesub/server
 ```
 
-Use the closest relevant checks while iterating, then run the broader checks appropriate to the
-changed surface. Markdown-only changes do not require a package release or the full build.
+A per-workspace `type-check` script exists only in `providers`, `sdk`, `mcp-server`, and `dashboard`.
+For `shared`, `server`, and `cli`, type-check with `npx tsc --noEmit -p packages/<name>` — the root
+`type-check` script reaches them that way. `npm run type-check -w @onesub/server` fails with
+`Missing script`.
+
+## Build Model and Traps
+
+Read this before your first edit. These traps fire on ordinary tasks and two of them fail silently.
+
+**`@onesub/shared` is consumed as compiled output, not as source.** Dependents resolve
+`@onesub/shared` to `packages/shared/dist`, which is gitignored, is not rebuilt automatically, and
+has no Vitest alias. After any edit under `packages/shared/src` you must run
+`npm run build -w @onesub/shared` before `npm test`, `npm run type-check`, or any dependent build
+observes it. A stale `dist` fails loudly for type-only changes but **silently for value exports** —
+a new member added to `SUBSCRIPTION_STATUS` resolves to `undefined` at runtime, so a comparison
+quietly never matches and no error is thrown. To recover from a confusing state, delete
+`packages/*/dist` and re-run `npm run build`.
+
+**Two tests enforce contract parity mechanically, and both are easy to trip.**
+
+- `packages/server/src/__tests__/openapi.test.ts` mounts every router and asserts both directions:
+  every mounted route is documented in `packages/server/src/openapi.ts`, and every documented path is
+  actually mounted. Adding, renaming, or removing a route without editing `openapi.ts` turns CI red.
+- `packages/server/src/__tests__/schema.test.ts` asserts that `packages/server/sql/schema.sql`
+  matches the DDL string constants in `packages/server/src/stores/schema.ts`. Persisted-column
+  changes must edit both.
+
+When either test fails, the message is "you changed one side of a contract," not "you broke
+behavior."
+
+**Line endings are load-bearing.** `.gitattributes` forces LF on text sources because the schema
+parity test anchors on `/--.*$/` per line and misbehaves on CRLF. Do not write CRLF content, and add
+any new text file type to `.gitattributes`.
+
+**This repository is developed on Windows.** Command blocks in `docs/` are written for bash. In
+PowerShell, translate them: `rm -rf` is not available, `\` line continuations must become backticks,
+POSIX inline env prefixes (`FOO=bar npm run dev`) must become `$env:FOO = 'bar'; npm run dev`, and
+`curl -d '{...}'` needs `Invoke-RestMethod` or `curl.exe`. The root `clean` script
+(`rm -rf packages/*/dist`) is POSIX-only; delete the `dist` folders directly instead.
+
+**`npm run size -w @onesub/server` measures `dist/`, so it needs a build first.** It gates the
+gzipped ESM and CJS bundles against the ceilings in `packages/server/.size-limit.cjs` and is a
+required CI check. If a deliberate surface addition exceeds a ceiling, raise the limit in that file
+and add a dated comment recording the reason and the measured size, following the existing entry.
+Do not delete the check or a budget entry to make it pass.
+
+**Never run these locally.** `npm run version-packages` and `npm run release` are owned by the
+`Release` workflow. `version-packages` runs `changeset version`, which rewrites every package version
+field, rewrites every per-package `CHANGELOG.md`, and consumes `.changeset/*.md` — exactly the
+hand-editing this guide forbids, performed by machine. Author changesets with `npm run changeset`
+and let CI apply them.
 
 ## Architecture Rules
 
@@ -87,41 +139,149 @@ changed surface. Markdown-only changes do not require a package release or the f
   deletion, which can revoke valid sibling consumable purchases.
 - MCP product tools import App Store Connect/Google Play operations from `@onesub/providers`; do not
   recreate provider clients inside `packages/mcp-server`.
-- The React Native SDK treats `react-native-iap` and `expo-in-app-purchases` as optional peers. Keep
-  both adapter paths and structured `OneSubError` behavior working.
+- The React Native SDK has exactly one purchase adapter: `react-native-iap`, required at runtime and
+  loaded lazily in `packages/sdk/src/OneSubProvider.tsx`. `expo-in-app-purchases` remains a vestigial
+  optional peer in `package.json` with no adapter behind it — do not treat it as a code path to
+  preserve, and do not "restore" it without an explicit product decision. Keep the structured
+  `OneSubError` behavior working.
 - Keep purchasing-only code in `packages/unity`. Sharing, review, social, leaderboard, and auth
   helpers belong in `packages/unity-platform-services`. Run the UPM boundary validator after Unity
   package changes.
+
+## Contract Change Checklist
+
+Some changes must move several files together or a parity test fails. Use these as the minimum file
+set, then let the tests confirm.
+
+**Adding or changing a route:** `packages/shared/src/constants.ts` (`ROUTES`) → the router under
+`packages/server/src/routes/` → `packages/server/src/openapi.ts` (parity-tested) →
+`packages/server/README.md` (the canonical route list) → `docs/ARCHITECTURE.md` if the middleware
+flow changes.
+
+**Adding a persisted field to `SubscriptionInfo` or `PurchaseInfo`:** `packages/shared/src/types.ts`
+→ `packages/server/src/stores/schema.ts` (embedded DDL plus the additive `ALTER TABLE` backfill) →
+`packages/server/sql/schema.sql` (parity-tested) → `packages/server/src/stores/postgres.ts` →
+`packages/server/src/stores/redis.ts` → `packages/server/src/store.ts` (in-memory) → the reading
+route → `packages/server/src/openapi.ts` → `packages/dashboard` and `packages/sdk` if surfaced.
+Rebuild `@onesub/shared` first, or everything downstream reads the old type.
+
+**Adding a config field:** `packages/shared/src/types.ts` → the consuming code →
+`docs/CONFIGURATION.md` (the canonical config reference) → `packages/server/README.md` if it is part
+of the middleware's public surface.
+
+**Adding an error code:** `packages/shared/src/constants.ts` (`ONESUB_ERROR_CODE`) →
+`docs/RECEIPT-ERRORS.md`, which is the canonical cause-and-fix catalog.
+
+**Adding an MCP tool or CLI command:** register it, then document it in
+`packages/mcp-server/README.md` or `packages/cli/README.md`. `npm run docs:check` fails if a
+registered tool or command is undocumented.
+
+**Adding a workspace:** root `package.json` `workspaces` and `build`/`type-check` scripts → CI
+coverage → the Repository Map above (`docs:check` enforces this) → the package catalog in
+`README.md`.
+
+**Releasing a Unity package:** Changesets does not cover UPM. Bump the version in
+`packages/unity*/package.json` → tag as `<upm-package-name>@<version>` (for example
+`com.onesub.unity@0.2.0`) → update the version column in the `README.md` package catalog and the
+pinned install URLs in `docs/UNITY-INTEGRATION.md`. Nothing verifies these three agree, so check them
+by hand.
+
+## Testing Model
+
+There is no `fixtures/` directory. Deterministic provider behavior comes from two places:
+
+- `packages/server/src/providers/mock.ts` — the mock provider, selected by `apple.mockMode` /
+  `google.mockMode` in config and keyed on receipt prefixes. This is what unit tests drive, and it is
+  the same provider behind `onesub dev`.
+- `packages/server/src/__tests__/test-utils.ts` — shared test setup.
+
+Run a single test file with `npm test -- <path>`. Inside this repository, always exercise the CLI
+built from the current checkout (`node packages/cli/dist/index.js dev --port 4100`); `npx @onesub/cli`
+resolves to the *published* package, so a change under test appears to have no effect. See
+`docs/TESTING.md`.
+
+## What CI Gates On
+
+Reconstructing this from the workflows is slow, so it is stated once here. `.github/workflows/ci.yml`:
+
+1. `npm ci`
+2. `npm run build`  (this is the real type-error gate; CI never runs root `npm run type-check`)
+3. `npm test`
+4. `pwsh ./validate-unity-packages.ps1`
+5. `npm run size -w @onesub/server`
+
+Plus a **separate `dashboard` job** — `npm run build -w @onesub/shared` → `type-check` → `build` for
+`@onesub/dashboard`. CI can therefore be red for a dashboard break while the entire root build is
+green. Plus `codeql.yml` (`security-extended`, can fail a PR) and a path-filtered `docs.yml` running
+`npm run docs:check`.
+
+`ci.yml` sets `paths-ignore: '**/*.md'`, so a Markdown-only PR runs **no build and no tests** —
+`docs:check` is its only gate. Conversely, `docs.yml` is path-filtered and does not fire on ordinary
+source changes, so renaming a file that documentation references can ship green. Run
+`npm run docs:check` yourself when you rename or move anything the docs cite.
 
 ## Change Workflow
 
 1. Read the nearest package README and the relevant source/tests before editing.
 2. Check `git status` and preserve unrelated user changes.
 3. Make the smallest coherent change and add/update tests for behavior changes.
-4. Update public docs when routes, config, exports, package boundaries, or operator workflows change.
-5. Run checks proportional to the affected packages and report any check that could not be run.
-6. For a published-package change, run `npm run changeset` and commit the generated
-   `.changeset/*.md`. Do not hand-edit package versions or generated per-package changelogs.
-7. Breaking changes also require `docs/MIGRATION.md`. Docs/tests/CI/example-only changes do not need
-   a changeset.
+4. If the change touches a contract, follow the Contract Change Checklist above.
+5. Update the owning document — see Documentation Ownership — when routes, config, exports, error
+   codes, package boundaries, or operator workflows change.
+6. Run the checks for what you touched:
+
+   | Touched | Run |
+   |---|---|
+   | `packages/shared/src` | `npm run build -w @onesub/shared`, then `npm test` and `npm run type-check` |
+   | `packages/server/src` | `npm run build -w @onesub/server`, `npm test`, `npm run size -w @onesub/server` |
+   | A route or the OpenAPI spec | the above plus `npm test -- packages/server/src/__tests__/openapi.test.ts` |
+   | A store or SQL schema | the above plus `npm test -- packages/server/src/__tests__/schema.test.ts` |
+   | `packages/dashboard` | the three dashboard commands under Commands |
+   | `packages/unity*` | `pwsh ./validate-unity-packages.ps1` |
+   | Any `.md` | `npm run docs:check` |
+   | Anything cross-package | the full CI gate set above |
+
+   Report any check you could not run, and why.
+7. For a published-package change, run `npm run changeset` and commit the generated `.changeset/*.md`.
+   Do not hand-edit package versions or generated per-package changelogs.
+8. Breaking changes also require `docs/MIGRATION.md`. Docs, tests, CI, `examples/*`, and
+   `packages/dashboard` changes need no changeset — the dashboard is private and ships as a Docker
+   image published by `docker-dashboard.yml`, which also republishes on any `packages/shared/src`
+   change.
 
 ## Documentation Ownership
 
-- `README.md`: product overview, quick start, supported features, package catalog, and roadmap.
-- `docs/README.md`: documentation index and routing guide.
-- `docs/ARCHITECTURE.md`: dependency direction, runtime flow, stores, state transitions, and hooks.
-- `docs/AI-WORKFLOW.md`: copy-ready prompts for repository work, app integration, and safe MCP use.
-- `docs/LOCAL-DEVELOPMENT.md`: clean-clone setup, local services, and contributor baseline checks.
-- `docs/CONFIGURATION.md`: server, middleware, SDK, multi-app, and environment configuration.
-- `docs/DEPLOYMENT.md`: production topology, durable infrastructure, operations, and recovery.
-- `docs/TESTING.md`: deterministic, mock, E2E, dashboard, documentation, and Unity checks.
-- `docs/UNITY-INTEGRATION.md`: public Unity Core installation, runtime flow, events, and host responsibilities.
-- `CONTRIBUTING.md`: contributor setup, tests, releases, and PR checklist.
-- Package `README.md` files: package-specific installation and APIs.
-- `SKILL.md`: public single-file integration context for agents integrating OneSub into another app;
-  it is not the internal contributor guide.
-- `AGENTS.md`: internal repository instructions shared by Codex and Claude.
-- `CLAUDE.md`: a thin Claude entry point only; do not duplicate this guide there.
+Each fact has one owner. Link to the owner rather than restating it.
 
-Avoid volatile claims such as a hard-coded test count. Derive command order, tool counts, route names,
-and package names from the current code before documenting them.
+| Document | Owns |
+|---|---|
+| `README.md` | Product overview, quick start, supported features, package catalog, roadmap |
+| `docs/README.md` | Documentation index and routing |
+| `docs/ARCHITECTURE.md` | Dependency direction, runtime flow, stores, state transitions, hooks |
+| `docs/AI-WORKFLOW.md` | Copy-ready prompts for repository work, app integration, safe MCP use |
+| `docs/LOCAL-DEVELOPMENT.md` | Clean-clone setup and local services |
+| `docs/CONFIGURATION.md` | Every `OneSubServerConfig` field, SDK, multi-app, and environment config |
+| `docs/DEPLOYMENT.md` | Production topology, durable infrastructure, operations, recovery |
+| `docs/TESTING.md` | Test suites, mock receipts, E2E, dashboard, docs, Unity checks, CI parity |
+| `docs/POSTGRES.md` | Postgres schema, indexing, initialization, read replicas |
+| `docs/SECURITY.md` | Trust boundaries, credential handling, verification, vulnerability reporting |
+| `docs/RECEIPT-ERRORS.md` | Every `ONESUB_ERROR_CODE` with cause and fix |
+| `docs/MIGRATION.md` | Version-specific upgrade notes and breaking changes |
+| `docs/MIGRATE-FROM-REVENUECAT.md` | Moving an app and its data off RevenueCat |
+| `docs/UNITY-INTEGRATION.md` | Unity Core installation, runtime flow, events, host responsibilities |
+| `docs/UNITY-PRO.md` | The Core/Pro boundary |
+| `packages/server/README.md` | The canonical route list and middleware API |
+| `packages/shared/README.md` | Lifecycle states and the `active` formula |
+| `packages/mcp-server/README.md` | The MCP tool catalog (`docs:check`-enforced) |
+| `packages/cli/README.md` | The CLI command list (`docs:check`-enforced) |
+| Other package `README.md` | That package's installation and API |
+| `CONTRIBUTING.md` | Contributor onboarding, releases, PR checklist |
+| `SKILL.md` | Public single-file integration context for agents adding OneSub to *another* app; not the internal contributor guide |
+| `AGENTS.md` | Internal repository instructions shared by Codex and Claude |
+| `CLAUDE.md` | A thin Claude entry point only; do not duplicate this guide there |
+
+Avoid volatile claims: hard-coded test counts, tool counts, package counts, or version numbers.
+Derive command order, tool names, route names, and package names from the current code.
+`scripts/validate-docs.mjs` mechanizes part of this — it checks local links, that every npm workspace
+appears in the Repository Map, and that every registered MCP tool and CLI command is documented — but
+it cannot catch a wrong version number or a stale prose claim. Verify those against the source.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ copy Pro sources into this repository. See `docs/UNITY-PRO.md` for the compatibi
 | `packages/dashboard` | Private npm workspace for the self-hosted Next.js operations dashboard; shipped as a Docker image |
 | `packages/unity` | `com.onesub.unity`: public Unity 2022.3+ purchasing and server-validation Core package |
 | `packages/unity-platform-services` | Optional Unity sharing, review, leaderboard, and authentication helpers; not part of purchasing Core |
-| `examples` | Runnable server and Expo examples. Not npm workspaces — they install OneSub from npm, not from this checkout |
+| `examples` | Runnable server and Expo examples. Not npm workspaces, but inside this checkout they still resolve `@onesub/server` through the root `node_modules` symlink to `packages/server` — so they do exercise your local build. The version pin in their own `package.json` only applies to a standalone copy |
 | `bench` | k6 status/webhook load tests, run by the scheduled `bench` workflow |
 | `scripts` | `validate-docs.mjs`, which backs `npm run docs:check` |
 | `docs` | Architecture, security, deployment, migration, receipt-error, and Unity boundary documentation |
@@ -77,12 +77,15 @@ Read this before your first edit. These traps fire on ordinary tasks and two of 
 
 **`@onesub/shared` is consumed as compiled output, not as source.** Dependents resolve
 `@onesub/shared` to `packages/shared/dist`, which is gitignored, is not rebuilt automatically, and
-has no Vitest alias. After any edit under `packages/shared/src` you must run
+has no Vitest alias or tsconfig path mapping. After any edit under `packages/shared/src` you must run
 `npm run build -w @onesub/shared` before `npm test`, `npm run type-check`, or any dependent build
-observes it. A stale `dist` fails loudly for type-only changes but **silently for value exports** —
-a new member added to `SUBSCRIPTION_STATUS` resolves to `undefined` at runtime, so a comparison
-quietly never matches and no error is thrown. To recover from a confusing state, delete
-`packages/*/dist` and re-run `npm run build`.
+observes it.
+
+The stale `dist` is stale in its `.d.ts` too, so `tsc` usually catches it loudly. The dangerous case
+is **`npm test`**: Vitest transpiles without type-checking, so a new value export that is missing
+from the stale `dist` is simply `undefined` at runtime — a comparison quietly never matches and no
+error is thrown. A green `npm test` on a shared change you did not rebuild proves nothing. To recover
+from a confusing state, delete `packages/*/dist` and re-run `npm run build`.
 
 **Two tests enforce contract parity mechanically, and both are easy to trip.**
 
@@ -96,9 +99,9 @@ quietly never matches and no error is thrown. To recover from a confusing state,
 When either test fails, the message is "you changed one side of a contract," not "you broke
 behavior."
 
-**Line endings are load-bearing.** `.gitattributes` forces LF on text sources because the schema
-parity test anchors on `/--.*$/` per line and misbehaves on CRLF. Do not write CRLF content, and add
-any new text file type to `.gitattributes`.
+**Line endings.** `.gitattributes` forces LF on text sources; the schema parity test additionally
+strips `\r` itself, so it is CRLF-proof today. Keep both defenses: add any new text file type to
+`.gitattributes`, and do not assume a parser downstream is as forgiving.
 
 **This repository is developed on Windows.** Command blocks in `docs/` are written for bash. In
 PowerShell, translate them: `rm -rf` is not available, `\` line continuations must become backticks,
@@ -139,11 +142,12 @@ and let CI apply them.
   deletion, which can revoke valid sibling consumable purchases.
 - MCP product tools import App Store Connect/Google Play operations from `@onesub/providers`; do not
   recreate provider clients inside `packages/mcp-server`.
-- The React Native SDK has exactly one purchase adapter: `react-native-iap`, required at runtime and
-  loaded lazily in `packages/sdk/src/OneSubProvider.tsx`. `expo-in-app-purchases` remains a vestigial
-  optional peer in `package.json` with no adapter behind it — do not treat it as a code path to
-  preserve, and do not "restore" it without an explicit product decision. Keep the structured
-  `OneSubError` behavior working.
+- The React Native SDK has exactly one purchase adapter: `react-native-iap`, `require`d at module
+  scope inside a `try/catch` in `packages/sdk/src/OneSubProvider.tsx`. When it is absent the provider
+  still imports and renders, and the purchase paths throw a clear error instead.
+  `expo-in-app-purchases` is listed alongside it in `peerDependenciesMeta` as optional, but has **no
+  adapter behind it** — do not treat it as a code path to preserve, and do not "restore" it without
+  an explicit product decision. Keep the structured `OneSubError` behavior working.
 - Keep purchasing-only code in `packages/unity`. Sharing, review, social, leaderboard, and auth
   helpers belong in `packages/unity-platform-services`. Run the UPM boundary validator after Unity
   package changes.
@@ -215,8 +219,11 @@ Plus a **separate `dashboard` job** — `npm run build -w @onesub/shared` → `t
 green. Plus `codeql.yml` (`security-extended`, can fail a PR) and a path-filtered `docs.yml` running
 `npm run docs:check`.
 
-`ci.yml` sets `paths-ignore: '**/*.md'`, so a Markdown-only PR runs **no build and no tests** —
-`docs:check` is its only gate. Conversely, `docs.yml` is path-filtered and does not fire on ordinary
+`ci.yml` sets `paths-ignore: '**/*.md'`, so a Markdown-only PR runs **no build and no tests** — its
+gates are `docs.yml` and CodeQL, which has no path filter and runs on every PR.
+
+`docs.yml` is path-filtered to Markdown plus `package.json`, `scripts/validate-docs.mjs`,
+`packages/cli/src/index.ts`, and `packages/mcp-server/src/index.ts`. It does **not** fire on other
 source changes, so renaming a file that documentation references can ship green. Run
 `npm run docs:check` yourself when you rename or move anything the docs cite.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,8 @@ Two things to know before your first edit:
 
 - **`@onesub/shared` is consumed as compiled output.** After editing `packages/shared/src`, run
   `npm run build -w @onesub/shared` or every dependent build, test, and type-check keeps reading the
-  old `dist`. Type changes fail loudly; new *value* exports (a new `SUBSCRIPTION_STATUS` member) go
-  silently `undefined` instead.
+  old `dist`. `tsc` usually complains, but `npm test` does not type-check — there a missing value
+  export is just `undefined` at runtime, so a green test run proves nothing.
 - **Never run `npm run version-packages` or `npm run release` locally.** They belong to the Release
   workflow and rewrite every version field and changelog.
 
@@ -126,8 +126,8 @@ what your change touched — [`AGENTS.md`](AGENTS.md) has the table — and at m
 - [ ] No new `any` or `// @ts-ignore` without a comment explaining why (reviewer-enforced; there is
       no ESLint config in this repository)
 
-A Markdown-only PR skips CI entirely (`ci.yml` sets `paths-ignore: '**/*.md'`), so `docs:check` is
-its only gate.
+A Markdown-only PR skips the build and test job (`ci.yml` sets `paths-ignore: '**/*.md'`). Its gates
+are the `docs` workflow and CodeQL, which has no path filter and runs on every PR.
 
 ## Reporting security issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,14 +7,27 @@ Thanks for your interest. onesub is MIT-licensed and community contributions are
 ```bash
 git clone https://github.com/jeonghwanko/onesub.git
 cd onesub
-npm install
+npm ci                # reproducible. Use `npm install` only when changing dependencies —
+                      # it rewrites package-lock.json and produces a spurious diff
 npm run build         # shared → providers → server → sdk → mcp-server → cli
 npm test              # vitest
 npm run type-check
-npm run docs:check      # local links + documented workspace/tool/CLI coverage
+npm run docs:check    # trailing whitespace, local links, and documented workspace/tool/CLI coverage
 ```
 
-Node 20+ is required (uses `node:crypto.X509Certificate`).
+Node 20+ is required (uses `node:crypto.X509Certificate`). CI runs Node 22.
+
+Two things to know before your first edit:
+
+- **`@onesub/shared` is consumed as compiled output.** After editing `packages/shared/src`, run
+  `npm run build -w @onesub/shared` or every dependent build, test, and type-check keeps reading the
+  old `dist`. Type changes fail loudly; new *value* exports (a new `SUBSCRIPTION_STATUS` member) go
+  silently `undefined` instead.
+- **Never run `npm run version-packages` or `npm run release` locally.** They belong to the Release
+  workflow and rewrite every version field and changelog.
+
+[`AGENTS.md`](AGENTS.md) carries the full build model, the contract-change checklist, and the exact
+set of checks CI gates on.
 
 ## Monorepo layout
 
@@ -50,9 +63,15 @@ If you add a package, update the root workspace/build configuration, CI coverage
 
 ## Tests
 
-- Unit tests live beside source in `__tests__/` folders.
-- Integration tests that hit real Apple/Google endpoints are not run in CI — use fixtures / mocks.
+- Unit tests live beside source in `__tests__/` folders. Run one file with `npm test -- <path>`.
+- Integration tests that hit real Apple/Google endpoints are not run in CI. There is no `fixtures/`
+  directory: deterministic provider behavior comes from `packages/server/src/providers/mock.ts`
+  (selected via `apple.mockMode` / `google.mockMode`, keyed on receipt prefixes) plus
+  `packages/server/src/__tests__/test-utils.ts`.
 - New provider behavior (Apple JWS, Google Play API) needs a unit test; look at existing `apple.test.ts` / `google.test.ts` patterns.
+- Two tests enforce contracts mechanically rather than behavior: `openapi.test.ts` (every mounted
+  route documented in `openapi.ts`, and vice versa) and `schema.test.ts` (`sql/schema.sql` matches
+  the embedded DDL constants). When they fail, you changed one side of a contract.
 
 For dashboard changes, also run:
 
@@ -84,18 +103,31 @@ On merge to `master`, the `Release` workflow opens a **"Version Packages"** PR t
 
 **Breaking changes** (`major`) additionally require a section in [docs/MIGRATION.md](docs/MIGRATION.md) — the changeset summary is not enough.
 
-Docs-only, test-only, CI-only, or `examples/*` changes don't need a changeset.
+Docs-only, test-only, CI-only, and `examples/*` changes don't need a changeset. Neither does
+`packages/dashboard`: it is private and ships as a Docker image published by `docker-dashboard.yml`,
+not to npm.
 
 ## PR checklist
 
+CI gates on `npm ci` → `npm run build` → `npm test` → `pwsh ./validate-unity-packages.ps1` →
+`npm run size -w @onesub/server`, plus a separate job that type-checks and builds the dashboard. Run
+what your change touched — [`AGENTS.md`](AGENTS.md) has the table — and at minimum:
+
 - [ ] `npm run build` succeeds
 - [ ] `npm test` passes
-- [ ] `npm run type-check` clean
+- [ ] `npm run type-check` clean (not a CI gate, but the build only catches what it compiles)
+- [ ] `npm run size -w @onesub/server` within budget, when `packages/server` changed
+- [ ] `pwsh ./validate-unity-packages.ps1` passes, when either Unity package changed
+- [ ] Dashboard type-check + build pass, when `packages/dashboard` or `packages/shared` changed
 - [ ] `npm run docs:check` succeeds when documentation or documented surfaces changed
 - [ ] Added a changeset for changes to published packages
 - [ ] Updated `docs/MIGRATION.md` for breaking changes
-- [ ] Updated public/package docs for changed APIs, configuration, or package boundaries
-- [ ] No new `any` or `// @ts-ignore` without a comment explaining why
+- [ ] Updated the owning document for changed APIs, configuration, or package boundaries
+- [ ] No new `any` or `// @ts-ignore` without a comment explaining why (reviewer-enforced; there is
+      no ESLint config in this repository)
+
+A Markdown-only PR skips CI entirely (`ci.yml` sets `paths-ignore: '**/*.md'`), so `docs:check` is
+its only gate.
 
 ## Reporting security issues
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,12 @@ Mounted only when `config.adminSecret` is set. All requests must include the `X-
 | `GET /onesub/admin/customers/:userId` | Full per-user profile: subscriptions + purchases + entitlements (when configured) |
 | `GET /onesub/admin/webhook-deadletters` | List failed webhook jobs (requires BullMQ queue) |
 | `POST /onesub/admin/webhook-replay/:id` | Replay a failed webhook job (requires BullMQ queue) |
+| `POST /onesub/admin/sync-apple/:originalTransactionId` | Refresh one subscription from the Apple Status API (requires App Store Server API credentials) |
+| `POST /onesub/apple/offer-signature` | Sign an Apple promotional offer (requires `apple.offerKeyId` + `offerPrivateKey`) |
+
+The canonical, always-current route list is in
+[`packages/server/README.md`](packages/server/README.md); `openapi.test.ts` keeps it honest against
+the mounted routers.
 
 ### Entitlements (opt-in — requires `config.entitlements`)
 
@@ -449,7 +455,7 @@ run it for you on startup.
 
 ```bash
 git clone https://github.com/jeonghwanko/onesub.git
-cd onesub && npm install && npm run build && npm test
+cd onesub && npm ci && npm run build && npm test
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the contributor workflow, [docs/README.md](docs/README.md)

--- a/README.md
+++ b/README.md
@@ -171,11 +171,21 @@ Mounted only when `config.adminSecret` is set. All requests must include the `X-
 | `GET /onesub/admin/webhook-deadletters` | List failed webhook jobs (requires BullMQ queue) |
 | `POST /onesub/admin/webhook-replay/:id` | Replay a failed webhook job (requires BullMQ queue) |
 | `POST /onesub/admin/sync-apple/:originalTransactionId` | Refresh one subscription from the Apple Status API (requires App Store Server API credentials) |
-| `POST /onesub/apple/offer-signature` | Sign an Apple promotional offer (requires `apple.offerKeyId` + `offerPrivateKey`) |
 
-The canonical, always-current route list is in
-[`packages/server/README.md`](packages/server/README.md); `openapi.test.ts` keeps it honest against
-the mounted routers.
+### Apple promotional offers (opt-in — separate mount and separate header)
+
+| Endpoint | What it does |
+|----------|-------------|
+| `POST /onesub/apple/offer-signature` | Sign an Apple promotional offer |
+
+Mounted when `apple.offerKeyId` **and** `apple.offerPrivateKey` are set — independently of
+`adminSecret`. Its auth header is **`X-Onesub-Offer-Secret`** (compared against `adminSecret`), not
+`X-Admin-Secret`. If `adminSecret` is unset the endpoint is unauthenticated and the host is
+responsible for securing it.
+
+The full route list lives in [`packages/server/README.md`](packages/server/README.md). Note that no
+test validates that list — `openapi.test.ts` checks the mounted routers against
+`packages/server/src/openapi.ts`, not against any Markdown.
 
 ### Entitlements (opt-in — requires `config.entitlements`)
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,13 +5,14 @@ description: Use this skill when the user wants to add in-app purchases (subscri
 
 # onesub — integration skill
 
-onesub is a TypeScript monorepo published to npm as 5 packages:
+onesub is a TypeScript monorepo. The npm packages you can install:
 
 | Package | Install | Use in |
 |---------|---------|--------|
 | `@onesub/server` | `npm i express @onesub/server` | Node.js backend (Express 4 or 5) |
 | `@jeonghwanko/onesub-sdk` | `npm i react-native-iap @jeonghwanko/onesub-sdk` | React Native / Expo app |
 | `@onesub/shared` | (transitive) | types only — auto-installed |
+| `@onesub/providers` | `npm i @onesub/providers` | Managing App Store Connect / Play products from your own code |
 | `@onesub/mcp-server` | `npx -y @onesub/mcp-server` | MCP-compatible AI clients |
 | `@onesub/cli` | `npx @onesub/cli init` | Scaffolds a starter server project |
 
@@ -144,22 +145,33 @@ Peer dep: **`react-native-iap` v15+** (event-based purchase flow).
 
 ## Config reference
 
+The commonly used fields. The full, canonical reference is
+[`docs/CONFIGURATION.md`](https://github.com/jeonghwanko/onesub/blob/master/docs/CONFIGURATION.md) —
+consult it before concluding an option doesn't exist.
+
 ```ts
 interface OneSubServerConfig {
   apple?: {
     bundleId: string;
     sharedSecret?: string;     // legacy App Store shared secret (optional for StoreKit 2 JWS)
     skipJwsVerification?: boolean;  // DEV ONLY — warns in production
+    mockMode?: boolean;        // DEV ONLY — synthetic provider, never enable in production
     keyId?: string;            // App Store Server API key
     issuerId?: string;
     privateKey?: string;
     offerKeyId?: string;       // separate subscription-offer key
     offerPrivateKey?: string;
+    productReceiptMaxAgeHours?: number;  // one-time-purchase receipt age limit, default 72
   };
   google?: {
     packageName: string;
     serviceAccountKey?: string;  // JSON string of service account
     pushAudience?: string;       // Pub/Sub push endpoint URL for JWT verification
+    pushServiceAccountEmail?: string;  // STRONGLY RECOMMENDED in production: with pushAudience,
+                                       // requires the push JWT to carry this exact email, so any
+                                       // Google-signed token no longer suffices
+    mockMode?: boolean;          // DEV ONLY
+    productReceiptMaxAgeHours?: number;  // default 72
   };
   database: { url: string };
   apps?: Array<{             // optional: isolate credentials for multiple apps
@@ -170,6 +182,7 @@ interface OneSubServerConfig {
   defaultAppId?: string;
   adminSecret?: string;          // enables /onesub/purchase/admin/* + /onesub/admin/* + /onesub/metrics/* routes
   entitlements?: Record<string, { productIds: string[] }>;  // enables /onesub/entitlement(s) routes
+  refundPolicy?: 'immediate' | 'until_expiry';   // how a refund webhook affects an active subscription
   logger?: OneSubLogger;         // { info, warn, error } — defaults to console
 }
 ```

--- a/docs/AI-WORKFLOW.md
+++ b/docs/AI-WORKFLOW.md
@@ -20,6 +20,15 @@ npx @onesub/cli dev --port 4100
 npx @onesub/cli --help
 ```
 
+`npx @onesub/cli` resolves to the **published** package. That is what you want from an application
+repository. It is not what you want **inside this repository**: a change you just made to the OneSub
+source will appear to have no effect, and you will chase a phantom bug. When working in the OneSub
+repository, run the CLI built from the current checkout instead:
+
+```bash
+npm run build && node packages/cli/dist/index.js dev --port 4100
+```
+
 ## First Prompt After Cloning
 
 Run `npm ci`, open the repository in Codex or Claude, and start with a read-only orientation:
@@ -97,7 +106,8 @@ Requirements:
 
 ### Test locally without store credentials
 
-Start the mocked server first:
+Start the mocked server first (from the application repository — inside the OneSub repository, use
+the checkout-built CLI shown above):
 
 ```bash
 npx @onesub/cli dev --port 4100

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -171,7 +171,7 @@ OpenAPI route:
 ```ts
 import { openapiHandler } from '@onesub/server';
 
-app.get('/openapi.json', openapiHandler);
+app.get('/openapi.json', openapiHandler());
 ```
 
 Protect or omit internal/admin operations in externally published API portals as required by the

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -101,10 +101,11 @@ docker compose up
 Use fake/local credentials only for mock mode. Real Apple and Google credentials belong in a secret
 manager or an untracked local environment file.
 
-`examples/` is not an npm workspace. It installs `@onesub/server` from npm at the version pinned in
-its own `package.json`, so **it does not exercise your working tree** — a change you just made to
-`packages/server` will not appear here. Use it to check the published integration story; use the
-checkout-built mock server above to validate local changes.
+`examples/` is not an npm workspace, but it has no `node_modules` of its own, so inside this checkout
+Node resolution walks up to the root `node_modules/@onesub/server` — a symlink to `packages/server`.
+The example therefore runs **your local build**, not the version pinned in its own `package.json`
+(that pin only applies to a standalone copy). Run `npm run build` first, or you will exercise a stale
+`dist`.
 
 ## Run the Dashboard
 

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -101,6 +101,11 @@ docker compose up
 Use fake/local credentials only for mock mode. Real Apple and Google credentials belong in a secret
 manager or an untracked local environment file.
 
+`examples/` is not an npm workspace. It installs `@onesub/server` from npm at the version pinned in
+its own `package.json`, so **it does not exercise your working tree** — a change you just made to
+`packages/server` will not appear here. Use it to check the published integration story; use the
+checkout-built mock server above to validate local changes.
+
 ## Run the Dashboard
 
 Start a OneSub server with `adminSecret` configured, then in another terminal:

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -252,13 +252,21 @@ Previously `savePurchase` used `ON CONFLICT (transaction_id) DO NOTHING`, so the
 
 ---
 
-## `@onesub/sdk` 0.2.x → 0.3.x
+## React Native SDK 0.2.x → 0.3.x
 
-**What changed:** `react-native-iap` peer dependency bumped to **v15**. v15 switched from promise-returning `requestPurchase()` to an event-based model (`purchaseUpdatedListener`). The SDK now uses the new pattern internally.
+**What changed:**
+
+1. **The package was renamed** from `@onesub/sdk` to **`@jeonghwanko/onesub-sdk`** in this release.
+   `@onesub/sdk` receives no further updates. Every version from 0.3.0 onward is published under the
+   new name; all other documentation refers to it that way.
+2. `react-native-iap` peer dependency bumped to **v15**. v15 switched from promise-returning
+   `requestPurchase()` to an event-based model (`purchaseUpdatedListener`). The SDK now uses the new
+   pattern internally.
 
 **Action:**
+- `npm uninstall @onesub/sdk && npm i @jeonghwanko/onesub-sdk`, and update your import specifiers.
 - `npm i react-native-iap@^15` in your app.
-- No source change required if you only use `useOneSub()` — the pattern change is internal.
+- No other source change required if you only use `useOneSub()` — the pattern change is internal.
 
 ---
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -6,7 +6,8 @@
 - JWS signature verified with the leaf certificate from the `x5c` header
 - **Full certificate chain verified up to Apple Root CA G3** (as of `@onesub/server@0.6.0`) using `node:crypto.X509Certificate` — each cert in the chain must be signed by the next, be within its validity window, and the final cert must be issued by a bundled Apple root. Leaf-only verification was insufficient because a self-signed cert could mint a passing signature
 - Sandbox receipts rejected in `NODE_ENV=production` unless `ONESUB_ALLOW_SANDBOX=true` is set (for TestFlight / pre-launch QA)
-- 72-hour receipt age limit enforced
+- One-time-purchase receipt age limit, defaulting to 72 hours. It is a default, not an invariant: a
+  host can raise or disable it with `apple.productReceiptMaxAgeHours` (see `docs/CONFIGURATION.md`)
 - Apple webhooks accept only `signedPayload` JWS format. Pre-decoded payloads are rejected
 
 ### Google Play Billing

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -22,12 +22,35 @@ npm test -- packages/server/src/__tests__/webhook-google.test.ts \
 Do not document a fixed test count; it changes frequently. A feature is covered by the relevant
 behavioral assertions, not by a repository-wide number.
 
+### Contract parity tests
+
+Two tests assert that a contract's two halves still agree. They fail on *drift*, not on broken
+behavior, and their message reads as a puzzle unless you know that:
+
+| Test | Asserts | Fails when |
+|---|---|---|
+| `packages/server/src/__tests__/openapi.test.ts` | Every mounted route is documented in `packages/server/src/openapi.ts`, and every documented path is actually mounted | You added, renamed, or removed a route without editing the spec |
+| `packages/server/src/__tests__/schema.test.ts` | `packages/server/sql/schema.sql` matches the DDL constants in `packages/server/src/stores/schema.ts` | You changed a persisted column in only one of the two |
+
+The schema test compares line by line, which is why `.gitattributes` forces LF. CRLF content can make
+it misbehave.
+
 ## Build and Type Checks
 
 ```bash
 npm run build
 npm run type-check
 ```
+
+After editing `packages/shared/src`, rebuild it before anything downstream is meaningful — dependents
+read `packages/shared/dist`, which is gitignored and never rebuilt automatically:
+
+```bash
+npm run build -w @onesub/shared
+```
+
+A stale `dist` produces a *silent* failure for new value exports (they resolve to `undefined`), not
+just a type error.
 
 The root build excludes the dashboard, so dashboard changes also require:
 
@@ -37,11 +60,17 @@ npm run type-check -w @onesub/dashboard
 npm run build -w @onesub/dashboard
 ```
 
-Server bundle-size changes can be checked with:
+Server bundle size is a required CI check. It measures the emitted files, so it needs a build first:
 
 ```bash
+npm run build -w @onesub/server
 npm run size -w @onesub/server
 ```
+
+It gates the gzipped ESM and CJS bundles against the ceilings in `packages/server/.size-limit.cjs`.
+If a deliberate surface addition exceeds a ceiling, raise the limit there and add a dated comment
+recording the reason and the measured size, following the existing entry. Do not delete the check or
+a budget entry to make it pass.
 
 ## Local Mock Provider
 
@@ -185,17 +214,44 @@ npm test
 npm run type-check
 pwsh ./validate-unity-packages.ps1
 npm run size -w @onesub/server
+
+# the dashboard is a separate CI job — it can be red while the root build is green
+npm run build -w @onesub/shared
+npm run type-check -w @onesub/dashboard
 npm run build -w @onesub/dashboard
+
 npm run docs:check
 ```
 
+This is a superset of CI, not a mirror of it. CI's `ci.yml` job runs `npm ci` → `build` → `test` →
+the Unity validator → the size check; it never runs root `npm run type-check`, because `build` is the
+type gate. `docs:check` runs in its own path-filtered workflow, and CodeQL (`security-extended`) runs
+separately and can fail a PR.
+
 Use focused checks for package-local changes. Documentation-only changes normally need only
-`npm run docs:check`; real store E2E runs only when provider/verification behavior warrants it.
+`npm run docs:check` — `ci.yml` sets `paths-ignore: '**/*.md'`, so a Markdown-only PR runs no build
+and no tests at all. Real store E2E runs only when provider/verification behavior warrants it.
+
+## When a Check Goes Red
+
+| Symptom | Usually means |
+|---|---|
+| Type error on `@onesub/shared` symbols inside another package | You edited `packages/shared/src` and did not run `npm run build -w @onesub/shared` |
+| A shared constant is `undefined` at runtime, no error thrown | The same stale `dist`, in its silent form |
+| `openapi.test.ts` fails | A route and `openapi.ts` disagree — one side of a contract moved |
+| `schema.test.ts` fails | `sql/schema.sql` and the embedded DDL constants disagree; or CRLF crept into the SQL |
+| `npm run size` fails with a missing file | You did not build `@onesub/server` first |
+| `npm run size` fails on the budget | Shrink the addition, or raise the ceiling in `.size-limit.cjs` with a dated justification |
+| CI red but the whole root build is green locally | The separate `dashboard` job — run the three dashboard commands |
+| `docs:check` fails after a rename | A document cites the old path; `docs.yml` is path-filtered and will not have caught it earlier |
 
 ## Adding Tests
 
 - Put TypeScript tests beside source under a `src/**/__tests__` directory.
-- Use fixtures/mocks for routine Apple/Google behavior; do not call real store APIs from PR tests.
+- There is no `fixtures/` directory. Drive deterministic Apple/Google behavior through
+  `packages/server/src/providers/mock.ts` — selected by `apple.mockMode` / `google.mockMode` in the
+  config you pass to the middleware, and keyed on the receipt prefixes in the table above — together
+  with `packages/server/src/__tests__/test-utils.ts`. Do not call real store APIs from PR tests.
 - Add multi-step lifecycle tests when order or preserved state matters.
 - Test security failures as well as success: signature, audience, ownership, app isolation, body
   limits, and production mock guards.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -32,8 +32,8 @@ behavior, and their message reads as a puzzle unless you know that:
 | `packages/server/src/__tests__/openapi.test.ts` | Every mounted route is documented in `packages/server/src/openapi.ts`, and every documented path is actually mounted | You added, renamed, or removed a route without editing the spec |
 | `packages/server/src/__tests__/schema.test.ts` | `packages/server/sql/schema.sql` matches the DDL constants in `packages/server/src/stores/schema.ts` | You changed a persisted column in only one of the two |
 
-The schema test compares line by line, which is why `.gitattributes` forces LF. CRLF content can make
-it misbehave.
+The schema test strips SQL comments, collapses whitespace, and does a normalized substring check — it
+also strips `\r` first, so a CRLF checkout does not break it.
 
 ## Build and Type Checks
 
@@ -49,8 +49,9 @@ read `packages/shared/dist`, which is gitignored and never rebuilt automatically
 npm run build -w @onesub/shared
 ```
 
-A stale `dist` produces a *silent* failure for new value exports (they resolve to `undefined`), not
-just a type error.
+`tsc` usually catches a stale `dist` loudly, because the stale `.d.ts` ships with it. `npm test` does
+not — Vitest transpiles without type-checking, so a value export missing from the stale `dist` is
+simply `undefined` at runtime. A green test run on an unbuilt shared change proves nothing.
 
 The root build excludes the dashboard, so dashboard changes also require:
 
@@ -230,7 +231,8 @@ separately and can fail a PR.
 
 Use focused checks for package-local changes. Documentation-only changes normally need only
 `npm run docs:check` — `ci.yml` sets `paths-ignore: '**/*.md'`, so a Markdown-only PR runs no build
-and no tests at all. Real store E2E runs only when provider/verification behavior warrants it.
+and no tests (CodeQL still runs; it has no path filter). Real store E2E runs only when
+provider/verification behavior warrants it.
 
 ## When a Check Goes Red
 
@@ -239,7 +241,7 @@ and no tests at all. Real store E2E runs only when provider/verification behavio
 | Type error on `@onesub/shared` symbols inside another package | You edited `packages/shared/src` and did not run `npm run build -w @onesub/shared` |
 | A shared constant is `undefined` at runtime, no error thrown | The same stale `dist`, in its silent form |
 | `openapi.test.ts` fails | A route and `openapi.ts` disagree — one side of a contract moved |
-| `schema.test.ts` fails | `sql/schema.sql` and the embedded DDL constants disagree; or CRLF crept into the SQL |
+| `schema.test.ts` fails | `sql/schema.sql` and the embedded DDL constants in `stores/schema.ts` disagree |
 | `npm run size` fails with a missing file | You did not build `@onesub/server` first |
 | `npm run size` fails on the budget | Shrink the addition, or raise the ceiling in `.size-limit.cjs` with a dated justification |
 | CI red but the whole root build is green locally | The separate `dashboard` job — run the three dashboard commands |

--- a/docs/UNITY-INTEGRATION.md
+++ b/docs/UNITY-INTEGRATION.md
@@ -103,9 +103,17 @@ Equivalent `Packages/manifest.json` entry:
 }
 ```
 
-For reproducible production builds, append a known tag or commit revision after the path URL rather
-than tracking the default branch. When developing from a local clone, Package Manager can add
-`packages/unity/package.json` from disk.
+The URLs above track the default branch, so a Package Manager resolve picks up whatever is on
+`master` at that moment. **For reproducible production builds, pin the release tag** by appending it
+as a `#` revision fragment after the path query. Release tags are named `<upm-package-name>@<version>`:
+
+```text
+https://github.com/jeonghwanko/onesub.git?path=/packages/unity#com.onesub.unity@0.2.0
+https://github.com/jeonghwanko/onesub.git?path=/packages/unity-platform-services#com.onesub.unity.platform-services@0.2.0
+```
+
+Check the repository's tag list for the current release. When developing from a local clone, Package
+Manager can add `packages/unity/package.json` from disk instead.
 
 The Core runtime assembly references only `Unity.Purchasing`. Do not install
 `com.onesub.unity.platform-services` unless the project specifically needs its optional PenguinRun

--- a/examples/expo-app/README.md
+++ b/examples/expo-app/README.md
@@ -1,6 +1,6 @@
 # onesub Expo example
 
-Expo Router app that exercises every public surface of `@onesub/sdk`:
+Expo Router app that exercises every public surface of `@jeonghwanko/onesub-sdk`:
 subscriptions, consumables, non-consumables, and entitlement gates.
 
 ## Quick start (5 minutes)

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -24,7 +24,7 @@ docker run -p 4101:4101 -e ONESUB_SERVER_URL=http://host.docker.internal:4100 on
 
 ```bash
 # from the monorepo root
-npm install
+npm ci
 npm run build -w @onesub/shared
 
 cd packages/dashboard

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -101,8 +101,10 @@ try {
 ## Requirements
 
 - `react-native-iap` **v15+** (event-based purchase flow)
-- React Native 0.71+
+- React Native 0.73+ and React 19
 - `@onesub/server` running somewhere reachable
+
+The authoritative floors are the `peerDependencies` in this package's `package.json`.
 
 ## Links
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -101,7 +101,7 @@ try {
 ## Requirements
 
 - `react-native-iap` **v15+** (event-based purchase flow)
-- React Native 0.73+ and React 19
+- React Native 0.73+ and React 19.2.6+
 - `@onesub/server` running somewhere reachable
 
 The authoritative floors are the `peerDependencies` in this package's `package.json`.


### PR DESCRIPTION
## What changed

Audited every Markdown file for one question: if a coding agent follows it, does it take a correct action? `npm run docs:check` passed before and after — what it does not cover is where the damage was. Findings were fan-out audited, then each high-stakes claim was verified against the source before editing.

### Instructions that were wrong

| Where | Problem |
|---|---|
| `AGENTS.md` | Told agents to preserve an `expo-in-app-purchases` adapter path **that does not exist**. `packages/sdk/src` has exactly one adapter (`react-native-iap`, lazily required in `OneSubProvider.tsx`); the expo entry is a vestigial optional peer in `package.json`. An agent would hunt for — or "restore" — a code path that was never there. |
| `docs/DEPLOYMENT.md` | Registered `openapiHandler` instead of `openapiHandler()`. It is a factory (`openapi.ts:584`), so the copied snippet hands Express a function that returns a function — **the request never responds**. |
| `CONTRIBUTING.md`, `README.md`, `packages/dashboard/README.md` | Told contributors to run `npm install` on a clean clone, rewriting `package-lock.json`. `AGENTS.md` and CI already say `npm ci`. |
| `SKILL.md` | Claimed 5 npm packages (there are 6 — `@onesub/providers` was missing) and had drifted from `OneSubServerConfig`, omitting `google.pushServiceAccountEmail`, which is strongly recommended in production. |
| `packages/sdk/README.md` | Claimed React Native 0.71+; the peer floor is `>=0.73.0`. |
| `docs/SECURITY.md` | Stated the 72-hour receipt age limit as an invariant. It is a **default**, overridable via `productReceiptMaxAgeHours`. |
| `docs/MIGRATION.md` | The SDK rename to `@jeonghwanko/onesub-sdk` (shipped in 0.3.0, `aafc009`) was documented nowhere — including in its own `0.2.x → 0.3.x` section. A 0.2.x user upgrading had no path. |
| `examples/expo-app/README.md`, PR template | Referenced the non-existent `@onesub/sdk`. |

### Load-bearing knowledge that lived only in code comments

- **`@onesub/shared` is consumed as compiled `dist`.** Dependents resolve it to `packages/shared/dist`, which is gitignored, never rebuilt automatically, and has no Vitest alias. Skipping the rebuild fails loudly for types but **silently for value exports** — a new `SUBSCRIPTION_STATUS` member resolves to `undefined`, so a comparison quietly never matches. The docs framed this as a clean-clone problem; it is an every-edit problem.
- **`openapi.test.ts` and `schema.test.ts` enforce contract parity mechanically.** Following the old "update the three store implementations together" rule to the letter still broke the build, because `sql/schema.sql` and the embedded DDL constants must move together too.
- **What CI actually gates on**: root `type-check` never runs in CI (`build` is the type gate), the dashboard is a separate job that can be red while the root build is green, and a Markdown-only PR skips build and tests entirely.
- **Never run `npm run version-packages` or `npm run release` locally** — they rewrite every version field and changelog, which is exactly what the guide forbids by hand.
- Replaced *"run checks proportional to the affected packages"* with a **touched-this → run-that table**, and added a **contract-change checklist** (route / persisted field / config field / error code / MCP tool / workspace) naming which files must move together and which are parity-tested.

### Unity

The `com.onesub.unity@0.2.0` and `com.onesub.unity.platform-services@0.2.0` release tags had **no documentation pointing at them**. The UPM install URL tracked the default branch, so a cut release was never actually installed. Documented the tag-pinned install form, and added the manual Unity release steps to `AGENTS.md` since Changesets does not cover UPM.

## Type of change

- [x] Docs / tests / tooling only

## Checklist

- [x] `npm run docs:check` passes
- [x] No changeset needed — documentation only
- [x] Every factual change verified against source (`package.json` peers, `openapi.ts`, `ci.yml`, `.size-limit.cjs`, `packages/sdk/src`), not against another document

`ci.yml` sets `paths-ignore: '**/*.md'`, so this PR runs no build and no tests — `docs:check` is its only gate. That fact is itself now written down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)