### PR TITLE
feat(server): sandbox-only entitlement overrides for manual testing

### DIFF
--- a/.changeset/sandbox-entitlement-overrides.md
+++ b/.changeset/sandbox-entitlement-overrides.md
@@ -1,0 +1,36 @@
+---
+'@onesub/server': minor
+'@onesub/shared': minor
+---
+
+Add sandbox-only entitlement overrides for manual testing.
+
+Apple provides no way to cancel a sandbox subscription bought with a real Apple
+Account through TestFlight — "Clear Purchase History" in App Store Connect only
+covers sandbox *tester* accounts. A developer who subscribes once to check the
+paywall stays entitled indefinitely and cannot re-run the purchase flow.
+
+Deleting server records does not help: `/onesub/validate` re-derives entitlement
+from Apple on every call, so any local edit is overwritten on the next launch.
+The override therefore sits in front of that verdict:
+
+- `GET /onesub/admin/test-overrides`
+- `PUT /onesub/admin/test-overrides/:userId` — body `{ "entitled": false }`
+- `DELETE /onesub/admin/test-overrides/:userId`
+
+An override is keyed by `userId` and is honoured **only when the receipt just
+validated came from Sandbox**, so a production customer is unaffected even if an
+override exists for their id. To make that check possible, the Apple validator
+now reports the receipt environment as a transient `SubscriptionInfo.sandbox`
+flag, stripped by the validate route before the record reaches a store — the
+same lifecycle as the existing `boundAccountId`.
+
+Overrides are process-local and non-persistent by design: they do not survive a
+restart, and in a multi-instance deployment they apply to the instance that
+received the request. This keeps them a debugging aid rather than a product
+feature.
+
+This is not hypothetical. It hid a paywall entry point from App Review
+(Guideline 2.1(b) "we cannot locate the In-App Purchases") because the reviewer
+had subscribed in an earlier submission and the app hides that entry point for
+subscribers.

