### PR TITLE
fix(server): treat Apple empty account token as absent

### DIFF
--- a/.changeset/calm-apples-bind.md
+++ b/.changeset/calm-apples-bind.md
@@ -1,0 +1,5 @@
+---
+'@onesub/server': patch
+---
+
+Treat Apple's all-zero `appAccountToken` as absent while preserving transaction ownership checks.

--- a/packages/server/src/__tests__/apple-status-api.test.ts
+++ b/packages/server/src/__tests__/apple-status-api.test.ts
@@ -239,7 +239,7 @@ describe('fetchAppleSubscriptionStatus', () => {
 // ── fetchAppleTransactionHistory pagination guards ──────────────────────────
 
 describe('fetchAppleTransactionHistory pagination guards', () => {
-  function historyTx(id: number): string {
+  function historyTx(id: number, appAccountToken?: string): string {
     return makeJws({
       bundleId: 'com.example.app',
       type: 'Auto-Renewable Subscription',
@@ -247,6 +247,7 @@ describe('fetchAppleTransactionHistory pagination guards', () => {
       transactionId: `tx_${id}`,
       originalTransactionId: 'orig_hist',
       purchaseDate: Date.now(),
+      appAccountToken,
     });
   }
 
@@ -320,6 +321,22 @@ describe('fetchAppleTransactionHistory pagination guards', () => {
     expect(counter.count()).toBe(3);
     expect(result).toHaveLength(3);
     expect(result?.map((t) => t.transactionId)).toEqual(['tx_0', 'tx_1', 'tx_2']);
+  });
+
+  it('normalizes Guid.Empty account tokens while preserving real tokens', async () => {
+    const emptyToken = '00000000-0000-0000-0000-000000000000';
+    const realToken = '123e4567-e89b-12d3-a456-426614174000';
+    mockHistoryFetch(() => ({
+      signedTransactions: [
+        historyTx(0, emptyToken),
+        historyTx(1, realToken),
+      ],
+      hasMore: false,
+    }));
+
+    const result = await fetchAppleTransactionHistory('orig_hist', appleConfigWithApi());
+
+    expect(result?.map((tx) => tx.appAccountToken)).toEqual([null, realToken]);
   });
 });
 

--- a/packages/server/src/__tests__/mock-provider.test.ts
+++ b/packages/server/src/__tests__/mock-provider.test.ts
@@ -13,6 +13,8 @@ import {
   mockValidateGoogleProduct,
 } from '../providers/mock.js';
 
+const EMPTY_APP_ACCOUNT_TOKEN = '00000000-0000-0000-0000-000000000000';
+
 /** Full onesub server in mockMode on both platforms — shared by the HTTP describes. */
 function mockApp() {
   const config: OneSubServerConfig = {
@@ -239,6 +241,28 @@ describe('full server in mockMode', () => {
     expect(res.body.errorCode).toBe(ONESUB_ERROR_CODE.TRANSACTION_BELONGS_TO_OTHER_USER);
   });
 
+  it('account-binding: Apple Guid.Empty is unbound, while transaction ownership still rejects a consumable replay', async () => {
+    const app = mockApp();
+    const body = {
+      platform: 'apple',
+      receipt: `MOCK_VALID_empty_guid#token=${EMPTY_APP_ACCOUNT_TOKEN}`,
+      userId: 'firebase-user-a',
+      productId: 'credits_100',
+      type: 'consumable',
+    };
+
+    const first = await request(app).post('/onesub/purchase/validate').send(body);
+    expect(first.status).toBe(200);
+    expect(first.body.action).toBe('new');
+
+    const replay = await request(app).post('/onesub/purchase/validate').send({
+      ...body,
+      userId: 'firebase-user-b',
+    });
+    expect(replay.status).toBe(409);
+    expect(replay.body.errorCode).toBe(ONESUB_ERROR_CODE.TRANSACTION_BELONGS_TO_OTHER_USER);
+  });
+
   it('account-binding: Google obfuscatedExternalAccountId matching userId is accepted', async () => {
     const app = mockApp();
     const res = await request(app).post('/onesub/purchase/validate').send({
@@ -267,12 +291,40 @@ describe('full server in mockMode', () => {
     expect(res.status).toBe(409);
     expect(res.body.errorCode).toBe(ONESUB_ERROR_CODE.TRANSACTION_BELONGS_TO_OTHER_USER);
   });
+
+  it('account-binding: Google keeps the all-zero string as a real bound account id', async () => {
+    const app = mockApp();
+    const res = await request(app).post('/onesub/purchase/validate').send({
+      platform: 'google',
+      receipt: `MOCK_VALID_google_zero#token=${EMPTY_APP_ACCOUNT_TOKEN}`,
+      userId: 'firebase-user',
+      productId: 'premium',
+      type: 'non_consumable',
+    });
+
+    expect(res.status).toBe(409);
+    expect(res.body.errorCode).toBe(ONESUB_ERROR_CODE.TRANSACTION_BELONGS_TO_OTHER_USER);
+  });
 });
 
 // ---------------------------------------------------------------------------
 // Subscription route account-binding (mirrors the one-time purchase guard)
 // ---------------------------------------------------------------------------
 describe('POST /onesub/validate — subscription account-binding', () => {
+  it('treats Apple Guid.Empty as an unbound subscription token', async () => {
+    const app = mockApp();
+    const res = await request(app).post('/onesub/validate').send({
+      platform: 'apple',
+      receipt: `MOCK_VALID_sub_empty_guid#token=${EMPTY_APP_ACCOUNT_TOKEN}`,
+      userId: 'firebase-user',
+      productId: 'premium_monthly',
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.valid).toBe(true);
+    expect(res.body.subscription.userId).toBe('firebase-user');
+  });
+
   it('receipt bound to a matching userId is accepted and stored', async () => {
     const app = mockApp();
     const res = await request(app).post('/onesub/validate').send({

--- a/packages/server/src/__tests__/providers.test.ts
+++ b/packages/server/src/__tests__/providers.test.ts
@@ -5,7 +5,11 @@
 
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import { generateKeyPairSync } from 'crypto';
-import { validateAppleConsumableReceipt } from '../providers/apple.js';
+import {
+  decodeAppleNotification,
+  validateAppleConsumableReceipt,
+  validateAppleReceipt,
+} from '../providers/apple.js';
 import {
   validateGoogleProductReceipt,
   acknowledgeGoogleSubscription,
@@ -26,6 +30,9 @@ function makeJws(payload: Record<string, unknown>): string {
 }
 
 const APPLE_CONFIG = { bundleId: 'com.example.app', skipJwsVerification: true as const };
+const EMPTY_APP_ACCOUNT_TOKEN = '00000000-0000-0000-0000-000000000000';
+const NEAR_EMPTY_APP_ACCOUNT_TOKEN = '00000000-0000-0000-0000-000000000001';
+const REAL_APP_ACCOUNT_TOKEN = '123e4567-e89b-12d3-a456-426614174000';
 
 function validApplePayload(overrides?: Record<string, unknown>): Record<string, unknown> {
   return {
@@ -35,6 +42,19 @@ function validApplePayload(overrides?: Record<string, unknown>): Record<string, 
     transactionId: 'txn_apple_001',
     originalTransactionId: 'orig_apple_001',
     purchaseDate: Date.now(),
+    ...overrides,
+  };
+}
+
+function validAppleSubscriptionPayload(overrides?: Record<string, unknown>): Record<string, unknown> {
+  return {
+    bundleId: 'com.example.app',
+    type: 'Auto-Renewable Subscription',
+    productId: 'pro_monthly',
+    transactionId: 'txn_apple_subscription_001',
+    originalTransactionId: 'orig_apple_subscription_001',
+    purchaseDate: Date.now(),
+    expiresDate: Date.now() + 30 * 24 * 60 * 60 * 1000,
     ...overrides,
   };
 }
@@ -102,6 +122,43 @@ function mockGoogleFetch(productPurchase: MockProductPurchase) {
     throw new Error(`[test] Unexpected fetch URL: ${String(url)}`);
   });
 }
+
+// ============================================================================
+// validateAppleReceipt
+// ============================================================================
+
+describe('validateAppleReceipt — appAccountToken normalization', () => {
+  it('treats Guid.Empty as an absent account token', async () => {
+    const jws = makeJws(validAppleSubscriptionPayload({
+      appAccountToken: EMPTY_APP_ACCOUNT_TOKEN,
+    }));
+
+    const result = await validateAppleReceipt(jws, APPLE_CONFIG);
+
+    expect(result).not.toBeNull();
+    expect(result?.boundAccountId).toBeUndefined();
+  });
+
+  it('preserves a real account token', async () => {
+    const jws = makeJws(validAppleSubscriptionPayload({
+      appAccountToken: REAL_APP_ACCOUNT_TOKEN,
+    }));
+
+    const result = await validateAppleReceipt(jws, APPLE_CONFIG);
+
+    expect(result?.boundAccountId).toBe(REAL_APP_ACCOUNT_TOKEN);
+  });
+
+  it('preserves a near-empty UUID as a real account token', async () => {
+    const jws = makeJws(validAppleSubscriptionPayload({
+      appAccountToken: NEAR_EMPTY_APP_ACCOUNT_TOKEN,
+    }));
+
+    const result = await validateAppleReceipt(jws, APPLE_CONFIG);
+
+    expect(result?.boundAccountId).toBe(NEAR_EMPTY_APP_ACCOUNT_TOKEN);
+  });
+});
 
 // ============================================================================
 // validateAppleConsumableReceipt
@@ -195,6 +252,56 @@ describe('validateAppleConsumableReceipt', () => {
     const jws = makeJws(validApplePayload({ type: 'Non-Consumable', productId: 'premium_unlock' }));
     const result = await validateAppleConsumableReceipt(jws, APPLE_CONFIG);
     expect(result).not.toBeNull();
+  });
+
+  it('treats a Guid.Empty appAccountToken as absent', async () => {
+    const jws = makeJws(validApplePayload({ appAccountToken: EMPTY_APP_ACCOUNT_TOKEN }));
+
+    const result = await validateAppleConsumableReceipt(jws, APPLE_CONFIG);
+
+    expect(result?.appAccountToken).toBeUndefined();
+  });
+
+  it('preserves a real appAccountToken', async () => {
+    const jws = makeJws(validApplePayload({ appAccountToken: REAL_APP_ACCOUNT_TOKEN }));
+
+    const result = await validateAppleConsumableReceipt(jws, APPLE_CONFIG);
+
+    expect(result?.appAccountToken).toBe(REAL_APP_ACCOUNT_TOKEN);
+  });
+});
+
+// ============================================================================
+// decodeAppleNotification
+// ============================================================================
+
+describe('decodeAppleNotification — appAccountToken normalization', () => {
+  function notificationWithToken(appAccountToken: string) {
+    return {
+      notificationType: 'DID_RENEW',
+      data: {
+        signedTransactionInfo: makeJws(validAppleSubscriptionPayload({ appAccountToken })),
+        signedRenewalInfo: makeJws({ autoRenewStatus: 1 }),
+      },
+    };
+  }
+
+  it('treats Guid.Empty as an absent account token', async () => {
+    const result = await decodeAppleNotification(
+      notificationWithToken(EMPTY_APP_ACCOUNT_TOKEN),
+      true,
+    );
+
+    expect(result?.appAccountToken).toBeNull();
+  });
+
+  it('preserves a real account token', async () => {
+    const result = await decodeAppleNotification(
+      notificationWithToken(REAL_APP_ACCOUNT_TOKEN),
+      true,
+    );
+
+    expect(result?.appAccountToken).toBe(REAL_APP_ACCOUNT_TOKEN);
   });
 });
 

--- a/packages/server/src/providers/apple.ts
+++ b/packages/server/src/providers/apple.ts
@@ -38,6 +38,17 @@ interface AppleTransactionPayload {
   [key: string]: unknown;
 }
 
+const EMPTY_APP_ACCOUNT_TOKEN = '00000000-0000-0000-0000-000000000000';
+
+/**
+ * Unity IAP can send Guid.Empty when no Apple account token was configured.
+ * Apple includes that sentinel in the signed transaction, so normalize only
+ * that exact UUID to an absent token before any account-binding decision.
+ */
+function normalizeAppleAppAccountToken(token: string | undefined): string | undefined {
+  return token === EMPTY_APP_ACCOUNT_TOKEN ? undefined : token;
+}
+
 /**
  * Decoded Apple signed renewal info (JWS payload).
  */
@@ -203,7 +214,15 @@ export async function validateAppleReceipt(
   receipt: string,
   config: AppleConfig
 ): Promise<SubscriptionInfo | null> {
-  if (config.mockMode) return mockValidateAppleSubscription(receipt);
+  if (config.mockMode) {
+    const mock = mockValidateAppleSubscription(receipt);
+    if (mock) {
+      const boundAccountId = normalizeAppleAppAccountToken(mock.boundAccountId);
+      if (boundAccountId) mock.boundAccountId = boundAccountId;
+      else delete mock.boundAccountId;
+    }
+    return mock;
+  }
   let tx: AppleTransactionPayload;
 
   try {
@@ -243,6 +262,7 @@ export async function validateAppleReceipt(
 
   const status = deriveStatus(tx, null);
   const purchasedAt = tx.originalPurchaseDate ?? tx.purchaseDate ?? Date.now();
+  const appAccountToken = normalizeAppleAppAccountToken(tx.appAccountToken);
 
   return {
     userId: '',  // caller fills this in from the request body
@@ -253,7 +273,7 @@ export async function validateAppleReceipt(
     originalTransactionId: tx.originalTransactionId,
     purchasedAt: new Date(purchasedAt).toISOString(),
     willRenew: status === SUBSCRIPTION_STATUS.ACTIVE, // refined by renewal info in webhook
-    ...(tx.appAccountToken ? { boundAccountId: tx.appAccountToken } : {}),
+    ...(appAccountToken ? { boundAccountId: appAccountToken } : {}),
   };
 }
 
@@ -290,7 +310,15 @@ export async function validateAppleConsumableReceipt(
   config: AppleConfig,
   expectedProductId?: string,
 ): Promise<AppleProductResult | null> {
-  if (config.mockMode) return mockValidateAppleProduct(signedTransaction, expectedProductId);
+  if (config.mockMode) {
+    const mock = mockValidateAppleProduct(signedTransaction, expectedProductId);
+    if (mock) {
+      const appAccountToken = normalizeAppleAppAccountToken(mock.appAccountToken);
+      if (appAccountToken) mock.appAccountToken = appAccountToken;
+      else delete mock.appAccountToken;
+    }
+    return mock;
+  }
   let tx: AppleTransactionPayload;
 
   try {
@@ -371,7 +399,7 @@ export async function validateAppleConsumableReceipt(
     purchasedAt: tx.purchaseDate
       ? new Date(tx.purchaseDate).toISOString()
       : new Date().toISOString(),
-    appAccountToken: tx.appAccountToken ?? undefined,
+    appAccountToken: normalizeAppleAppAccountToken(tx.appAccountToken),
   };
 }
 
@@ -451,7 +479,7 @@ export async function decodeAppleNotification(
     status,
     willRenew,
     expiresAt: tx.expiresDate ? new Date(tx.expiresDate).toISOString() : null,
-    appAccountToken: tx.appAccountToken ?? null,
+    appAccountToken: normalizeAppleAppAccountToken(tx.appAccountToken) ?? null,
     inAppOwnershipType: tx.inAppOwnershipType ?? null,
   };
 }
@@ -829,7 +857,7 @@ export async function fetchAppleTransactionHistory(
           type: tx.type ?? 'Unknown',
           purchasedAt: tx.purchaseDate ? new Date(tx.purchaseDate).toISOString() : new Date().toISOString(),
           expiresAt: tx.expiresDate ? new Date(tx.expiresDate).toISOString() : null,
-          appAccountToken: tx.appAccountToken ?? null,
+          appAccountToken: normalizeAppleAppAccountToken(tx.appAccountToken) ?? null,
           inAppOwnershipType: tx.inAppOwnershipType ?? null,
           revocationDate: tx.revocationDate ? new Date(tx.revocationDate).toISOString() : null,
         });


### PR DESCRIPTION
## What changed

- Normalize Apple's exact all-zero `appAccountToken` (`Guid.Empty`) to an absent token at the provider boundary.
- Apply the normalization consistently to subscriptions, one-time purchases, Apple webhooks, transaction history, and Apple mock mode.
- Preserve real and near-empty Apple UUIDs and leave Google account identifiers unchanged.

## Root cause

Unity IAP 5.4 can encode `Guid.Empty` when no Apple account token was configured. Because the all-zero UUID is a non-empty string, `@onesub/server` treated it as a real account binding and rejected valid Firebase UIDs.

## Security impact

The existing per-`transactionId` ownership checks are unchanged. Regression coverage proves a Guid.Empty consumable can be accepted initially while cross-user replay of the same transaction still returns 409; real Apple mismatches and Google all-zero identifiers remain rejected.

## Validation

- `npm run build`
- `npm run type-check`
- `npm test` - 602 passed
- `pwsh ./validate-unity-packages.ps1`
- `npm run size -w @onesub/server`
- `npm run docs:check`
- `git diff --check`
