### PR TITLE
feat(docs): machine-check the server route list against the OpenAPI spec

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,7 @@
 name: Docs
 
+# The trigger paths must list every input `scripts/validate-docs.mjs` reads, or a
+# source change can silently invalidate the docs and still ship green.
 on:
   push:
     branches: [master]
@@ -9,6 +11,8 @@ on:
       - 'scripts/validate-docs.mjs'
       - 'packages/cli/src/index.ts'
       - 'packages/mcp-server/src/index.ts'
+      - 'packages/server/src/openapi.ts'
+      - 'packages/shared/src/constants.ts'
       - '.github/workflows/docs.yml'
   pull_request:
     branches: [master]
@@ -18,6 +22,8 @@ on:
       - 'scripts/validate-docs.mjs'
       - 'packages/cli/src/index.ts'
       - 'packages/mcp-server/src/index.ts'
+      - 'packages/server/src/openapi.ts'
+      - 'packages/shared/src/constants.ts'
       - '.github/workflows/docs.yml'
 
 jobs:
@@ -28,5 +34,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 22
+      # No `npm ci`: validate-docs.mjs deliberately imports nothing outside
+      # node:fs/node:path/node:url. Keep it dependency-free or add an install step.
       - name: Validate documentation
         run: npm run docs:check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,8 +159,10 @@ set, then let the tests confirm.
 
 **Adding or changing a route:** `packages/shared/src/constants.ts` (`ROUTES`) → the router under
 `packages/server/src/routes/` → `packages/server/src/openapi.ts` (parity-tested) →
-`packages/server/README.md` (the canonical route list) → `docs/ARCHITECTURE.md` if the middleware
-flow changes.
+`packages/server/README.md` (the canonical route list, `docs:check`-enforced against the spec) →
+`docs/ARCHITECTURE.md` if the middleware flow changes. Both links in that chain are machine-checked,
+so a route cannot ship undocumented — but only `packages/server/README.md` is checked. Route tables in
+`README.md` and `SKILL.md` are prose and still drift by hand.
 
 **Adding a persisted field to `SubscriptionInfo` or `PurchaseInfo`:** `packages/shared/src/types.ts`
 → `packages/server/src/stores/schema.ts` (embedded DDL plus the additive `ALTER TABLE` backfill) →
@@ -277,7 +279,7 @@ Each fact has one owner. Link to the owner rather than restating it.
 | `docs/MIGRATE-FROM-REVENUECAT.md` | Moving an app and its data off RevenueCat |
 | `docs/UNITY-INTEGRATION.md` | Unity Core installation, runtime flow, events, host responsibilities |
 | `docs/UNITY-PRO.md` | The Core/Pro boundary |
-| `packages/server/README.md` | The canonical route list and middleware API |
+| `packages/server/README.md` | The canonical route list (`docs:check`-enforced) and middleware API |
 | `packages/shared/README.md` | Lifecycle states and the `active` formula |
 | `packages/mcp-server/README.md` | The MCP tool catalog (`docs:check`-enforced) |
 | `packages/cli/README.md` | The CLI command list (`docs:check`-enforced) |
@@ -289,6 +291,12 @@ Each fact has one owner. Link to the owner rather than restating it.
 
 Avoid volatile claims: hard-coded test counts, tool counts, package counts, or version numbers.
 Derive command order, tool names, route names, and package names from the current code.
-`scripts/validate-docs.mjs` mechanizes part of this — it checks local links, that every npm workspace
-appears in the Repository Map, and that every registered MCP tool and CLI command is documented — but
-it cannot catch a wrong version number or a stale prose claim. Verify those against the source.
+`scripts/validate-docs.mjs` mechanizes part of this. It checks local links and referenced file paths,
+that every npm workspace appears in the Repository Map, that every registered MCP tool and CLI command
+is documented, and that the route list in `packages/server/README.md` matches the OpenAPI spec — which
+`openapi.test.ts` in turn holds to the actually mounted routers. It cannot catch a wrong version
+number or a stale prose claim. Verify those against the source.
+
+When adding a check there, also add its inputs to the `paths` filter in `.github/workflows/docs.yml`,
+or the check will not run on the change that breaks it. Keep the script dependency-free: that workflow
+has no `npm ci` step.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ npm ci                # reproducible. Use `npm install` only when changing depen
 npm run build         # shared → providers → server → sdk → mcp-server → cli
 npm test              # vitest
 npm run type-check