--- a/README.md
+++ b/README.md
@@ -171,6 +171,25 @@ Mounted only when `config.adminSecret` is set. All requests must include the `X-
 | `GET /onesub/admin/webhook-deadletters` | List failed webhook jobs (requires BullMQ queue) |
 | `POST /onesub/admin/webhook-replay/:id` | Replay a failed webhook job (requires BullMQ queue) |
 | `POST /onesub/admin/sync-apple/:originalTransactionId` | Refresh one subscription from the Apple Status API (requires App Store Server API credentials) |
+| `GET /onesub/admin/test-overrides` | List active sandbox entitlement overrides |
+| `PUT /onesub/admin/test-overrides/:userId` | Force an entitlement verdict for one user — body `{ "entitled": false }` |
+| `DELETE /onesub/admin/test-overrides/:userId` | Clear that user's override |
+
+#### Sandbox entitlement overrides
+
+Apple offers no way to cancel a sandbox subscription bought with a real Apple
+Account through TestFlight — "Clear Purchase History" in App Store Connect only
+covers sandbox *tester* accounts. A developer who subscribes once to check the
+paywall therefore stays entitled and cannot re-run the purchase flow. Deleting
+server records does not help either: `/onesub/validate` re-derives entitlement
+from Apple on every call, so a local edit is overwritten on the next app launch.
+
+These endpoints sit in front of that verdict. An override is keyed by `userId`
+and is honoured **only when the receipt being validated came from Sandbox**, so
+a production customer is unaffected even if an override exists for their id.
+Overrides are process-local and non-persistent: they do not survive a restart,
+and in a multi-instance deployment they apply to the instance that received the
+request. That is deliberate — this is a debugging aid, not a product feature.
 
 ### Apple promotional offers (opt-in — separate mount and separate header)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -89,6 +89,9 @@ createOneSubMiddleware(config)
           ├── GET    /onesub/admin/subscriptions/:transactionId  → subscription detail
           ├── GET    /onesub/admin/customers/:userId             → customer profile
           ├── POST   /onesub/admin/sync-apple/:originalTransactionId → Apple Status API sync
+          ├── GET    /onesub/admin/test-overrides                → list sandbox overrides
+          ├── PUT    /onesub/admin/test-overrides/:userId        → force entitlement (Sandbox only)
+          ├── DELETE /onesub/admin/test-overrides/:userId        → clear it
           ├── GET    /onesub/admin/webhook-deadletters           → failed BullMQ jobs
           ├── POST   /onesub/admin/webhook-replay/:id            → replay a failed job
           └── GET    /onesub/metrics/*                            → active/started/expired counts

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -96,6 +96,9 @@ explicit app IDs fail closed and are never validated with another app's credenti
 | `GET  /onesub/admin/subscriptions/:transactionId` | Get subscription detail (requires `adminSecret`) |
 | `GET  /onesub/admin/customers/:userId` | Get a customer profile (requires `adminSecret`) |
 | `POST /onesub/admin/sync-apple/:originalTransactionId` | Refresh a subscription from Apple (requires `adminSecret`) |
+| `GET /onesub/admin/test-overrides` | List sandbox-only entitlement overrides (requires `adminSecret`) |
+| `PUT /onesub/admin/test-overrides/:userId` | Force an entitlement verdict for one user — body `{ "entitled": false }`. Honoured **only for Sandbox receipts**, so production customers are unaffected. Exists because Apple cannot cancel a sandbox subscription bought with a real Apple Account, which otherwise locks a tester out of the purchase flow. Process-local and non-persistent |
+| `DELETE /onesub/admin/test-overrides/:userId` | Clear that user's override (requires `adminSecret`) |
 | `GET  /onesub/admin/webhook-deadletters` | List failed webhook jobs in DLQ (requires `adminSecret` + BullMQ) |
 | `POST /onesub/admin/webhook-replay/:id` | Replay a dead-letter job (requires `adminSecret` + BullMQ) |
 | `GET  /onesub/entitlement?userId=&id=` | Evaluate one configured entitlement |

--- a/packages/server/src/__tests__/test-overrides.test.ts
+++ b/packages/server/src/__tests__/test-overrides.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Sandbox-only entitlement overrides.
+ *
+ * Apple cannot cancel a sandbox subscription bought with a real Apple Account
+ * through TestFlight, so a tester who subscribes once stays entitled and can
+ * never re-run the purchase flow. That is not a hypothetical: it hid a paywall
+ * entry point from App Review (PenguinRun 2.0.6, Guideline 2.1(b)) because the
+ * reviewer had subscribed in an earlier round.
+ *
+ * The guarantee under test is the safety one — an override must be incapable of
+ * touching a paying customer. It is honoured only when the receipt just
+ * validated came from Sandbox.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import type { OneSubServerConfig, ValidateReceiptResponse } from '@onesub/shared';
+import { createOneSubMiddleware, InMemorySubscriptionStore, InMemoryPurchaseStore } from '../index.js';
+import { clearAllTestOverrides } from '../test-overrides.js';
+
+const ADMIN_SECRET = 'test-admin-secret';
+const USER = 'firebase-uid-1';
+
+function makeJws(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'ES256' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.fakesig`;
+}
+
+/** An active auto-renewable subscription transaction, Sandbox or Production. */
+function receipt(environment: 'Sandbox' | 'Production'): string {
+  const now = Date.now();
+  return makeJws({
+    bundleId: 'com.example.app',
+    productId: 'vip_monthly',
+    transactionId: 'tx-1',
+    originalTransactionId: 'orig-1',
+    purchaseDate: now - 60_000,
+    expiresDate: now + 30 * 24 * 60 * 60 * 1000,
+    type: 'Auto-Renewable Subscription',
+    environment,
+  });
+}
+
+function buildApp() {
+  const config: OneSubServerConfig = {
+    apple: { bundleId: 'com.example.app', skipJwsVerification: true },
+    database: { url: '' },
+    adminSecret: ADMIN_SECRET,
+  };
+  const app = express();
+  app.use(createOneSubMiddleware({
+    ...config,
+    store: new InMemorySubscriptionStore(),
+    purchaseStore: new InMemoryPurchaseStore(),
+  }));
+  return app;
+}
+
+async function withServer<T>(app: express.Express, fn: (base: string) => Promise<T>): Promise<T> {
+  const httpServer = app.listen(0);
+  const port = (httpServer.address() as { port: number }).port;
+  try {
+    return await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise<void>((r) => httpServer.close(() => r()));
+  }
+}
+
+async function validate(base: string, environment: 'Sandbox' | 'Production') {
+  const resp = await fetch(`${base}/onesub/validate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      platform: 'apple',
+      receipt: receipt(environment),
+      userId: USER,
+      productId: 'vip_monthly',
+    }),
+  });
+  return { status: resp.status, body: (await resp.json()) as ValidateReceiptResponse };
+}
+
+async function setOverride(base: string, entitled: boolean, secret = ADMIN_SECRET) {
+  return fetch(`${base}/onesub/admin/test-overrides/${USER}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', 'x-admin-secret': secret },
+    body: JSON.stringify({ entitled }),
+  });
+}
+
+beforeEach(() => clearAllTestOverrides());
+afterEach(() => clearAllTestOverrides());
+
+describe('sandbox test overrides', () => {
+  it('without an override, a sandbox subscription validates as active', async () => {
+    await withServer(buildApp(), async (base) => {
+      const { body } = await validate(base, 'Sandbox');
+      expect(body.valid).toBe(true);
+      expect(body.subscription?.status).toBe('active');
+    });
+  });
+
+  it('forces not-entitled for a sandbox receipt once set', async () => {
+    await withServer(buildApp(), async (base) => {
+      const put = await setOverride(base, false);
+      expect(put.status).toBe(200);
+
+      const { body } = await validate(base, 'Sandbox');
+      expect(body.valid).toBe(true);
+      expect(body.subscription?.status).toBe('expired');
+      expect(body.subscription?.willRenew).toBe(false);
+    });
+  });
+
+  // The whole safety argument. A production receipt must be untouched even when
+  // an override exists for that same userId.
+  it('never affects a production receipt', async () => {
+    await withServer(buildApp(), async (base) => {
+      await setOverride(base, false);
+      const { body } = await validate(base, 'Production');
+      expect(body.subscription?.status).toBe('active');
+    });
+  });
+
+  it('stops applying once cleared', async () => {
+    await withServer(buildApp(), async (base) => {
+      await setOverride(base, false);
+      const del = await fetch(`${base}/onesub/admin/test-overrides/${USER}`, {
+        method: 'DELETE',
+        headers: { 'x-admin-secret': ADMIN_SECRET },
+      });
+      expect(del.status).toBe(200);
+
+      const { body } = await validate(base, 'Sandbox');
+      expect(body.subscription?.status).toBe('active');
+    });
+  });
+
+  it('rejects a wrong admin secret', async () => {
+    await withServer(buildApp(), async (base) => {
+      const resp = await setOverride(base, false, 'wrong');
+      expect(resp.status).toBe(401);
+    });
+  });
+
+  it('never persists the transient sandbox flag', async () => {
+    await withServer(buildApp(), async (base) => {
+      const { body } = await validate(base, 'Sandbox');
+      expect(body.subscription).not.toHaveProperty('sandbox');
+    });
+  });
+});

