### PR TITLE
fix(sdk): purchase error contract + agent-facing docs

### DIFF
--- a/.changeset/quiet-stores-restore.md
+++ b/.changeset/quiet-stores-restore.md
@@ -1,0 +1,7 @@
+---
+'@jeonghwanko/onesub-sdk': patch
+---
+
+Normalize react-native-iap v15 purchase errors, preserve server validation error codes on restore failures,
+pre-register StoreKit listeners before connection initialization, and report concurrent one-time purchase/restore
+operations as `CONCURRENT_PURCHASE` instead of an ambiguous null result.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,12 @@ This is the canonical repository guide for coding agents. `CLAUDE.md` imports th
 and Claude share one set of project instructions. Keep durable project knowledge here; keep public
 setup and API documentation in `README.md` and `docs/`.
 
+**How to use this guide.** Read *Build Model and Traps* before your first edit — it is the section
+that prevents silent failures. Then jump: *Source Map* for where code lives, *Start Here by Task* for
+which files a given task touches, *Contract Change Checklist* for changes that must move several
+files at once, *Change Workflow* and *Before You Call a Task Done* for what to run and report.
+`docs/AI-WORKFLOW.md` holds copy-ready prompts; this file holds the rules.
+
 ## Project Scope
 
 OneSub is a self-hosted in-app purchase backend and client toolkit. It validates Apple StoreKit 2
@@ -34,6 +40,55 @@ copy Pro sources into this repository. See `docs/UNITY-PRO.md` for the compatibi
 
 The two Unity packages are UPM packages, not npm workspaces. `validate-unity-packages.ps1` lives at
 the repository root, not under `scripts`.
+
+## Source Map
+
+File-level orientation, so you can open the right file instead of grepping for it. Paths are stable;
+verify contents against the source before quoting them.
+
+| Area | Files |
+|---|---|
+| Route constants, statuses, error codes | `packages/shared/src/constants.ts` |
+| Cross-package types (config, `SubscriptionInfo`, `PurchaseInfo`) | `packages/shared/src/types.ts` |
+| Middleware assembly and public exports | `packages/server/src/index.ts` |
+| Routes | `packages/server/src/routes/` — `validate.ts`, `status.ts`, `purchase.ts`, `admin.ts`, `entitlements.ts`, `metrics.ts`, `apple-offer.ts`, `webhook-apple.ts`, `webhook-google.ts`, `webhook.ts` |
+| Admin-secret comparison | `packages/server/src/routes/secret-compare.ts` |
+| Providers (Apple, Google, mock) | `packages/server/src/providers/` |
+| Stores | `packages/server/src/store.ts` (in-memory), `packages/server/src/stores/postgres.ts`, `stores/redis.ts`, `stores/schema.ts` (DDL constants) |
+| SQL schema shipped to users | `packages/server/sql/schema.sql` (parity-tested against `stores/schema.ts`) |
+| OpenAPI spec | `packages/server/src/openapi.ts` (parity-tested against mounted routers) |
+| Webhook durability | `packages/server/src/webhook-queue.ts`, `webhook-events.ts` |
+| Outbound HTTP, caching, logging, tracing | `packages/server/src/http.ts`, `cache.ts`, `logger.ts`, `tracing.ts` |
+| Multi-app credential resolution | `packages/server/src/apps.ts` |
+| SDK provider (listeners, drain gate, purchase/restore entry points) | `packages/sdk/src/OneSubProvider.tsx` |
+| SDK pure purchase-flow logic (in-flight map, native error mapping, type resolution) | `packages/sdk/src/purchaseFlow.ts` |
+| SDK request shaping (Google offer tokens, platform args) | `packages/sdk/src/iapRequest.ts` |
+| SDK error class and server HTTP client | `packages/sdk/src/OneSubError.ts`, `packages/sdk/src/api.ts` |
+| MCP tool registration | `packages/mcp-server/src/index.ts`, tools under `packages/mcp-server/src/tools/` |
+| CLI (`init` scaffolder + `dev` mock server) | `packages/cli/src/index.ts`, templates under `packages/cli/templates/` |
+| Docs validator | `scripts/validate-docs.mjs` |
+
+`packages/sdk/src/purchaseFlow.ts` holds the logic that is unit-testable without a native module;
+`OneSubProvider.tsx` holds the React and `react-native-iap` wiring. Put new purchase logic in
+`purchaseFlow.ts` and test it directly — that is why the split exists.
+
+## Start Here by Task
+
+Routing table for the tasks that come up most. Each row is "open these first," not the full file set;
+contract changes still follow the Contract Change Checklist.
+
+| Task | Open first | Then run |
+|---|---|---|
+| Change or add a route | `packages/shared/src/constants.ts`, the router, `packages/server/src/openapi.ts` | `npm test -- packages/server/src/__tests__/openapi.test.ts`, `npm run docs:check` |
+| Change receipt validation | `packages/server/src/routes/validate.ts`, `packages/server/src/providers/` | `npm test -- packages/server/src/__tests__` |
+| Change webhook handling | `packages/server/src/routes/webhook-*.ts`, `webhook-queue.ts` | `npm test -- packages/server/src/__tests__` |
+| Add or change a persisted field | `packages/shared/src/types.ts`, `stores/schema.ts`, `sql/schema.sql` | rebuild `@onesub/shared`, then `npm test -- packages/server/src/__tests__/schema.test.ts` |
+| Change SDK purchase behavior | `packages/sdk/src/purchaseFlow.ts`, `packages/sdk/src/OneSubProvider.tsx` | `npm test -- packages/sdk/src/__tests__`, `npm run type-check -w @jeonghwanko/onesub-sdk` |
+| Add an error code | `packages/shared/src/constants.ts`, `docs/RECEIPT-ERRORS.md` | rebuild `@onesub/shared`, then `npm test` |
+| Add an MCP tool | `packages/mcp-server/src/index.ts`, `packages/mcp-server/src/tools/` | `npm run docs:check`, `npm test` |
+| Add a CLI command or template change | `packages/cli/src/index.ts`, `packages/cli/templates/` | `npm run docs:check`, `npm run build -w @onesub/cli` |
+| Reproduce a client bug end to end | `packages/cli/src/index.ts` (`dev` command), `docs/TESTING.md` | `npm run build && node packages/cli/dist/index.js dev --port 4100` |
+| Documentation only | the owning document in Documentation Ownership | `npm run docs:check` |
 
 ## Commands
 
@@ -103,11 +158,15 @@ behavior."
 strips `\r` itself, so it is CRLF-proof today. Keep both defenses: add any new text file type to
 `.gitattributes`, and do not assume a parser downstream is as forgiving.
 