-npm run docs:check    # trailing whitespace, local links, and documented workspace/tool/CLI coverage
+npm run docs:check    # links, workspace/tool/CLI coverage, and server route parity vs the OpenAPI spec
 ```
 
 Node 20+ is required (uses `node:crypto.X509Certificate`). CI runs Node 22.

--- a/README.md
+++ b/README.md
@@ -183,9 +183,10 @@ Mounted when `apple.offerKeyId` **and** `apple.offerPrivateKey` are set — inde
 `X-Admin-Secret`. If `adminSecret` is unset the endpoint is unauthenticated and the host is
 responsible for securing it.
 
-The full route list lives in [`packages/server/README.md`](packages/server/README.md). Note that no
-test validates that list — `openapi.test.ts` checks the mounted routers against
-`packages/server/src/openapi.ts`, not against any Markdown.
+The full route list lives in [`packages/server/README.md`](packages/server/README.md) and is
+machine-checked: `openapi.test.ts` asserts the mounted routers against
+`packages/server/src/openapi.ts`, and `npm run docs:check` asserts that spec against the README. A
+route cannot ship undocumented.
 
 ### Entitlements (opt-in — requires `config.entitlements`)
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -201,8 +201,13 @@ assembly references, dependencies, and separation of optional platform services.
 npm run docs:check
 ```
 
-This validates local Markdown links, trailing whitespace, npm workspace coverage in `AGENTS.md`, MCP
-tool documentation, and CLI command documentation. It requires no network access.
+This validates local Markdown links and referenced file paths, trailing whitespace, npm workspace
+coverage in `AGENTS.md`, MCP tool documentation, CLI command documentation, and the route list in
+`packages/server/README.md` against `packages/server/src/openapi.ts` — which `openapi.test.ts` in turn
+holds to the actually mounted routers. It requires no network access and no `npm ci`.
+
+If you add a check, add its inputs to the `paths` filter in `.github/workflows/docs.yml` too, or it
+will not run on the change that breaks it.
 
 ## CI-Parity Checklist
 

--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -135,6 +135,72 @@ async function validateMcpTools() {
   return compareSets('MCP tools', registered, documented);
 }
 