--- a/packages/server/src/openapi.ts
+++ b/packages/server/src/openapi.ts
@@ -177,6 +177,57 @@ export const ONESUB_OPENAPI: OpenAPIDoc = {
       },
     },
     // ── admin (mounted when config.adminSecret is set) ───────────────────────
+    [ROUTES.ADMIN_TEST_OVERRIDES]: {
+      get: {
+        summary: 'List sandbox-only entitlement overrides (admin).',
+        parameters: [ADMIN_SECRET_PARAM],
+        responses: {
+          200: { description: 'OK' },
+          401: err('Invalid admin secret (INVALID_ADMIN_SECRET).'),
+        },
+      },
+    },
+    '/onesub/admin/test-overrides/{userId}': {
+      put: {
+        summary:
+          'Force an entitlement verdict for one userId. Honoured ONLY for Sandbox receipts — '
+          + 'a Production receipt ignores it. Exists because Apple cannot cancel a sandbox '
+          + 'subscription bought with a real Apple Account, which otherwise locks a tester in.',
+        parameters: [
+          ADMIN_SECRET_PARAM,
+          { in: 'path', name: 'userId', required: true, schema: { type: 'string' } },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['entitled'],
+                properties: { entitled: { type: 'boolean' } },
+              },
+            },
+          },
+        },
+        responses: {
+          200: { description: 'OK' },
+          400: err('Invalid input (INVALID_INPUT).'),
+          401: err('Invalid admin secret (INVALID_ADMIN_SECRET).'),
+        },
+      },
+      delete: {
+        summary: 'Clear the sandbox entitlement override for one userId (admin).',
+        parameters: [
+          ADMIN_SECRET_PARAM,
+          { in: 'path', name: 'userId', required: true, schema: { type: 'string' } },
+        ],
+        responses: {
+          200: { description: 'OK' },
+          400: err('Invalid input (INVALID_INPUT).'),
+          401: err('Invalid admin secret (INVALID_ADMIN_SECRET).'),
+        },
+      },
+    },
     [ROUTES.ADMIN_SUBSCRIPTIONS]: {
       get: {
         summary: 'Filtered, paginated subscription list (admin).',

--- a/packages/server/src/providers/apple.ts
+++ b/packages/server/src/providers/apple.ts
@@ -274,6 +274,9 @@ export async function validateAppleReceipt(
     purchasedAt: new Date(purchasedAt).toISOString(),
     willRenew: status === SUBSCRIPTION_STATUS.ACTIVE, // refined by renewal info in webhook
     ...(appAccountToken ? { boundAccountId: appAccountToken } : {}),
+    // Transient, like boundAccountId: the validate route uses it to decide
+    // whether a sandbox-only test override may apply, then strips it.
+    ...(tx.environment === 'Sandbox' ? { sandbox: true } : {}),
   };
 }
 

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -17,6 +17,8 @@ import { sendError, sendZodError } from '../errors.js';
 import type { WebhookQueue } from '../webhook-queue.js';
 import { fetchAppleSubscriptionStatus } from '../providers/apple.js';
 import { secretsEqual } from './secret-compare.js';
+import { setTestOverride, clearTestOverride, listTestOverrides } from '../test-overrides.js';
+import { log } from '../logger.js';
 
 const ADMIN_SECRET_HEADER = 'x-admin-secret';
 
@@ -318,6 +320,51 @@ export function createAdminRouter(
     } catch (err) {
       sendError(res, 500, ONESUB_ERROR_CODE.INTERNAL_ERROR, (err as Error).message ?? 'sync error');
     }
+  });
+
+  // ── Sandbox-only entitlement overrides (manual testing) ──
+  // Apple cannot cancel a sandbox subscription bought with a real Apple Account,
+  // so a tester who subscribes once stays entitled and can never re-run the
+  // purchase flow. These force "not entitled" for one userId, and are honoured
+  // only when the receipt being validated is a Sandbox one. See test-overrides.ts.
+  const overrideParamsSchema = z.object({ userId: z.string().min(1).max(256) });
+  const overrideBodySchema = z.object({ entitled: z.boolean() });
+
+  router.get(ROUTES.ADMIN_TEST_OVERRIDES, (_req: Request, res: Response) => {
+    res.json({ overrides: listTestOverrides() });
+  });
+
+  router.put(ROUTES.ADMIN_TEST_OVERRIDE, (req: Request, res: Response) => {
+    let params;
+    let body;
+    try {
+      params = overrideParamsSchema.parse(req.params);
+      body = overrideBodySchema.parse(req.body);
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        sendZodError(res, err);
+      } else {
+        sendError(res, 400, ONESUB_ERROR_CODE.INVALID_INPUT, 'userId and { entitled: boolean } required');
+      }
+      return;
+    }
+    setTestOverride(params.userId, body.entitled);
+    log.warn(
+      `[onesub/admin] sandbox test override set for ${params.userId}: entitled=${body.entitled}`,
+    );
+    res.json({ ok: true, userId: params.userId, entitled: body.entitled, sandboxOnly: true });
+  });
+
+  router.delete(ROUTES.ADMIN_TEST_OVERRIDE, (req: Request, res: Response) => {
+    let params;
+    try {
+      params = overrideParamsSchema.parse(req.params);
+    } catch {
+      sendError(res, 400, ONESUB_ERROR_CODE.INVALID_INPUT, 'userId required');
+      return;
+    }
+    const cleared = clearTestOverride(params.userId);
+    res.json({ ok: true, userId: params.userId, cleared });
   });
 
   // GET /onesub/admin/webhook-deadletters