-**This repository is developed on Windows.** Command blocks in `docs/` are written for bash. In
+**This repository is developed on Windows, but agents often run it on Linux or macOS.** Everything
+except `validate-unity-packages.ps1` (which needs `pwsh`) is cross-platform; the traps run the other
+way. Command blocks in this guide and in `docs/` are written for bash. In
 PowerShell, translate them: `rm -rf` is not available, `\` line continuations must become backticks,
 POSIX inline env prefixes (`FOO=bar npm run dev`) must become `$env:FOO = 'bar'; npm run dev`, and
 `curl -d '{...}'` needs `Invoke-RestMethod` or `curl.exe`. The root `clean` script
-(`rm -rf packages/*/dist`) is POSIX-only; delete the `dist` folders directly instead.
+(`rm -rf packages/*/dist`) is POSIX-only; delete the `dist` folders directly instead. On a
+POSIX host the reverse applies: `pwsh ./validate-unity-packages.ps1` only runs if PowerShell is
+installed — if it is not, say so in your report rather than skipping the check silently.
 
 **`npm run size -w @onesub/server` measures `dist/`, so it needs a build first.** It gates the
 gzipped ESM and CJS bundles against the ceilings in `packages/server/.size-limit.cjs` and is a
@@ -148,6 +207,16 @@ and let CI apply them.
   `expo-in-app-purchases` is listed alongside it in `peerDependenciesMeta` as optional, but has **no
   adapter behind it** — do not treat it as a code path to preserve, and do not "restore" it without
   an explicit product decision. Keep the structured `OneSubError` behavior working.
+- The SDK's `null` return and its thrown `OneSubError` mean different things, and the difference is
+  load-bearing for host apps. `null` means "no purchase happened and that is normal" — user
+  cancelled, or `restoreProduct` found nothing in the store's purchase history. A thrown
+  `OneSubError` means the operation failed or was refused, including
+  `CONCURRENT_PURCHASE` when `purchaseProduct` / `restoreProduct` is called while another IAP
+  operation is in flight. Do not "simplify" a throw into a `null` (it makes a refusal look like a
+  cancel) or a `null` into a throw. When a native `react-native-iap` error reaches the SDK, map it
+  through `mapNativePurchaseErrorCode` in `packages/sdk/src/purchaseFlow.ts` instead of inventing a
+  new code at the call site, and keep server-supplied `errorCode` values intact when rethrowing a
+  failed validation.
 - Keep purchasing-only code in `packages/unity`. Sharing, review, social, leaderboard, and auth
   helpers belong in `packages/unity-platform-services`. Run the UPM boundary validator after Unity
   package changes.
@@ -229,6 +298,18 @@ gates are `docs.yml` and CodeQL, which has no path filter and runs on every PR.
 source changes, so renaming a file that documentation references can ship green. Run
 `npm run docs:check` yourself when you rename or move anything the docs cite.
 
+The remaining workflows never gate a PR, so do not wait on them or try to trigger them:
+
+| Workflow | Trigger | What it does |
+|---|---|---|
+| `publish.yml` (`Release`) | push to `master` | Runs Changesets: opens/updates the "Version Packages" PR, publishes on merge |
+| `docker-dashboard.yml` | push to `master` touching `packages/dashboard/**` or `packages/shared/src/**` (also manual) | Builds and publishes the dashboard Docker image |
+| `e2e.yml` | manual dispatch only | Real Apple/Google sandbox round-trips; needs shared secrets, so it cannot run on a PR |
+| `bench.yml` | weekly schedule (also manual) | k6 status/webhook load tests from `bench/` |
+
+If a change needs real sandbox coverage, say so in the PR description and ask a maintainer to dispatch
+`e2e.yml` — you cannot validate that path locally.
+
 ## Change Workflow
 
 1. Read the nearest package README and the relevant source/tests before editing.
@@ -258,6 +339,36 @@ source changes, so renaming a file that documentation references can ship green.
    image published by `docker-dashboard.yml`, which also republishes on any `packages/shared/src`
    change.
 
+### Before You Call a Task Done
+
+Answer these five questions in your final report. They map one-to-one to how this repository fails.
+
+1. **Rebuild:** did I touch `packages/shared/src`, and if so did I rebuild it before testing?
+   A green `npm test` without that rebuild is not evidence.
+2. **Contracts:** does the change add, rename, or remove a route, a persisted field, a config field,
+   an error code, an MCP tool, a CLI command, or a workspace? If yes, did I move every file in the
+   matching Contract Change Checklist row?
+3. **Checks:** which commands did I actually run, with what result — and which ones did I skip, and
+   why (no PowerShell, no network, no store credentials)? Never present an unrun check as passing.
+4. **Changeset:** does the change touch a published package? If yes, is there a `.changeset/*.md`
+   for it, authored via `npm run changeset` rather than by hand?
+5. **Working tree:** are unrelated modified files still intact, and did I avoid committing or pushing
+   unless asked?
+
+### Do Not Do These Without Being Asked
+
+- Commit, push, open a PR, or tag a release.
+- Run `npm run version-packages`, `npm run release`, or edit a `package.json` `version` field or a
+  generated `CHANGELOG.md`.
+- Run bare `npm install`, upgrade a dependency, or regenerate `package-lock.json`.
+- Weaken a security control (JWS/certificate verification, webhook auth, admin-secret comparison,
+  ownership checks, body limits) or enable a `mockMode` / `skipJwsVerification` path outside
+  development.
+- Delete or raise a failing gate — a size budget, a parity test, a docs check — to make CI green.
+- Call a live App Store Connect or Google Play write API. Product-management tools mutate real
+  stores; propose first and wait for explicit approval.
+- Copy anything from the private `onesub-unity-pro` repository into this one.
+
 ## Documentation Ownership
 
 Each fact has one owner. Link to the owner rather than restating it.
@@ -266,7 +377,7 @@ Each fact has one owner. Link to the owner rather than restating it.
 |---|---|
 | `README.md` | Product overview, quick start, supported features, package catalog, roadmap |
 | `docs/README.md` | Documentation index and routing |
-| `docs/ARCHITECTURE.md` | Dependency direction, runtime flow, stores, state transitions, hooks |
+| `docs/ARCHITECTURE.md` | Dependency direction, runtime flow, stores, state transitions, hooks, SDK client purchase flow |
 | `docs/AI-WORKFLOW.md` | Copy-ready prompts for repository work, app integration, safe MCP use |
 | `docs/LOCAL-DEVELOPMENT.md` | Clean-clone setup and local services |
 | `docs/CONFIGURATION.md` | Every `OneSubServerConfig` field, SDK, multi-app, and environment config |
@@ -287,7 +398,7 @@ Each fact has one owner. Link to the owner rather than restating it.
 | `CONTRIBUTING.md` | Contributor onboarding, releases, PR checklist |
 | `SKILL.md` | Public single-file integration context for agents adding OneSub to *another* app; not the internal contributor guide |
 | `AGENTS.md` | Internal repository instructions shared by Codex and Claude |
-| `CLAUDE.md` | A thin Claude entry point only; do not duplicate this guide there |
+| `CLAUDE.md` | A thin Claude entry point: imports this file, plus Claude Code harness notes only — no project rules |
 
 Avoid volatile claims: hard-coded test counts, tool counts, package counts, or version numbers.
 Derive command order, tool names, route names, and package names from the current code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ verify contents against the source before quoting them.
 | Middleware assembly and public exports | `packages/server/src/index.ts` |
 | Routes | `packages/server/src/routes/` — `validate.ts`, `status.ts`, `purchase.ts`, `admin.ts`, `entitlements.ts`, `metrics.ts`, `apple-offer.ts`, `webhook-apple.ts`, `webhook-google.ts`, `webhook.ts` |
 | Admin-secret comparison | `packages/server/src/routes/secret-compare.ts` |
+| Sandbox-only entitlement overrides (process-local, never persisted) | `packages/server/src/test-overrides.ts` |
 | Providers (Apple, Google, mock) | `packages/server/src/providers/` |
 | Stores | `packages/server/src/store.ts` (in-memory), `packages/server/src/stores/postgres.ts`, `stores/redis.ts`, `stores/schema.ts` (DDL constants) |
 | SQL schema shipped to users | `packages/server/sql/schema.sql` (parity-tested against `stores/schema.ts`) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,4 +3,22 @@
 @AGENTS.md
 
 `AGENTS.md` is the canonical repository guide shared with Codex. Update that file instead of
-duplicating project structure, commands, or coding rules here.
+duplicating project structure, commands, or coding rules here. This file holds only notes about
+using Claude Code *in* this repository.
+
+## Working here with Claude Code
+
+- **Orient before editing.** `AGENTS.md` → *Source Map* tells you which file to open; *Start Here by
+  Task* tells you what a given task touches. Prefer that over a repo-wide grep.
+- **Plan first for cross-package work.** Anything that touches `packages/shared/src`, a route, or a
+  persisted field fans out into several files — sketch the file set from the *Contract Change
+  Checklist* before the first edit.
+- **Long commands.** `npm ci` and a full `npm run build` take minutes; raise the Bash timeout rather
+  than letting them be killed. `npm test -- <path>` is the fast inner loop.
+- **Verify what you changed, not everything.** Use the "Touched → Run" table in *Change Workflow*.
+  Say explicitly which checks you ran and which you could not (this checkout may have no `pwsh`, no
+  network, and no store credentials).
+- **Never commit, push, or release unless asked.** See *Do Not Do These Without Being Asked*.
+  The working tree often carries the user's own in-progress changes — leave them intact.
+- **Reviews.** `/code-review` covers your working diff; `/security-review` is worth running on any
+  change to receipt validation, webhooks, admin routes, or secret handling.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,11 @@ what your change touched — [`AGENTS.md`](AGENTS.md) has the table — and at m
 A Markdown-only PR skips the build and test job (`ci.yml` sets `paths-ignore: '**/*.md'`). Its gates
 are the `docs` workflow and CodeQL, which has no path filter and runs on every PR.
 