+// Canonical route names live in @onesub/shared as ROUTES; openapi.ts keys its
+// `paths` off them (or off a literal, for parameterized routes). openapi.test.ts
+// already asserts openapi.ts against the actually mounted routers, so binding
+// the server README to openapi.ts makes the whole chain machine-checked:
+// mounted routers -> openapi.ts -> packages/server/README.md.
+function parseRoutesConstant(source) {
+  const block = /export const ROUTES = \{([\s\S]*?)\n\} as const;/u.exec(source);
+  if (!block) throw new Error('could not locate ROUTES in packages/shared/src/constants.ts');
+  const routes = new Map();
+  for (const match of block[1].matchAll(/^\s*([A-Z_]+):\s*'([^']+)'/gmu)) {
+    routes.set(match[1], match[2]);
+  }
+  if (!routes.size) throw new Error('parsed no entries from ROUTES');
+  return routes;
+}
+
+// Express writes `:userId`, OpenAPI writes `{userId}`. Compare in one form.
+function canonicalPath(path) {
+  return path.split('?')[0].trim().replace(/\{([^}]+)\}/gu, ':$1');
+}
+
+function parseOpenApiOperations(source, routes) {
+  const operations = [];
+  let currentPath = null;
+  for (const line of source.split('\n')) {
+    const pathKey = /^ {4}(?:\[ROUTES\.([A-Z_]+)\]|'([^']+)'):\s*\{/u.exec(line);
+    if (pathKey) {
+      const [, routeName, literal] = pathKey;
+      if (routeName && !routes.has(routeName)) {
+        throw new Error(`openapi.ts references unknown ROUTES.${routeName}`);
+      }
+      currentPath = canonicalPath(routeName ? routes.get(routeName) : literal);
+      continue;
+    }
+    // Any other line at path-key depth closes the current block. Without this a
+    // path key we failed to parse would silently donate its methods to the
+    // previous route.
+    if (/^ {4}\S/u.test(line)) {
+      currentPath = null;
+      continue;
+    }
+    const method = /^ {6}(get|post|put|patch|delete):\s*\{/u.exec(line);
+    if (method && currentPath) operations.push(`${method[1].toUpperCase()} ${currentPath}`);
+  }
+  if (!operations.length) {
+    throw new Error('parsed no operations from packages/server/src/openapi.ts — the shape changed');
+  }
+  return operations;
+}
+
+async function validateServerRoutes() {
+  const constants = await readFile(join(root, 'packages/shared/src/constants.ts'), 'utf8');
+  const openapi = await readFile(join(root, 'packages/server/src/openapi.ts'), 'utf8');
+  const docs = await readFile(join(root, 'packages/server/README.md'), 'utf8');
+
+  const specified = parseOpenApiOperations(openapi, parseRoutesConstant(constants));
+
+  // Only middleware-mounted routes are compared. `/openapi.json` is mounted by
+  // the host via openapiHandler(), so it is documented without being in the spec.
+  const documented = [...docs.matchAll(/^\|\s*`(GET|POST|PUT|PATCH|DELETE)\s+([^`]+)`/gmu)]
+    .map((match) => `${match[1]} ${canonicalPath(match[2])}`)
+    .filter((entry) => entry.includes(' /onesub/'));
+
+  return compareSets('server routes', specified, documented);
+}
+
 async function validateCliCommands() {
   const source = await readFile(join(root, 'packages/cli/src/index.ts'), 'utf8');
   const docs = await readFile(join(root, 'packages/cli/README.md'), 'utf8');
@@ -149,6 +215,7 @@ await Promise.all(markdownFiles.map(validateMarkdown));
 const workspaceCount = await validateWorkspaceMap();
 const mcpToolCount = await validateMcpTools();
 const cliCommandCount = await validateCliCommands();
+const routeCount = await validateServerRoutes();
 
 if (failures.length) {
   console.error(`Documentation validation failed (${failures.length} issue${failures.length === 1 ? '' : 's'}):`);
@@ -158,5 +225,5 @@ if (failures.length) {
 
 console.log(
   `Documentation OK: ${markdownFiles.length} Markdown files, ${workspaceCount} workspaces, ` +
-  `${mcpToolCount} MCP tools, ${cliCommandCount} CLI commands.`,
+  `${mcpToolCount} MCP tools, ${cliCommandCount} CLI commands, ${routeCount} server routes.`,
 );


### PR DESCRIPTION
## Why

#107 had to admit, in prose, that nothing verified the route list in `packages/server/README.md`:

> Note that no test validates that list — `openapi.test.ts` checks the mounted routers against `packages/server/src/openapi.ts`, not against any Markdown.

That was the last hand-maintained link in the chain. `openapi.test.ts` already holds `openapi.ts` to the actually mounted routers in both directions — so binding the README to `openapi.ts` makes the whole path mechanical:

```
mounted routers  ──openapi.test.ts──▶  openapi.ts  ──docs:check──▶  packages/server/README.md
```

A route can no longer ship undocumented.

## How

`scripts/validate-docs.mjs` gains `validateServerRoutes()`. It parses `ROUTES` from `@onesub/shared`, resolves the `paths` keys of `openapi.ts` (both the computed `[ROUTES.X]` form and the literal parameterized form), normalizes Express `:param` against OpenAPI `{param}`, and compares bidirectionally with the README's route table using the existing `compareSets()`. 22 routes are covered.

`/openapi.json` is deliberately excluded: it is mounted by the host via `openapiHandler()`, not by the middleware, so it is documented without being in the spec.

## Proof that it bites

A check that only ever reports OK is worse than no check, so I broke it on purpose in three ways:

| Injected fault | Result |
|---|---|
| Delete a row from the README | `server routes: undocumented: POST /onesub/admin/sync-apple/:originalTransactionId` |
| Invent a row the server doesn't serve | `server routes: documented but not registered: GET /onesub/ghost/route` |
| Reindent `openapi.ts` so parsing fails | throws `parsed no operations from packages/server/src/openapi.ts — the shape changed`, exit 1 |

The last one matters: a text parser that silently matches nothing would turn this into a permanent green light. It fails closed instead. The parser also resets its current path on any line at path-key depth, so a key it fails to parse cannot silently donate its methods to the previous route.

## The trigger, which is half the work

`docs.yml`'s `paths` filter now includes `packages/server/src/openapi.ts` and `packages/shared/src/constants.ts`. Without that, a route change would not run the workflow that now depends on it — the check would exist and never fire. Added a comment to the workflow saying the filter must list every input the script reads, and why there is no `npm ci` step (the script is deliberately dependency-free).

## Docs

Updated the places that said the route list was unverified. Also stated plainly what is *still* prose: the route tables in `README.md` and `SKILL.md` are duplicates that drift by hand — only `packages/server/README.md` is enforced.

## Type of change

- [x] Docs / tests / tooling only — no changeset (no published package changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)