--- a/packages/server/src/routes/validate.ts
+++ b/packages/server/src/routes/validate.ts
@@ -2,13 +2,14 @@ import { Router } from 'express';
 import type { Request, Response } from 'express';
 import { z } from 'zod';
 import type { ValidateReceiptResponse, OneSubServerConfig } from '@onesub/shared';
-import { ROUTES, ONESUB_ERROR_CODE } from '@onesub/shared';
+import { ROUTES, ONESUB_ERROR_CODE, SUBSCRIPTION_STATUS } from '@onesub/shared';
 import type { SubscriptionStore } from '../store.js';
 import { validateAppleReceipt } from '../providers/apple.js';
 import { validateGoogleReceipt, acknowledgeGoogleSubscription } from '../providers/google.js';
 import { log } from '../logger.js';
 import { sendError, sendZodError } from '../errors.js';
 import { getAppRegistry, peekAppleBundleId } from '../apps.js';
+import { getTestOverride } from '../test-overrides.js';
 
 const NO_SUB = { valid: false, subscription: null } as const;
 
@@ -99,6 +100,19 @@ export function createValidateRouter(
           NO_SUB,
         );
         return;
+      }
+
+      // Sandbox-only test override. Apple cannot cancel a sandbox subscription
+      // bought with a real Apple Account, so without this a tester who
+      // subscribed once can never see the paywall again. Gated on the receipt
+      // actually being a Sandbox one, so a Production receipt is unaffected
+      // even when an override exists for this userId.
+      const isSandbox = sub.sandbox === true;
+      delete sub.sandbox;
+      if (isSandbox && getTestOverride(userId) === false) {
+        log.warn(`[onesub/validate] sandbox test override active for ${userId}: forcing not-entitled`);
+        sub.status = SUBSCRIPTION_STATUS.EXPIRED;
+        sub.willRenew = false;
       }
 
       sub.userId = userId;

