### PR TITLE
ci: widen dashboard image trigger to the full Dockerfile input set

### DIFF
--- a/.github/workflows/docker-dashboard.yml
+++ b/.github/workflows/docker-dashboard.yml
@@ -4,8 +4,16 @@ on:
   push:
     branches: [master]
     paths:
+      # Keep this list in sync with everything packages/dashboard/Dockerfile
+      # copies. The image runs `npm ci` against the ROOT lockfile, so a
+      # dependency bump that touches nothing under packages/ still changes what
+      # ships — omitting package-lock.json here silently leaves the published
+      # image on the old dependency set.
       - 'packages/dashboard/**'
-      - 'packages/shared/src/**'
+      - 'packages/shared/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.base.json'
       - '.github/workflows/docker-dashboard.yml'
   workflow_dispatch:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,7 +304,7 @@ The remaining workflows never gate a PR, so do not wait on them or try to trigge
 | Workflow | Trigger | What it does |
 |---|---|---|
 | `publish.yml` (`Release`) | push to `master` | Runs Changesets: opens/updates the "Version Packages" PR, publishes on merge |
-| `docker-dashboard.yml` | push to `master` touching `packages/dashboard/**` or `packages/shared/src/**` (also manual) | Builds and publishes the dashboard Docker image |
+| `docker-dashboard.yml` | push to `master` touching `packages/dashboard/**`, `packages/shared/**`, the root `package.json` / `package-lock.json`, or `tsconfig.base.json` (also manual) | Builds and publishes the dashboard Docker image |
 | `e2e.yml` | manual dispatch only | Real Apple/Google sandbox round-trips; needs shared secrets, so it cannot run on a PR |
 | `bench.yml` | weekly schedule (also manual) | k6 status/webhook load tests from `bench/` |
 
@@ -337,8 +337,10 @@ If a change needs real sandbox coverage, say so in the PR description and ask a 
    Do not hand-edit package versions or generated per-package changelogs.
 8. Breaking changes also require `docs/MIGRATION.md`. Docs, tests, CI, `examples/*`, and
    `packages/dashboard` changes need no changeset — the dashboard is private and ships as a Docker
-   image published by `docker-dashboard.yml`, which also republishes on any `packages/shared/src`
-   change.
+   image published by `docker-dashboard.yml`, which also republishes on any `packages/shared`,
+   root-manifest, or `tsconfig.base.json` change. The image builds with `npm ci` against the root
+   lockfile, so a dependency bump touching nothing under `packages/` still changes what ships; keep
+   that workflow's `paths` filter in sync with what `packages/dashboard/Dockerfile` copies.
 
 ### Before You Call a Task Done
 


### PR DESCRIPTION
## The gap

`packages/dashboard/Dockerfile` copies the root `package*.json` and `tsconfig.base.json`, then runs `npm ci --workspaces --include-workspace-root`. **The root lockfile decides what ships in the image.**

The `paths` filter only watched `packages/dashboard/**` and `packages/shared/src/**`.

This is not theoretical. #121 bumped `next` 16.2.10 → 16.2.12 to clear nine Next.js advisories (SSRF, middleware bypass, DoS, cache confusion). It touched nothing under `packages/`, so `docker-dashboard.yml` never fired — the published image kept serving the vulnerable dependency set until the workflow was dispatched by hand.

## The fix

```diff
     paths:
       - 'packages/dashboard/**'
-      - 'packages/shared/src/**'
+      - 'packages/shared/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.base.json'
       - '.github/workflows/docker-dashboard.yml'
```

Every entry maps to something the Dockerfile actually consumes. `packages/shared/**` rather than only its `src/` because the Dockerfile copies the whole directory — a change to its build script would otherwise be missed too.

## Trade-off

The image now rebuilds on any dependency change. That is noisier, and it is correct: a dependency change is precisely what changes the image contents. The alternative is the failure mode above, where a security fix lands on `master` and silently never reaches the artifact.

## Docs

`AGENTS.md` had two stale descriptions of the old filter — the non-gating workflow table row and the changeset note in *Change Workflow*. Both updated, with the root-lockfile reason recorded so the filter and the Dockerfile stay in sync.

`npm run docs:check` — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)