+AI-assisted PRs are welcome under the same bar: point the agent at [`AGENTS.md`](AGENTS.md), and
+state in the PR description which checks were actually run and which were skipped. An unrun check
+reported as passing is worse than an admitted gap. [`docs/AI-WORKFLOW.md`](docs/AI-WORKFLOW.md) has
+ready-made prompts and a session-setup checklist.
+
 ## Reporting security issues
 
 Do **not** open a public issue for security vulnerabilities. See [docs/SECURITY.md](docs/SECURITY.md#reporting-vulnerabilities).

--- a/README.md
+++ b/README.md
@@ -302,6 +302,8 @@ if (purchase?.action === 'restored') {
 const restored = await restoreProduct('premium_unlock', 'non_consumable');
 ```
 
+**One purchase at a time** — the hook exposes `isBusy`; disable every IAP button while it is true. `purchaseProduct` / `restoreProduct` throw `OneSubError` with `CONCURRENT_PURCHASE` if called anyway, so a refusal never looks like a user cancel. The full `null`-versus-throw contract is in the [SDK README](packages/sdk/README.md).
+
 **Mock mode** — set `config.mockMode: true` to return synthetic success from `subscribe` / `restore` / `purchaseProduct` / `restoreProduct` without calling `react-native-iap` or the onesub server. Useful for running UI flows in Expo Go / the simulator. Never enable in production.
 
 **Peer dependency:** SDK requires `react-native-iap` **v15+** (event-based purchase flow).

--- a/SKILL.md
+++ b/SKILL.md
@@ -104,12 +104,12 @@ import { OneSubProvider, useOneSub } from '@jeonghwanko/onesub-sdk';
 ```tsx
 // Any component
 const {
-  isActive, subscribe, restore,         // auto-renewable subscriptions
+  isActive, isBusy, subscribe, restore,  // auto-renewable subscriptions
   purchaseProduct, restoreProduct,       // one-time products
 } = useOneSub();
 
-// Subscription
-if (!isActive) <Button onPress={subscribe} title="Subscribe" />;
+// Subscription — disable every IAP button while isBusy is true
+if (!isActive) <Button disabled={isBusy} onPress={subscribe} title="Subscribe" />;
 
 // Consumable (e.g. coins)
 const result = await purchaseProduct('credits_100', 'consumable');
@@ -123,7 +123,16 @@ if (owned?.action === 'restored') { /* user already owned — show "복원 완�
 const restored = await restoreProduct('premium_unlock', 'non_consumable');
 ```
 
-Peer dep: **`react-native-iap` v15+** (event-based purchase flow).
+**`null` versus throw.** `null` means "nothing was purchased and that's normal" — the user cancelled,
+or `restoreProduct` found no matching purchase in the store's history. A thrown `OneSubError` means
+the operation failed or was refused: `purchaseProduct` / `restoreProduct` throw `CONCURRENT_PURCHASE`
+when another IAP operation is still running, and `NON_CONSUMABLE_ALREADY_OWNED` when the store says
+the device already owns that SKU (recover with `restoreProduct`). `subscribe()` / `restore()` return
+`void` and no-op while busy. Always branch on both outcomes.
+
+Peer dep: **`react-native-iap` v15+** (event-based purchase flow). Google Play subscription offer
+tokens are read from the fetched product and forwarded automatically — no client wiring needed, but
+the subscription must have an active base-plan offer in Play Console.
 
 **Mock mode** for Expo Go / simulator UI testing (no native module needed):
 ```tsx
@@ -208,6 +217,8 @@ Full catalog (every `ONESUB_ERROR_CODE` with cause and fix): https://github.com/
 | SDK `isActive` stays false after purchase | Server didn't receive webhook | Verify webhook URL in App Store Connect / Pub/Sub push config. Check `POST /onesub/webhook/*` returns 2xx |
 | SDK throws `RN_IAP_NOT_INSTALLED` | Peer dep missing | `npm i react-native-iap@^15` in the app |
 | TestFlight purchase succeeds without sheet | Stale pending in StoreKit queue (fixed in sdk@0.5.1+) | Upgrade `@jeonghwanko/onesub-sdk` and rebuild |
+| SDK throws `CONCURRENT_PURCHASE` | A second purchase/restore started while one was still running — cleanup after a subscription counts | Disable IAP buttons on `isBusy`; treat a caught `CONCURRENT_PURCHASE` as a double-tap and return |
+| Google subscription purchase fails before the sheet | Subscription has no active base-plan offer, so there is no offer token to send | Activate a base plan + offer in Play Console; the SDK forwards the token automatically |
 
 Enable `config.debug: true` on the SDK for verbose `[onesub]` traces. Server logs are tagged `[onesub/*]` per provider/route.
 

--- a/docs/AI-WORKFLOW.md
+++ b/docs/AI-WORKFLOW.md
@@ -41,6 +41,27 @@ yet; report the current state, relevant commands, and likely risks.
 
 Claude reads `CLAUDE.md`, which imports the same canonical `AGENTS.md` used by Codex.
 
+## Session Setup
+
+Both agents read the same rules, but the environment around them differs. Settle these before the
+first edit:
+
+| Concern | What to check |
+|---|---|
+| Instructions loaded | Codex reads `AGENTS.md` directly; Claude Code reads `CLAUDE.md`, which imports it. If the agent has not read the *Build Model and Traps* section, tell it to. |
+| Network | `npm ci` needs registry access. In a sandboxed or offline session, install once up front — a mid-task install failure looks like a broken build. |
+| Approvals | Builds, tests, and `docs:check` are safe to run unattended. Git writes, package publishing, and any store-product write are not; require explicit approval for those. |
+| Shell | Command blocks here are bash. On Windows, translate them as described in `AGENTS.md`. `pwsh ./validate-unity-packages.ps1` needs PowerShell — if it is unavailable, the agent must report the skip. |
+| Working tree | Run `git status` first. The tree frequently carries unrelated in-progress work that must survive the task. |
+
+A useful standing instruction for either agent:
+
+```text
+Follow AGENTS.md. Do not commit, push, or release. Preserve unrelated working-tree changes. Before
+you finish, answer the five questions in "Before You Call a Task Done" — including which checks you
+ran and which you skipped, and why.
+```
+
 ## Repository Work Prompts
 
 ### Implement a focused change

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -179,6 +179,50 @@ CREATE UNIQUE INDEX idx_onesub_purchases_non_consumable
 ```
 Application-level `hasPurchased()` check is a fast path; the DB constraint is the atomic guarantee.
 
+## SDK Purchase Flow (client)
+
+The React Native SDK is split so the decision logic is testable without a native module:
+`packages/sdk/src/purchaseFlow.ts` holds pure functions (in-flight registry, event handling, native
+error mapping, purchase-type resolution), and `packages/sdk/src/OneSubProvider.tsx` holds the React
+state and `react-native-iap` wiring. New logic belongs in `purchaseFlow.ts`.
+
+**One listener pair per mount.** `purchaseUpdatedListener` / `purchaseErrorListener` are registered
+once at provider mount, *before* `initConnection()` — RN-IAP can emit queued StoreKit transactions
+while initialization is still resolving. Registration is repeated after init for the case where the
+pre-init subscription was inert; RN-IAP fans out through a Set, so the retry does not double-deliver.
+
+**Drain window.** For a short window after mount, in-flight matching is suppressed. Transactions the
+store replays at launch are therefore handled as orphans (validated and finished silently) instead of
+resolving a purchase the user has not made yet — the fix for the "sheet never appears, app reports
+success" class of bug. `subscribe()` awaits the drain before requesting a purchase.
+
+**In-flight registry.** A `Map<productId, InFlightEntry>` correlates the promise returned to the
+caller with the event the store delivers later. Each entry records its kind (`subscription` or
+`purchase`) and, for one-time products, the caller's declared type. A second registration for the
+same `productId` is refused with `CONCURRENT_PURCHASE`.
+
+**Event handling** (`handlePurchaseEvent`), for both matched events and orphan replays:
+
+1. Classify: `isSubscriptionEvent()` trusts the in-flight entry, then the transaction's
+   `productType`; it never guesses "subscription" for an unmatched event.
+2. For one-time products, `resolvePurchaseType()` prefers the caller's declared type, then
+   `config.consumableProductIds`, then `non_consumable`. This is why hosts that sell consumables must
+   declare them: an orphan replay has nothing else to read, and a wrong answer both records the wrong
+   `type` server-side and acknowledges instead of consuming on Android.
+3. Validate against the server, then `finishTransaction` **only on success** — a rejected receipt is
+   left unfinished so the store replays it, and the validation routes are idempotent.
+4. Settle the in-flight promise. Subscriptions resolve as soon as validation passes and hand native
+   cleanup back to the provider, which keeps the SDK-wide busy lock held until cleanup settles.
+
+**Error contract.** Native codes are normalized (legacy `E_*` and OpenIAP spellings) by
+`mapNativePurchaseErrorCode`: cancels become `USER_CANCELLED`, already-owned becomes
+`NON_CONSUMABLE_ALREADY_OWNED` for non-consumables only, everything else `INTERNAL_ERROR`.
+A `duplicate-purchase` native error is ignored outright — RN-IAP emits it only after it already
+delivered the original event, and rejecting on it would strand a paid transaction. Server
+`errorCode`s are preserved when a validation failure is rethrown. See
+[`../packages/sdk/README.md`](../packages/sdk/README.md) for which calls return `null` and which
+throw.
+
 ## MCP Tool Design
 
 The registered tools return MCP text content:

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@ product overview and quick start; package directories contain package-specific A
 ## Contribute or Use an Agent
 
 - [`../CONTRIBUTING.md`](../CONTRIBUTING.md): contributor workflow, validation, and releases.
-- [`../AGENTS.md`](../AGENTS.md): canonical repository instructions for Codex and Claude.
+- [`../AGENTS.md`](../AGENTS.md): canonical repository instructions for Codex and Claude — build traps,
+  a file-level source map, per-task routing, contract checklists, and what CI gates on.
 - [`../SKILL.md`](../SKILL.md): portable context for an agent integrating OneSub into another project.
 - [`AI-WORKFLOW.md`](AI-WORKFLOW.md): prompts for repository work and application integration.

--- a/docs/RECEIPT-ERRORS.md
+++ b/docs/RECEIPT-ERRORS.md
@@ -102,6 +102,7 @@ User already owns this non-consumable on the server side (first check, before re
 - **Symptom**: User taps "Purchase" on a non-consumable they already own; server returns 409 immediately.
 - **SDK behavior**: the SDK translates this into `{ valid: true, action: 'restored' }` for user-friendly handling. The 409 + `errorCode` is what non-SDK HTTP clients see.
 - **Fix (client UX)**: use `result.action === 'restored'` to show "이미 구매한 상품입니다" instead of "구매 완료". The SDK also auto-fires `finishTransaction` so StoreKit queue stays clean.
+- **Store-side variant**: the same code is also thrown client-side when the *store* — not the server — reports that the device already owns the SKU (`react-native-iap` `already-owned` / `E_ITEM_ALREADY_OWNED`, in either legacy `E_*` or OpenIAP spelling). Only non-consumables map this way; a consumable must be consumed, not restored, so its duplicate events keep the generic error path. Recover by calling `restoreProduct(productId, 'non_consumable')`.
 
 ### `TRANSACTION_BELONGS_TO_OTHER_USER` (409)
 
@@ -211,9 +212,14 @@ User dismissed the StoreKit / Play sheet. Not an error — handle silently.
 
 ### `CONCURRENT_PURCHASE`
 
-`subscribe()` / `purchaseProduct()` for the same `productId` called while a previous call for that same `productId` hasn't resolved yet.
+Another IAP operation was still running. Two sources:
 
-- **Fix (client)**: gate the buy button on `isLoading`. The SDK already protects with `isBusyRef` at the session level, but concurrent calls for different `productId`s via separate code paths can still race.
+- `purchaseProduct()` / `restoreProduct()` called while the SDK is busy — including the window after a subscription validates but before native `finishTransaction` cleanup settles. These **throw** this code rather than returning `null`, so a refusal is never mistaken for a user cancel.
+- `registerInFlight()` refusing a second in-flight entry for the same `productId`.
+
+`subscribe()` / `subscribeWithResult()` are deliberately quieter: while busy they no-op (`void` / `null`) instead of throwing.
+
+- **Fix (client)**: gate every IAP button on `isBusy` (not `isLoading`, which also covers passive status refreshes). Treat a caught `CONCURRENT_PURCHASE` as a double-tap and return silently.
 
 ### `PROVIDER_UNMOUNTED`
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -124,6 +124,36 @@ Sample output when a user subscribes:
 
 If something goes wrong, trace shows exactly where: the `matched` flag distinguishes in-flight matches from orphan replays, `matchingAllowed` reveals drain-window state, and `action: 'restored'` vs `'new'` tells you whether the server treated the receipt as a first-time purchase.
 
+### `null` versus a thrown error
+
+`null` always means "nothing was purchased, and that is a normal outcome." A thrown `OneSubError`
+means the operation failed or was refused. Branch on both.
+
+| Call | Returns `null` when | Throws when |
+|---|---|---|
+| `subscribeWithResult()` | user cancelled, or another IAP operation is already running | validation fails, the store errors, or `react-native-iap` is missing |
+| `subscribe()` | — (returns `void`; no-ops on cancel or while busy) | same as above |
+| `restore()` | — (returns `void`; no-ops while busy, and falls back to the server's status when the store has nothing to restore or validation is rejected) | the matched purchase carries no receipt (`NO_RECEIPT_DATA`), the status call fails, or `react-native-iap` is missing |
+| `purchaseProduct(id, type)` | user cancelled | another IAP operation is running (`CONCURRENT_PURCHASE`), the non-consumable is already owned on the device (`NON_CONSUMABLE_ALREADY_OWNED`), or validation fails |
+| `restoreProduct(id, type)` | the store's purchase history has no matching purchase | another IAP operation is running (`CONCURRENT_PURCHASE`), the matched purchase carries no receipt (`NO_RECEIPT_DATA`), or validation fails |
+
+The subscription entry points are deliberately quieter than the one-time-purchase ones: a paywall
+that double-fires `subscribe()` should do nothing, while `purchaseProduct()` / `restoreProduct()`
+report the refusal so host code can tell a busy SDK apart from a user who backed out. Gate every IAP
+button on `isBusy` and both cases stay rare.
+
+When a `restoreProduct()` validation fails, the server's `errorCode` is preserved on the thrown
+`OneSubError` (falling back to `RECEIPT_VALIDATION_FAILED`), so the same `switch` handles client- and
+server-side causes.
+
+### Google Play subscription offers
+
+Play requires an offer token for every subscription purchase. The SDK reads the eligible offers off
+the product `react-native-iap` returns — both the OpenIAP `subscriptionOffers` field and the legacy
+`subscriptionOfferDetailsAndroid` field, de-duplicated — and passes them through to
+`requestPurchase`. Nothing to configure; just make sure the subscription has at least one active
+base plan offer in Play Console, or Play rejects the purchase before the sheet appears.
+
 ### Structured errors
 
 Every `Error` thrown by the SDK is a `OneSubError` with a machine-readable `code`:

--- a/packages/sdk/src/OneSubProvider.tsx
+++ b/packages/sdk/src/OneSubProvider.tsx
@@ -21,11 +21,16 @@ import {
   registerInFlight as registerInFlightPure,
   clearInFlight,
   isUserCancelled,
+  isAlreadyOwnedNativeCode,
+  isDuplicatePurchaseNativeCode,
+  assertIapOperationAvailable,
+  initializeIapConnectionWithListeners,
+  mapNativePurchaseErrorCode,
   extractReceiptToken,
   extractTransactionId,
   type InFlightEntry,
 } from './purchaseFlow.js';
-import { OneSubError } from './OneSubError.js';
+import { OneSubError, isOneSubErrorCode } from './OneSubError.js';
 import { createSdkLogger } from './logger.js';
 import { buildRequestPurchaseArgs } from './iapRequest.js';
 
@@ -150,14 +155,11 @@ function getCurrentPlatform(): 'ios' | 'android' {
 //      no promise to resolve, no UI side-effect).
 //
 // Why this fixes the "TestFlight: sheet doesn't appear, app says 결제 복구됨"
-// bug: under the old per-call listener pattern, attaching the listener after
-// initConnection immediately delivered the pending transaction (before
-// requestPurchase could show the StoreKit sheet). The listener resolved the
-// promise with that stale event. Under this mount-level pattern, pending
-// transactions are drained silently right after initConnection, so by the
-// time the user taps Subscribe the queue is empty and the only event that
-// can fire is the fresh transaction StoreKit creates after the user confirms
-// in the sheet.
+// bug: the mount listener is registered BEFORE initConnection because RN-IAP
+// can emit queued StoreKit transactions during initialization. The drain gate
+// handles those as orphan replays, so by the time the user taps Subscribe the
+// queue is empty and the only event that can match their in-flight entry is
+// the fresh transaction StoreKit creates after confirmation.
 // ---------------------------------------------------------------------------
 
 export interface OneSubProviderProps {
@@ -315,39 +317,66 @@ export function OneSubProvider({ config, userId, accountToken, children }: OneSu
         releaseDrain(mockMode ? 'mockMode' : 'no-rn-iap');
         return;
       }
-      try {
-        logger.trace('initConnection start');
-        await RNIap.initConnection();
-        logger.trace('initConnection ok');
-      } catch (err) {
-        logger.warn('initConnection failed', err);
-        releaseDrain('init-failed');
-        return;
-      }
-      if (cancelled) return;
 
-      // Attach listeners BEFORE any further await so we catch every replay
-      // from Transaction.updates.
+      // Keep callback identity stable across the pre-init registration and
+      // post-init retry. RN-IAP v15 fans out through a Set, so the retry does
+      // not duplicate delivery when the first registration was already live.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      updatedSub = RNIap.purchaseUpdatedListener((purchase: any) => {
+      const onPurchaseUpdated = (purchase: any) => {
         void handlePurchaseEvent(purchase);
-      });
+      };
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      errorSub = RNIap.purchaseErrorListener((err: any) => {
+      const onPurchaseError = (err: any) => {
         // Errors are routed to every in-flight promise (we can't tell which
-        // SKU StoreKit was processing when an error fires). RN-IAP surfaces
-        // 'E_USER_CANCELLED' / 'E_USER_ERROR' — map both to USER_CANCELLED.
+        // SKU StoreKit was processing when an error fires). Map each entry
+        // separately because already-owned is only a restore signal for a
+        // non-consumable; cancellation is common to every purchase kind.
         const rnCode: string | undefined = typeof err?.code === 'string' ? err.code : undefined;
-        const code = (rnCode === 'E_USER_CANCELLED' || rnCode === 'E_USER_ERROR')
-          ? ONESUB_ERROR_CODE.USER_CANCELLED
-          : ONESUB_ERROR_CODE.INTERNAL_ERROR;
-        logger.trace('purchase error event', { code, rnCode, inFlightCount: inFlightRef.current.size });
-        const wrapped = new OneSubError(code, err?.message ?? '[onesub] Purchase error', err);
+        // RN-IAP sends this only after it already delivered the original
+        // purchaseUpdated event. Rejecting here races the original async server
+        // validation and can strand a paid transaction before host fulfillment.
+        if (isDuplicatePurchaseNativeCode(rnCode)) {
+          logger.trace('duplicate purchase update ignored', { rnCode });
+          return;
+        }
         for (const [pid, entry] of inFlightRef.current.entries()) {
+          const code = mapNativePurchaseErrorCode(err, entry);
+          logger.trace('purchase error event', { code, rnCode, productId: pid });
+          const wrapped = new OneSubError(code, err?.message ?? '[onesub] Purchase error', err);
           entry.reject(wrapped);
           inFlightRef.current.delete(pid);
         }
-      });
+      };
+
+      function attachListeners(): void {
+        const nextUpdatedSub = RNIap.purchaseUpdatedListener(onPurchaseUpdated);
+        if (!updatedSub) updatedSub = nextUpdatedSub;
+        const nextErrorSub = RNIap.purchaseErrorListener(onPurchaseError);
+        if (!errorSub) errorSub = nextErrorSub;
+      }
+
+      try {
+        const ready = await initializeIapConnectionWithListeners(
+          attachListeners,
+          async () => {
+            logger.trace('initConnection start');
+            const connected = await RNIap.initConnection();
+            logger.trace('initConnection ok', { connected });
+            return connected;
+          },
+          () => cancelled,
+        );
+        if (!ready) return;
+      } catch (err) {
+        logger.warn('initConnection failed', err);
+        try { updatedSub?.remove?.(); } catch { /* ignore */ }
+        try { errorSub?.remove?.(); } catch { /* ignore */ }
+        updatedSub = null;
+        errorSub = null;
+        try { await RNIap.endConnection?.(); } catch { /* ignore */ }
+        releaseDrain('init-failed');
+        return;
+      }
       logger.trace('listeners attached; drain window open', { drainMs: DRAIN_WINDOW_MS });
 
       // Release the drain gate after the window closes. Any queued replays
@@ -596,7 +625,7 @@ export function OneSubProvider({ config, userId, accountToken, children }: OneSu
       productId: string,
       type: 'consumable' | 'non_consumable',
     ): Promise<(PurchaseInfo & { action?: 'new' | 'restored' }) | null> => {
-      if (isBusyRef.current) return null;
+      assertIapOperationAvailable(isBusyRef.current);
       if (mockMode) {
         return mockPurchaseInfo(productId, type);
       }
@@ -636,9 +665,23 @@ export function OneSubProvider({ config, userId, accountToken, children }: OneSu
         try {
           await RNIap.requestPurchase(buildRequestPurchaseArgs(productId, platform, 'in-app', accountTokenRef.current));
         } catch (err) {
-          clearInFlight(inFlightRef.current, productId);
-          if (isUserCancelled(err)) return null;
-          throw err;
+          const nativeCode = (err as { code?: unknown } | null)?.code;
+          // Same contract as the listener: the original updated event owns the
+          // result promise. Keep the entry registered and await it below.
+          if (isDuplicatePurchaseNativeCode(nativeCode)) {
+            logger.trace('requestPurchase duplicate update ignored', { productId });
+          } else {
+            clearInFlight(inFlightRef.current, productId);
+            if (isUserCancelled(err)) return null;
+            if (type === 'non_consumable' && isAlreadyOwnedNativeCode(nativeCode)) {
+              throw new OneSubError(
+                ONESUB_ERROR_CODE.NON_CONSUMABLE_ALREADY_OWNED,
+                err instanceof Error ? err.message : '[onesub] Product is already owned.',
+                err,
+              );
+            }
+            throw err;
+          }
         }
 
         const result = await resultPromise;
@@ -664,7 +707,7 @@ export function OneSubProvider({ config, userId, accountToken, children }: OneSu
       productId: string,
       type: 'consumable' | 'non_consumable',
     ): Promise<(PurchaseInfo & { action?: 'new' | 'restored' }) | null> => {
-      if (isBusyRef.current) return null;
+      assertIapOperationAvailable(isBusyRef.current);
       if (mockMode) {
         return mockPurchaseInfo(productId, type);
       }
@@ -728,7 +771,10 @@ export function OneSubProvider({ config, userId, accountToken, children }: OneSu
           } satisfies PurchaseInfo & { action: 'restored' };
         }
 
-        throw new OneSubError(ONESUB_ERROR_CODE.RECEIPT_VALIDATION_FAILED, validationResult.error ?? '[onesub] Restore validation failed.');
+        const validationCode = isOneSubErrorCode(validationResult.errorCode)
+          ? validationResult.errorCode
+          : ONESUB_ERROR_CODE.RECEIPT_VALIDATION_FAILED;
+        throw new OneSubError(validationCode, validationResult.error ?? '[onesub] Restore validation failed.');
       } finally {
         releaseIapOperation();
       }

--- a/packages/sdk/src/OneSubProvider.tsx
+++ b/packages/sdk/src/OneSubProvider.tsx
@@ -244,10 +244,18 @@ export function OneSubProvider({ config, userId, accountToken, children }: OneSu
   // -------------------------------------------------------------------------
   useEffect(() => {
     let cancelled = false;
+    // Every subscription handed back by RN-IAP, including the post-init retry.
+    // Storing only the first one would leak a live listener past unmount if a
+    // release ever stops deduping identical callbacks; removing an already
+    // removed subscription is a no-op, so keeping both is strictly safer.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let updatedSub: any = null;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let errorSub: any = null;
+    const listenerSubs: any[] = [];
+    function removeListeners(): void {
+      while (listenerSubs.length) {
+        const sub = listenerSubs.pop();
+        try { sub?.remove?.(); } catch { /* ignore */ }
+      }
+    }
 
     // Re-runs of this effect (userId/serverUrl change) re-init the IAP
     // connection, which can replay queued transactions all over again — the
@@ -349,10 +357,8 @@ export function OneSubProvider({ config, userId, accountToken, children }: OneSu
       };
 
       function attachListeners(): void {
-        const nextUpdatedSub = RNIap.purchaseUpdatedListener(onPurchaseUpdated);
-        if (!updatedSub) updatedSub = nextUpdatedSub;
-        const nextErrorSub = RNIap.purchaseErrorListener(onPurchaseError);
-        if (!errorSub) errorSub = nextErrorSub;
+        listenerSubs.push(RNIap.purchaseUpdatedListener(onPurchaseUpdated));
+        listenerSubs.push(RNIap.purchaseErrorListener(onPurchaseError));
       }
 
       try {
@@ -369,10 +375,7 @@ export function OneSubProvider({ config, userId, accountToken, children }: OneSu
         if (!ready) return;
       } catch (err) {
         logger.warn('initConnection failed', err);
-        try { updatedSub?.remove?.(); } catch { /* ignore */ }
-        try { errorSub?.remove?.(); } catch { /* ignore */ }
-        updatedSub = null;
-        errorSub = null;
+        removeListeners();
         try { await RNIap.endConnection?.(); } catch { /* ignore */ }
         releaseDrain('init-failed');
         return;
@@ -396,8 +399,7 @@ export function OneSubProvider({ config, userId, accountToken, children }: OneSu
     return () => {
       cancelled = true;
       logger.trace('provider unmount', { pendingInFlight: inFlightRef.current.size });
-      try { updatedSub?.remove?.(); } catch { /* ignore */ }
-      try { errorSub?.remove?.(); } catch { /* ignore */ }
+      removeListeners();
       // Reject any dangling in-flight promises so callers don't hang forever
       for (const [pid, entry] of inFlightRef.current.entries()) {
         entry.reject(new OneSubError(ONESUB_ERROR_CODE.PROVIDER_UNMOUNTED, '[onesub] Provider unmounted'));

--- a/packages/sdk/src/__tests__/purchaseFlow.test.ts
+++ b/packages/sdk/src/__tests__/purchaseFlow.test.ts
@@ -6,6 +6,12 @@ import {
   registerInFlight,
   clearInFlight,
   isUserCancelled,
+  isUserCancelledNativeCode,
+  isAlreadyOwnedNativeCode,
+  isDuplicatePurchaseNativeCode,
+  assertIapOperationAvailable,
+  initializeIapConnectionWithListeners,
+  mapNativePurchaseErrorCode,
   extractReceiptToken,
   isSubscriptionEvent,
   resolvePurchaseType,
@@ -598,6 +604,8 @@ describe('isUserCancelled', () => {
   it('matches raw react-native-iap cancel codes', () => {
     expect(isUserCancelled({ code: 'E_USER_CANCELLED' })).toBe(true);
     expect(isUserCancelled({ code: 'E_USER_ERROR' })).toBe(true);
+    expect(isUserCancelled({ code: 'user-cancelled' })).toBe(true);
+    expect(isUserCancelled({ code: 'user-error' })).toBe(true);
     expect(isUserCancelled({ code: 'E_UNKNOWN' })).toBe(false);
   });
 
@@ -613,6 +621,84 @@ describe('isUserCancelled', () => {
     expect(isUserCancelled(null)).toBe(false);
     expect(isUserCancelled(undefined)).toBe(false);
     expect(isUserCancelled('E_USER_CANCELLED')).toBe(false);
+  });
+});
+
+describe('native purchase error mapping', () => {
+  it('normalizes legacy and RN-IAP v15 cancellation spellings', () => {
+    expect(isUserCancelledNativeCode('E_USER_CANCELLED')).toBe(true);
+    expect(isUserCancelledNativeCode('E_USER_CANCELED')).toBe(true);
+    expect(isUserCancelledNativeCode('user-cancelled')).toBe(true);
+    expect(isUserCancelledNativeCode('user-error')).toBe(true);
+  });
+
+  it('recognizes RN-IAP v15 already-owned codes', () => {
+    expect(isAlreadyOwnedNativeCode('already-owned')).toBe(true);
+    expect(isAlreadyOwnedNativeCode('E_ITEM_ALREADY_OWNED')).toBe(true);
+  });
+
+  it('keeps duplicate purchase updates distinct from already-owned', () => {
+    expect(isDuplicatePurchaseNativeCode('duplicate-purchase')).toBe(true);
+    expect(isAlreadyOwnedNativeCode('duplicate-purchase')).toBe(false);
+  });
+
+  it('keeps a busy operation distinct from cancel/no-purchase null outcomes', () => {
+    expect(() => assertIapOperationAvailable(false)).not.toThrow();
+    expect(() => assertIapOperationAvailable(true)).toThrow(expect.objectContaining({
+      code: ONESUB_ERROR_CODE.CONCURRENT_PURCHASE,
+    }));
+  });
+
+  it('attaches listeners before init and retries after a successful connection', async () => {
+    const calls: string[] = [];
+    const attachListeners = vi.fn(() => { calls.push('attach'); });
+    const initConnection = vi.fn(async () => {
+      calls.push('init');
+      expect(attachListeners).toHaveBeenCalledOnce();
+      return true;
+    });
+
+    await expect(initializeIapConnectionWithListeners(
+      attachListeners,
+      initConnection,
+    )).resolves.toBe(true);
+    expect(calls).toEqual(['attach', 'init', 'attach']);
+  });
+
+  it('does not reattach after provider cancellation during init', async () => {
+    let cancelled = false;
+    const attachListeners = vi.fn();
+    const initConnection = vi.fn(async () => {
+      cancelled = true;
+      return true;
+    });
+
+    await expect(initializeIapConnectionWithListeners(
+      attachListeners,
+      initConnection,
+      () => cancelled,
+    )).resolves.toBe(false);
+    expect(attachListeners).toHaveBeenCalledOnce();
+  });
+
+  it('rejects false init without a post-init listener retry', async () => {
+    const attachListeners = vi.fn();
+    await expect(initializeIapConnectionWithListeners(
+      attachListeners,
+      async () => false,
+    )).rejects.toMatchObject({ code: ONESUB_ERROR_CODE.INTERNAL_ERROR });
+    expect(attachListeners).toHaveBeenCalledOnce();
+  });
+
+  it('maps ownership only for non-consumable purchase entries', () => {
+    const nonConsumable = { kind: 'purchase' as const, purchaseType: 'non_consumable' as const };
+    const consumable = { kind: 'purchase' as const, purchaseType: 'consumable' as const };
+    expect(mapNativePurchaseErrorCode({ code: 'already-owned' }, nonConsumable))
+      .toBe(ONESUB_ERROR_CODE.NON_CONSUMABLE_ALREADY_OWNED);
+    expect(mapNativePurchaseErrorCode({ code: 'duplicate-purchase' }, nonConsumable))
+      .toBe(ONESUB_ERROR_CODE.INTERNAL_ERROR);
+    expect(mapNativePurchaseErrorCode({ code: 'already-owned' }, consumable))
+      .toBe(ONESUB_ERROR_CODE.INTERNAL_ERROR);
   });
 });
 

--- a/packages/sdk/src/__tests__/purchaseFlow.test.ts
+++ b/packages/sdk/src/__tests__/purchaseFlow.test.ts
@@ -690,6 +690,17 @@ describe('native purchase error mapping', () => {
     expect(attachListeners).toHaveBeenCalledOnce();
   });
 
+  it('treats a void init resolution as connected', async () => {
+    // Some react-native-iap builds resolve undefined on success — tearing the
+    // listeners down there would kill purchasing on a healthy connection.
+    const attachListeners = vi.fn();
+    await expect(initializeIapConnectionWithListeners(
+      attachListeners,
+      async () => undefined,
+    )).resolves.toBe(true);
+    expect(attachListeners).toHaveBeenCalledTimes(2);
+  });
+
   it('maps ownership only for non-consumable purchase entries', () => {
     const nonConsumable = { kind: 'purchase' as const, purchaseType: 'non_consumable' as const };
     const consumable = { kind: 'purchase' as const, purchaseType: 'consumable' as const };

--- a/packages/sdk/src/purchaseFlow.ts
+++ b/packages/sdk/src/purchaseFlow.ts
@@ -416,15 +416,20 @@ export function assertIapOperationAvailable(isBusy: boolean): void {
  * RN-IAP 15 can emit queued StoreKit transactions while `initConnection()` is
  * still resolving. Register first, then retry registration after init for the
  * rare Nitro-not-ready path where the pre-init JS subscription was inert.
+ *
+ * Only an explicit `false` counts as a failed connection. Some react-native-iap
+ * builds resolve `undefined` on success, and tearing the listeners down there
+ * would kill purchasing on a perfectly healthy connection; a real failure
+ * rejects rather than resolving falsy.
  */
 export async function initializeIapConnectionWithListeners(
   attachListeners: () => void,
-  initConnection: () => Promise<boolean>,
+  initConnection: () => Promise<boolean | void>,
   isCancelled: () => boolean = () => false,
 ): Promise<boolean> {
   attachListeners();
   const connected = await initConnection();
-  if (!connected) {
+  if (connected === false) {
     throw new OneSubError(
       ONESUB_ERROR_CODE.INTERNAL_ERROR,
       '[onesub] IAP connection initialization returned false.',

--- a/packages/sdk/src/purchaseFlow.ts
+++ b/packages/sdk/src/purchaseFlow.ts
@@ -362,6 +362,105 @@ export function clearInFlight(inFlight: Map<string, InFlightEntry>, productId: s
   inFlight.delete(productId);
 }
 
+const USER_CANCELLED_NATIVE_CODES = new Set([
+  'e-user-cancelled',
+  'e-user-canceled',
+  'e-user-error',
+  'user-cancelled',
+  'user-canceled',
+  'user-error',
+]);
+
+const ALREADY_OWNED_NATIVE_CODES = new Set([
+  'already-owned',
+  'e-already-owned',
+  'e-item-already-owned',
+]);
+
+function normalizeNativeErrorCode(code: unknown): string {
+  return typeof code === 'string'
+    ? code.trim().toLowerCase().replace(/[\s_]+/g, '-')
+    : '';
+}
+
+/** True for both legacy RN-IAP E_* and v15/OpenIAP normalized cancel codes. */
+export function isUserCancelledNativeCode(code: unknown): boolean {
+  return USER_CANCELLED_NATIVE_CODES.has(normalizeNativeErrorCode(code));
+}
+
+/** True when RN-IAP reports that a one-time product is already present. */
+export function isAlreadyOwnedNativeCode(code: unknown): boolean {
+  return ALREADY_OWNED_NATIVE_CODES.has(normalizeNativeErrorCode(code));
+}
+
+/**
+ * RN-IAP emitted the same purchase update twice and deliberately skipped the
+ * second delivery. This is not an ownership error: the first update is already
+ * being validated and must be allowed to settle the in-flight promise.
+ */
+export function isDuplicatePurchaseNativeCode(code: unknown): boolean {
+  return normalizeNativeErrorCode(code) === 'duplicate-purchase';
+}
+
+/** Keep a busy SDK operation distinct from cancel/no-purchase null outcomes. */
+export function assertIapOperationAvailable(isBusy: boolean): void {
+  if (isBusy) {
+    throw new OneSubError(
+      ONESUB_ERROR_CODE.CONCURRENT_PURCHASE,
+      '[onesub] Another purchase or restore operation is already in progress.',
+    );
+  }
+}
+
+/**
+ * RN-IAP 15 can emit queued StoreKit transactions while `initConnection()` is
+ * still resolving. Register first, then retry registration after init for the
+ * rare Nitro-not-ready path where the pre-init JS subscription was inert.
+ */
+export async function initializeIapConnectionWithListeners(
+  attachListeners: () => void,
+  initConnection: () => Promise<boolean>,
+  isCancelled: () => boolean = () => false,
+): Promise<boolean> {
+  attachListeners();
+  const connected = await initConnection();
+  if (!connected) {
+    throw new OneSubError(
+      ONESUB_ERROR_CODE.INTERNAL_ERROR,
+      '[onesub] IAP connection initialization returned false.',
+    );
+  }
+  if (isCancelled()) return false;
+  attachListeners();
+  return true;
+}
+
+/**
+ * Convert a native purchase error into OneSub's stable public error contract.
+ * `already-owned` is only canonicalized for non-consumables: treating a
+ * consumable duplicate event as ownership would incorrectly send callers down
+ * a restore path for a product that must be consumed instead.
+ */
+export function mapNativePurchaseErrorCode(
+  err: unknown,
+  entry?: Pick<InFlightEntry, 'kind' | 'purchaseType'>,
+): OneSubErrorCode {
+  const nativeCode = err && typeof err === 'object'
+    ? (err as Record<string, unknown>).code
+    : undefined;
+  if (isUserCancelledNativeCode(nativeCode)) {
+    return ONESUB_ERROR_CODE.USER_CANCELLED;
+  }
+  if (
+    entry?.kind === 'purchase'
+    && entry.purchaseType === 'non_consumable'
+    && isAlreadyOwnedNativeCode(nativeCode)
+  ) {
+    return ONESUB_ERROR_CODE.NON_CONSUMABLE_ALREADY_OWNED;
+  }
+  return ONESUB_ERROR_CODE.INTERNAL_ERROR;
+}
+
 /**
  * True when the error represents the user dismissing the purchase sheet —
  * either a raw react-native-iap error code or the SDK's own OneSubError
@@ -375,5 +474,5 @@ export function isUserCancelled(err: unknown): boolean {
   }
   if (!err || typeof err !== 'object') return false;
   const code = (err as Record<string, unknown>).code;
-  return code === 'E_USER_CANCELLED' || code === 'E_USER_ERROR';
+  return isUserCancelledNativeCode(code);
 }


### PR DESCRIPTION
Two commits, reviewable separately.

## `fix(sdk)` — native purchase error contract

- Normalize react-native-iap v15 / OpenIAP error spellings alongside legacy `E_*` codes.
- Canonicalize already-owned to `NON_CONSUMABLE_ALREADY_OWNED` for non-consumables only — a consumable duplicate must be consumed, not restored.
- Ignore `duplicate-purchase` updates so the original event settles the in-flight promise instead of stranding a paid transaction.
- Register purchase listeners **before** `initConnection()`; the drain gate handles queued replays as orphans.
- `purchaseProduct` / `restoreProduct` throw `CONCURRENT_PURCHASE` while another IAP operation runs, instead of returning an ambiguous `null`. Restore validation failures keep the server's `errorCode`.

Changeset included (`patch`, `@jeonghwanko/onesub-sdk`).

**Worth a second look before merge:**
1. `initializeIapConnectionWithListeners` throws when `initConnection()` resolves falsy. If any rn-iap build resolves `undefined` on success, a healthy connection is torn down. `connected === false` would be stricter.
2. The post-init `attachListeners()` retry discards its subscription handle, relying on RN-IAP deduping identical callbacks in a Set; if that assumption breaks, a listener survives unmount.

## `docs` — contract accuracy + agent navigation

- SDK README: `null`-versus-throw table, Google Play offer-token forwarding.
- `docs/RECEIPT-ERRORS.md`: `CONCURRENT_PURCHASE` rewritten to match behavior; store-side already-owned variant added.
- `docs/ARCHITECTURE.md`: new "SDK Purchase Flow (client)" section (mount listeners, drain window, in-flight registry, event handling, error contract).
- `AGENTS.md`: file-level source map, start-here-by-task routing, non-gating workflows (release / dashboard image / manual e2e / weekly bench), finish-and-report checklist, do-not-without-asking list.
- `CLAUDE.md` stays an `AGENTS.md` importer plus harness notes; `AI-WORKFLOW.md` gains a session-setup checklist; README/SKILL/CONTRIBUTING updated to match.

## Validation

- `npm test` — 46 files, 599 tests, all pass
- `npm run type-check -w @jeonghwanko/onesub-sdk` — clean
- `npm run docs:check` — OK
- Not run: `pwsh ./validate-unity-packages.ps1` (no PowerShell in this environment; no Unity files touched), `npm run size -w @onesub/server` (no server changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)