--- a/packages/server/src/test-overrides.ts
+++ b/packages/server/src/test-overrides.ts
@@ -1,0 +1,50 @@
+/**
+ * Sandbox-only entitlement overrides for manual testing.
+ *
+ * Why this exists: Apple provides no way to cancel a sandbox subscription that
+ * was bought with a real Apple Account through TestFlight. "Clear Purchase
+ * History" in App Store Connect only covers sandbox *tester* accounts, and the
+ * store expires an accelerated subscription on its own schedule. A developer
+ * who subscribes once to check the paywall is therefore stuck as an entitled
+ * user, and cannot re-run the purchase flow — the exact situation that hid a
+ * paywall entry point from App Review (PenguinRun 2.0.6, Guideline 2.1(b)).
+ *
+ * Deleting server records does not help: `/onesub/validate` re-derives
+ * entitlement from Apple on every call, so any local edit is overwritten the
+ * next time the app launches. The override has to sit in front of that verdict.
+ *
+ * Safety model — an override can never affect a paying customer:
+ *   - it is keyed by userId, so it touches exactly one account;
+ *   - it is honoured ONLY when the receipt Apple just validated came from
+ *     Sandbox (`SubscriptionInfo.sandbox`), so a Production receipt ignores it
+ *     even if an override for that userId exists;
+ *   - it lives behind the admin secret, like every other admin route;
+ *   - it is process-local and non-persistent, so it cannot outlive a deploy or
+ *     silently linger in a database. Multi-instance deployments must set it on
+ *     the instance under test (or run one instance) — deliberate, so this stays
+ *     a debugging aid rather than a product feature.
+ */
+
+/** userId -> forced entitlement. `false` means "treat as not entitled". */
+const overrides = new Map<string, boolean>();
+
+export function setTestOverride(userId: string, entitled: boolean): void {
+  overrides.set(userId, entitled);
+}
+
+export function clearTestOverride(userId: string): boolean {
+  return overrides.delete(userId);
+}
+
+export function getTestOverride(userId: string): boolean | undefined {
+  return overrides.get(userId);
+}
+
+export function listTestOverrides(): Array<{ userId: string; entitled: boolean }> {
+  return [...overrides].map(([userId, entitled]) => ({ userId, entitled }));
+}
+
+/** Test seam — resets state between suites. */
+export function clearAllTestOverrides(): void {
+  overrides.clear();
+}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -20,6 +20,16 @@ export const ROUTES = {
   ADMIN_CUSTOMER_DETAIL: '/onesub/admin/customers/:userId',
   /** Sync a subscription from Apple Status API; takes :originalTransactionId path param. */
   ADMIN_SYNC_APPLE: '/onesub/admin/sync-apple/:originalTransactionId',
+  /**
+   * Sandbox-only entitlement overrides for manual testing. Listing endpoint.
+   * Apple gives no way to cancel a sandbox subscription bought with a real
+   * Apple Account, so a tester who subscribes once stays entitled until the
+   * store expires it on its own. These let a tester force "not entitled"
+   * without waiting. They apply ONLY to Sandbox receipts.
+   */
+  ADMIN_TEST_OVERRIDES: '/onesub/admin/test-overrides',
+  /** Set/clear one override; takes :userId path param. */
+  ADMIN_TEST_OVERRIDE: '/onesub/admin/test-overrides/:userId',
   /** Sign an Apple Promotional Offer payload (requires apple.offerKeyId + offerPrivateKey). */
   APPLE_OFFER_SIGNATURE: '/onesub/apple/offer-signature',
 } as const;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -83,6 +83,14 @@ export interface SubscriptionInfo {
    * stripped by every route before the record is stored.
    */
   boundAccountId?: string;
+  /**
+   * True when the receipt came from Apple's Sandbox (TestFlight / StoreKit
+   * testing) rather than Production. Transient in the same sense as
+   * `boundAccountId`: the validators set it, the validate route reads it to
+   * decide whether a test override may apply, and the route strips it before
+   * the record reaches a store. Never persisted.
+   */
+  sandbox?: boolean;
 }
 
 /** Subscription status check response */


### PR DESCRIPTION
## 왜

Apple 은 TestFlight 에서 **실제 Apple Account 로 산 샌드박스 구독을 취소할 방법을 주지 않는다.** App Store Connect 의 "Clear Purchase History" 는 샌드박스 *테스터 계정* 에만 적용된다. 그래서 페이월을 한 번 확인하려고 구독한 개발자는 계속 구독 상태로 남고, 구매 플로우를 다시 탈 수 없다.

서버 레코드를 지워도 소용없다. `/onesub/validate` 는 호출마다 Apple 로부터 자격을 다시 도출하므로, 로컬 수정은 앱이 다음에 실행되는 순간 덮인다. 그래서 오버라이드는 그 판정 **앞** 에 있어야 한다.

실제로 겪은 일이다: PenguinRun 2.0.6 이 Guideline 2.1(b) "we cannot locate the In-App Purchases" 로 반려됐는데, 리뷰어가 이전 심사에서 구독해 둔 상태였고 앱은 구독자에게 그 진입점을 숨기기 때문이었다. 심사 노트를 아무리 잘 써도 소용이 없었다.

## 무엇을

```
GET    /onesub/admin/test-overrides
PUT    /onesub/admin/test-overrides/:userId   { "entitled": false }
DELETE /onesub/admin/test-overrides/:userId
```

## 안전 모델 — 유료 사용자에게 닿을 수 없다

- `userId` 로 키잉되어 정확히 한 계정만 건드린다
- **방금 검증한 영수증이 Sandbox 일 때만** 적용된다. Production 영수증은 같은 userId 에 오버라이드가 있어도 무시한다
- 다른 admin 라우트와 동일하게 admin secret 뒤에 있다
- 프로세스 로컬·비영속. 배포를 넘겨 살아남지 않고 DB 에 잔류하지 않는다. 멀티 인스턴스에서는 테스트 대상 인스턴스에 걸어야 한다 — 이건 의도된 제약으로, 제품 기능이 아니라 디버깅 도구로 남기기 위함이다

샌드박스 판별을 위해 Apple 검증기가 영수증 환경을 transient `SubscriptionInfo.sandbox` 로 싣고, validate 라우트가 읽은 뒤 스토어에 닿기 전에 제거한다 — 기존 `boundAccountId` 와 동일한 수명 주기다.

## 검증

- 테스트 608건 통과 (신규 6건 포함 — 핵심은 "Production 영수증은 영향받지 않는다")
- `openapi` / `schema` 계약 테스트 통과
- `docs:check` 통과
- 서버 번들 32.78 kB gzipped (한도 34 kB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)