### PR TITLE
perf: cut redundant store reads and cache the hot verification/metrics paths

### DIFF
--- a/.changeset/fresh-metrics-settle.md
+++ b/.changeset/fresh-metrics-settle.md
@@ -1,0 +1,43 @@
+---
+'@onesub/shared': minor
+'@onesub/server': minor
+---
+
+Bound how often the metrics endpoints scan the store, and make their aggregation
+testable.
+
+Every `/onesub/metrics/*` endpoint reduces every record in the subscription or
+purchase store. The dashboard overview calls four of them per render and opts out
+of client-side fetch caching, so an uncached deployment re-scanned both tables on
+every browser refresh, by every operator — with the reduction running
+synchronously on the event loop, where it competes with receipt validation.
+
+Aggregate responses are now cached for `metricsCacheTtlSeconds` (new config
+field, default `30`, `0` disables). Cache keys are snapped onto the TTL grid
+because the dashboard sends `to = new Date()` at millisecond precision, which
+would otherwise make every request a unique key; the response still echoes the
+caller's own `from`/`to`, so a client always sees the window it asked about.
+Concurrent misses on one key collapse into a single computation.
+
+The cache is private to each middleware instance rather than shared through the
+`cache` adapter. A metrics key describes "every record in this store" and cannot
+discriminate one store from another, so sharing would let two middlewares in one
+process — or two deployments pointed at one Redis database — read each other's
+totals for any window that happened to match. The trade-off is that a K-process
+deployment recomputes up to K times per window instead of once, which is still a
+fixed bound where there previously was none.
+
+Nothing that decides entitlement is cached: `/onesub/status`,
+`/onesub/entitlement(s)`, and both validate routes are untouched.
+
+The reduction itself moved into `metrics-aggregate.ts` as pure functions. It had
+been duplicated across four handlers — each re-implementing the same window
+filter, product/platform tallies, and zero-filled UTC daily bucketing — and was
+unreachable by a test without an HTTP server. Responses are unchanged; the
+semantics now have direct coverage, including the inclusive window bounds and
+UTC bucket assignment, which is what a future SQL-side aggregation will have to
+reproduce.
+
+Per-request aggregation is still one full store read, so pushing the aggregation
+down into SQL remains worthwhile for large Postgres deployments. That needs
+per-store support and is not included here.

--- a/.changeset/heavy-moons-verify.md
+++ b/.changeset/heavy-moons-verify.md
@@ -1,0 +1,30 @@
+---
+'@onesub/server': patch
+---
+
+Cache successful Apple x5c chain verification instead of redoing it per request.
+
+`decodeJws` backs every receipt validation and every Apple webhook, and it
+re-ran the whole verification each time: an `X509Certificate` parse per cert in
+the chain, an ECDSA signature check per link, the bundled-root comparison, and a
+fresh `importX509` of the leaf key. All of it is synchronous CPU work on the
+event loop, and Apple's leaf certificates are stable for weeks, so the same
+chain was re-verified continuously to reach the same answer.
+
+Successful verifications are now memoised per process, keyed on the full `x5c`
+chain plus the JWS `alg`. Rejection behaviour is unchanged:
+
+- A failed verification is never cached, positive or negative — an untrusted
+  chain is rejected on every attempt.
+- An entry's lifetime is capped by the earliest `notAfter` in the chain that
+  produced it, so an expired certificate is never served from cache, and by a
+  1-hour ceiling on top of that.
+- `alg` is part of the entry identity, so a chain claiming a different algorithm
+  can never be served a key imported for another one.
+
+The cache is deliberately process-local rather than going through the pluggable
+`CacheAdapter`: an imported key is not JSON-serialisable (a Redis-backed adapter
+would round-trip it to `{}`), and what is avoided here is local CPU rather than
+a rate-limited network call — a Redis round-trip could cost more than the
+verification it replaces. Certificate revocation is not checked, unchanged from
+before.

--- a/.changeset/lucky-pandas-listen.md
+++ b/.changeset/lucky-pandas-listen.md
@@ -1,0 +1,22 @@
+---
+'@jeonghwanko/onesub-sdk': patch
+---
+
+Stop re-rendering every `useOneSub()` consumer on every provider render.
+
+The context value was rebuilt on each render, and the purchase/restore
+callbacks depended on the whole `config` object — which is a new object every
+render for the common `config={{ ... }}` inline-literal usage. Together that
+handed consumers a fresh context identity on any render of the tree above the
+provider.
+
+The config is now read through a ref (the same pattern already used for
+`accountToken`), so those callbacks are stable, and the context value is
+memoized. No API change.
+
+This also fixes a latent staleness bug: the mount effect re-runs only on
+`serverUrl` / `userId`, so a host that changed another config field — notably
+adding a `consumableProductIds` entry — kept feeding the purchase listener the
+config captured at mount. Orphan-replay purchase-type resolution reads exactly
+that list, so a consumable could be recorded as `non_consumable` even after the
+host declared it correctly.

--- a/.changeset/quiet-lions-observe.md
+++ b/.changeset/quiet-lions-observe.md
@@ -1,0 +1,23 @@
+---
+'@onesub/server': patch
+---
+
+Remove the per-entitlement store re-reads from batch entitlement evaluation.
+
+`evaluateEntitlement` reads a user's subscriptions and purchases itself, so
+callers evaluating several entitlements for one user paid two store round-trips
+per entitlement. `GET /onesub/entitlements` did that for every configured
+entitlement, and `GET /onesub/admin/customers/:userId` did it *serially* on top
+of records it had already fetched — so a host with N entitlements issued 2N
+redundant queries per request on both paths.
+
+Both now read the user's records once and evaluate every entitlement against
+them. New export `evaluateEntitlementFrom(subs, purchases, entitlement, now?)`
+is the store-free evaluator for hosts that want the same batching in their own
+code. `evaluateEntitlement` keeps its signature and its behavior, including
+skipping the purchase read when a subscription already grants the entitlement.
+
+Also fixes a listener leak in the shared outbound `fetch` helper: the
+caller-signal `abort` listener used `{ once: true }`, which only self-removes
+when the event fires, so a caller reusing one long-lived `AbortSignal` across
+requests accumulated a listener per call. It is now removed on every path.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -44,6 +44,7 @@ explicitly. Without them, middleware uses in-memory stores even when `database.u
 | `apps` | No | Single-app mode | Credentials for multiple isolated applications |
 | `defaultAppId` | No | Top-level app or only configured app | Fallback app when a request cannot identify one |
 | `adminSecret` | No | Admin/metrics routes not mounted | Protects admin, customer, metrics, sync, and dead-letter routes |
+| `metricsCacheTtlSeconds` | No | `30` | How long a `/onesub/metrics/*` aggregate may be reused; `0` disables |
 | `entitlements` | No | Entitlement routes not mounted | Maps stable entitlement IDs to product IDs |
 | `refundPolicy` | No | `immediate` | Subscription refund access policy |
 | `logger` | No | `console` | `{ info, warn, error }` server log sink |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -5,6 +5,13 @@
 ### Apple StoreKit 2
 - JWS signature verified with the leaf certificate from the `x5c` header
 - **Full certificate chain verified up to Apple Root CA G3** (as of `@onesub/server@0.6.0`) using `node:crypto.X509Certificate` — each cert in the chain must be signed by the next, be within its validity window, and the final cert must be issued by a bundled Apple root. Leaf-only verification was insufficient because a self-signed cert could mint a passing signature
+- The result of a **successful** chain verification is memoised per process, keyed on the full `x5c`
+  chain plus the JWS `alg`, so repeated receipts and webhooks reuse the imported leaf key instead of
+  re-walking the chain. A failed verification is never cached — an untrusted chain is rejected on
+  every attempt. An entry's lifetime is capped by the earliest `notAfter` in the chain it came from,
+  so an expired certificate is never honoured from cache, and by a 1-hour ceiling. The cache is
+  process-local by design and is not affected by the Redis-backed `cache` adapter. Note that
+  certificate **revocation** is not checked, before or after this change
 - Sandbox receipts rejected in `NODE_ENV=production` unless `ONESUB_ALLOW_SANDBOX=true` is set (for TestFlight / pre-launch QA)
 - One-time-purchase receipt age limit, defaulting to 72 hours. It is a default, not an invariant: a
   host can raise or disable it with `apple.productReceiptMaxAgeHours` (see `docs/CONFIGURATION.md`)

--- a/packages/sdk/src/OneSubProvider.tsx
+++ b/packages/sdk/src/OneSubProvider.tsx
@@ -194,6 +194,16 @@ export function OneSubProvider({ config, userId, accountToken, children }: OneSu
   // without needing to be in their dependency arrays.
   const accountTokenRef = useRef(accountToken);
   accountTokenRef.current = accountToken;
+  // Same rationale as accountTokenRef, applied to the whole config object.
+  // Hosts commonly pass an inline literal (`config={{ ... }}`), which is a new
+  // object every render — so depending on `config` in a useCallback recreated
+  // every purchase/restore callback, and through them the context value, making
+  // every useOneSub() consumer re-render on any parent render. Reading the
+  // config through a ref keeps those callbacks stable AND always current: they
+  // are imperative actions that need the latest values when invoked, not a new
+  // identity when the values change.
+  const configRef = useRef(config);
+  configRef.current = config;
   const inFlightRef = useRef<Map<string, InFlightEntry>>(new Map());
   // Recreate only when the relevant config fields change — referential
   // stability keeps re-mount effects from firing on every parent render.
@@ -304,7 +314,12 @@ export function OneSubProvider({ config, userId, accountToken, children }: OneSu
     async function handlePurchaseEvent(purchase: any): Promise<void> {
       const platform = getCurrentPlatform();
       await handlePurchaseEventPure(purchase, {
-        config,
+        // Via the ref, not the captured prop: this effect only re-runs on
+        // serverUrl/userId, so a host that changes another field (e.g. adds a
+        // `consumableProductIds` entry) would otherwise keep feeding the
+        // listener the config from mount time — and orphan-replay type
+        // resolution reads exactly that list.
+        config: configRef.current,
         userId,
         platform,
         inFlight: inFlightRef.current,
@@ -458,7 +473,7 @@ export function OneSubProvider({ config, userId, accountToken, children }: OneSu
     if (mockMode) {
       const mockSubscription = {
         userId,
-        productId: getProductId(config, 'ios'),
+        productId: getProductId(configRef.current, 'ios'),
       } as SubscriptionInfo;
       setIsActive(true);
       setSubscription(mockSubscription);
@@ -479,7 +494,7 @@ export function OneSubProvider({ config, userId, accountToken, children }: OneSu
 
     try {
       const platform = getCurrentPlatform();
-      const productId = getProductId(config, platform);
+      const productId = getProductId(configRef.current, platform);
       logger.trace('subscribe() called', { productId, drainReady: drainCompleteRef.current });
 
       // Wait until the mount drain window closes. During drain StoreKit may
@@ -555,7 +570,7 @@ export function OneSubProvider({ config, userId, accountToken, children }: OneSu
       // the busy lock only after finishTransaction settles.
       if (!cleanupHandedOff) releaseIapOperation();
     }
-  }, [config, userId, mockMode, releaseIapOperation]);
+  }, [userId, mockMode, releaseIapOperation, logger]);
 
   // -------------------------------------------------------------------------
   // restore() — query the store's existing purchases and re-validate with server.
@@ -581,11 +596,12 @@ export function OneSubProvider({ config, userId, accountToken, children }: OneSu
       const platform = getCurrentPlatform();
       const purchases = await RNIap.getAvailablePurchases();
 
-      const productId = getProductId(config, platform);
+      const cfg = configRef.current;
+      const productId = getProductId(cfg, platform);
       const match = purchases.find((p: { productId: string }) => p.productId === productId);
 
       if (!match) {
-        const status = await checkStatus(config.serverUrl, userId);
+        const status = await checkStatus(cfg.serverUrl, userId);
         setIsActive(status.active);
         setSubscription(status.subscription);
         return;
@@ -598,26 +614,26 @@ export function OneSubProvider({ config, userId, accountToken, children }: OneSu
         throw new OneSubError(ONESUB_ERROR_CODE.NO_RECEIPT_DATA, '[onesub] Matched purchase has no receipt data.');
       }
 
-      const result = await validateReceipt(config.serverUrl, {
+      const result = await validateReceipt(cfg.serverUrl, {
         platform: platform === 'ios' ? 'apple' : 'google',
         receipt: receiptToken,
         userId,
         productId,
-        ...(config.appId ? { appId: config.appId } : {}),
+        ...(cfg.appId ? { appId: cfg.appId } : {}),
       });
 
       if (result.valid && result.subscription) {
         setIsActive(true);
         setSubscription(result.subscription);
       } else {
-        const status = await checkStatus(config.serverUrl, userId);
+        const status = await checkStatus(cfg.serverUrl, userId);
         setIsActive(status.active);
         setSubscription(status.subscription);
       }
     } finally {
       releaseIapOperation();
     }
-  }, [config, userId, mockMode, releaseIapOperation]);
+  }, [userId, mockMode, releaseIapOperation]);
 
   // -------------------------------------------------------------------------
   // purchaseProduct() — consumable or non-consumable one-time purchase
@@ -698,7 +714,7 @@ export function OneSubProvider({ config, userId, accountToken, children }: OneSu
         releaseIapOperation();
       }
     },
-    [config, userId, mockMode, releaseIapOperation],
+    [userId, mockMode, releaseIapOperation, logger],
   );
 
   // -------------------------------------------------------------------------
@@ -742,13 +758,14 @@ export function OneSubProvider({ config, userId, accountToken, children }: OneSu
         const purchaseType: PurchaseType =
           type === 'consumable' ? PURCHASE_TYPE.CONSUMABLE : PURCHASE_TYPE.NON_CONSUMABLE;
 
-        const validationResult = await validatePurchase(config.serverUrl, {
+        const cfg = configRef.current;
+        const validationResult = await validatePurchase(cfg.serverUrl, {
           platform: platform === 'ios' ? 'apple' : 'google',
           receipt,
           userId,
           productId,
           type: purchaseType,
-          ...(config.appId ? { appId: config.appId } : {}),
+          ...(cfg.appId ? { appId: cfg.appId } : {}),
         });
 
         if (validationResult.valid && validationResult.purchase) {
@@ -781,7 +798,7 @@ export function OneSubProvider({ config, userId, accountToken, children }: OneSu
         releaseIapOperation();
       }
     },
-    [config, userId, mockMode, releaseIapOperation],
+    [userId, mockMode, releaseIapOperation],
   );
 
   // Stable refresh function exposed via context. Re-fetches the entitlements
@@ -859,20 +876,40 @@ export function OneSubProvider({ config, userId, accountToken, children }: OneSu
     [restoreProduct, refreshEntitlements],
   );
 
-  const value: OneSubContextValue = {
-    isActive,
-    isLoading,
-    isBusy,
-    subscription,
-    subscribe: subscribeWithRefresh,
-    subscribeWithResult: subscribeWithResultAndRefresh,
-    restore: restoreWithRefresh,
-    purchaseProduct: purchaseProductWithRefresh,
-    restoreProduct: restoreProductWithRefresh,
-    entitlements,
-    hasEntitlement,
-    refreshEntitlements,
-  };
+  // Memoized so the context identity changes only when something in it
+  // actually changed. Without this, every Provider render handed consumers a
+  // new object and re-rendered all of them — and the Provider wraps the app
+  // root, so that is every render of the tree above it.
+  const value: OneSubContextValue = useMemo(
+    () => ({
+      isActive,
+      isLoading,
+      isBusy,
+      subscription,
+      subscribe: subscribeWithRefresh,
+      subscribeWithResult: subscribeWithResultAndRefresh,
+      restore: restoreWithRefresh,
+      purchaseProduct: purchaseProductWithRefresh,
+      restoreProduct: restoreProductWithRefresh,
+      entitlements,
+      hasEntitlement,
+      refreshEntitlements,
+    }),
+    [
+      isActive,
+      isLoading,
+      isBusy,
+      subscription,
+      subscribeWithRefresh,
+      subscribeWithResultAndRefresh,
+      restoreWithRefresh,
+      purchaseProductWithRefresh,
+      restoreProductWithRefresh,
+      entitlements,
+      hasEntitlement,
+      refreshEntitlements,
+    ],
+  );
 
   return <OneSubContext.Provider value={value}>{children}</OneSubContext.Provider>;
 }

--- a/packages/server/.size-limit.cjs
+++ b/packages/server/.size-limit.cjs
@@ -10,17 +10,28 @@
 // webhookQueue wiring (queue-mode processors exported for standalone
 // workers) and the full-parity OpenAPI spec (every mounted route
 // documented). Measured 30.7/31.04 KB at the bump.
+//
+// 2026-07-26: raised 34 → 36 KB for the Apple x5c chain-verification cache
+// (`providers/verified-key-cache.ts`), which stops every receipt and webhook
+// re-walking the certificate chain and re-importing the leaf key.
+// Measured 33.56/33.94 KB at the bump — the addition itself is +0.66 KB.
+//
+// The prior entry's figures had already drifted before that change: the tree
+// measured 32.78/33.15 KB with the cache reverted, i.e. ~2 KB of growth
+// accumulated under the 34 KB ceiling without a recorded bump. It left 0.06 KB
+// of headroom, so an unrelated commit would have failed this gate. Re-measure
+// and record here when the numbers move, not only when the limit is raised.
 module.exports = [
   {
     name: 'esm bundle (gzipped)',
     path: 'dist/index.js',
-    limit: '34 KB',
+    limit: '36 KB',
     gzip: true,
   },
   {
     name: 'cjs bundle (gzipped)',
     path: 'dist/index.cjs',
-    limit: '34 KB',
+    limit: '36 KB',
     gzip: true,
   },
 ];

--- a/packages/server/.size-limit.cjs
+++ b/packages/server/.size-limit.cjs
@@ -21,6 +21,9 @@
 // accumulated under the 34 KB ceiling without a recorded bump. It left 0.06 KB
 // of headroom, so an unrelated commit would have failed this gate. Re-measure
 // and record here when the numbers move, not only when the limit is raised.
+//
+// 2026-07-26: 34.17/34.55 KB after the metrics aggregation split and response
+// cache (`metrics-aggregate.ts`, `metrics-cache.ts`). Limit unchanged.
 module.exports = [
   {
     name: 'esm bundle (gzipped)',

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -47,6 +47,7 @@ app.use(createOneSubMiddleware({
   adminSecret: process.env.ADMIN_SECRET,   // enables admin + metrics routes
   logger: require('pino')(),               // any { info, warn, error } logger
   refundPolicy: 'immediate',               // 'immediate' (default) | 'until_expiry'
+  metricsCacheTtlSeconds: 30,              // 30 (default) | 0 to disable
 }));
 
 app.listen(4100);

--- a/packages/server/src/__tests__/admin-customer-detail.test.ts
+++ b/packages/server/src/__tests__/admin-customer-detail.test.ts
@@ -84,6 +84,21 @@ function buildServer(opts: { adminSecret?: string; entitlements?: EntitlementsCo
 const SECRET = 's3cr3t';
 const AUTH = { 'x-admin-secret': SECRET };
 
+/**
+ * Wrap one method on a live store instance and count how often it is called.
+ * The middleware holds a reference to the same object, and resolves the method
+ * at call time, so patching after `buildServer` is observed by the routes.
+ */
+function countCalls<T extends object, K extends keyof T>(target: T, method: K): () => number {
+  let calls = 0;
+  const original = target[method] as unknown as (...args: unknown[]) => unknown;
+  (target as Record<K, unknown>)[method] = (...args: unknown[]) => {
+    calls++;
+    return original.apply(target, args);
+  };
+  return () => calls;
+}
+
 describe('GET /onesub/admin/customers/:userId auth', () => {
   it('returns 404 when adminSecret is unset (router not mounted)', async () => {
     const { server } = buildServer({});
@@ -171,5 +186,38 @@ describe('GET /onesub/admin/customers/:userId entitlements', () => {
 
     expect(resp.body.entitlements?.premium?.active).toBe(false);
     expect(resp.body.entitlements?.premium?.source).toBeNull();
+  });
+
+  // This route already fetches the user's subscriptions and purchases to put
+  // them in the response, so entitlement evaluation must reuse them. Evaluating
+  // via `evaluateEntitlement` re-read both stores per entitlement — serially,
+  // on top of the two reads above — while returning an identical body, so only
+  // a read count catches a regression.
+  it('evaluates entitlements from the records it already fetched (no extra reads)', async () => {
+    const { store, purchaseStore, server } = buildServer({
+      adminSecret: SECRET,
+      entitlements: {
+        premium: { productIds: ['pro_monthly'] },
+        lifetime: { productIds: ['lifetime_pass'] },
+        addon: { productIds: ['some_addon'] },
+      },
+    });
+    await store.save(sub({ userId: 'alice', productId: 'pro_monthly', originalTransactionId: 't1' }));
+    await purchaseStore.savePurchase(
+      purchase({ userId: 'alice', productId: 'lifetime_pass', transactionId: 'p1' }),
+    );
+
+    const subReads = countCalls(store, 'getAllByUserId');
+    const purchaseReads = countCalls(purchaseStore, 'getPurchasesByUserId');
+
+    const resp = await server.get<CustomerProfileResponse>('/onesub/admin/customers/alice', AUTH);
+
+    expect(resp.status).toBe(200);
+    expect(resp.body.entitlements?.premium?.active).toBe(true);
+    expect(resp.body.entitlements?.lifetime?.active).toBe(true);
+    expect(resp.body.entitlements?.addon?.active).toBe(false);
+
+    expect(subReads()).toBe(1);
+    expect(purchaseReads()).toBe(1);
   });
 });

--- a/packages/server/src/__tests__/apple-jws-cache.test.ts
+++ b/packages/server/src/__tests__/apple-jws-cache.test.ts
@@ -1,0 +1,92 @@
+/**
+ * decodeJws — the cached chain-verification wiring.
+ *
+ * The success path cannot be exercised here: a chain that passes
+ * `verifyAppleCertChain` must be signed by Apple's private keys, and the
+ * verifier correctly refuses everything else. The cache's own behaviour is
+ * tested in isolation in `verified-key-cache.test.ts` (with an injected
+ * verifier). What this file pins down is the part that only the real function
+ * can show — that introducing a cache did not weaken rejection:
+ *
+ *   - a chain that fails verification is rejected EVERY time, not remembered
+ *   - a missing x5c is still rejected
+ *   - `skipVerification` still bypasses the whole path
+ */
+
+import { describe, it, expect } from 'vitest';
+import { decodeJws, clearAppleCertCache } from '../providers/apple.js';
+
+/** base64url without padding, as used in JWS. */
+function b64url(input: string): string {
+  return Buffer.from(input, 'utf-8').toString('base64url');
+}
+
+/**
+ * A syntactically valid JWS whose x5c is not an Apple chain. The signature is
+ * never reached — chain verification fails first — so it can be any value.
+ */
+function jwsWithX5c(x5c: string[] | undefined, payload: Record<string, unknown> = { bundleId: 'com.example.app' }): string {
+  const header: Record<string, unknown> = { alg: 'ES256', typ: 'JWT' };
+  if (x5c) header['x5c'] = x5c;
+  return `${b64url(JSON.stringify(header))}.${b64url(JSON.stringify(payload))}.c2ln`;
+}
+
+// Well-formed base64 that is not a certificate — `new X509Certificate()`
+// rejects it, which is the first thing chain verification does.
+const NOT_A_CERT = Buffer.from('this is not a DER certificate').toString('base64');
+
+describe('decodeJws — untrusted chains are rejected every time', () => {
+  it('rejects a non-Apple chain, and keeps rejecting it on repeat calls', async () => {
+    clearAppleCertCache();
+    const jws = jwsWithX5c([NOT_A_CERT]);
+
+    // Three identical attempts. If a failed verification were ever cached — or
+    // if a cache lookup could short-circuit verification for an unverified
+    // chain — a later call would stop throwing.
+    await expect(decodeJws(jws)).rejects.toThrow();
+    await expect(decodeJws(jws)).rejects.toThrow();
+    await expect(decodeJws(jws)).rejects.toThrow();
+  });
+
+  it('rejects a multi-cert chain that does not terminate at an Apple root', async () => {
+    clearAppleCertCache();
+    const jws = jwsWithX5c([NOT_A_CERT, NOT_A_CERT, NOT_A_CERT]);
+    await expect(decodeJws(jws)).rejects.toThrow();
+    await expect(decodeJws(jws)).rejects.toThrow();
+  });
+
+  it('rejects a chain claiming a different alg just the same', async () => {
+    clearAppleCertCache();
+    const header = { alg: 'RS256', typ: 'JWT', x5c: [NOT_A_CERT] };
+    const jws = `${b64url(JSON.stringify(header))}.${b64url(JSON.stringify({ bundleId: 'x' }))}.c2ln`;
+    await expect(decodeJws(jws)).rejects.toThrow();
+    await expect(decodeJws(jws)).rejects.toThrow();
+  });
+
+  it('rejects a JWS with no x5c header', async () => {
+    clearAppleCertCache();
+    await expect(decodeJws(jwsWithX5c(undefined))).rejects.toThrow(/missing x5c/);
+  });
+
+  it('rejects an empty x5c array', async () => {
+    clearAppleCertCache();
+    await expect(decodeJws(jwsWithX5c([]))).rejects.toThrow(/missing x5c/);
+  });
+});
+
+describe('decodeJws — skipVerification is unaffected by the cache', () => {
+  it('returns the decoded payload without touching the chain', async () => {
+    clearAppleCertCache();
+    const payload = { bundleId: 'com.example.app', productId: 'pro_monthly' };
+    // Same bogus x5c that fails above — skipVerification must not consult it.
+    const decoded = await decodeJws<typeof payload>(jwsWithX5c([NOT_A_CERT], payload), true);
+    expect(decoded.bundleId).toBe('com.example.app');
+    expect(decoded.productId).toBe('pro_monthly');
+  });
+
+  it('still decodes when there is no x5c at all', async () => {
+    const payload = { bundleId: 'com.example.app' };
+    const decoded = await decodeJws<typeof payload>(jwsWithX5c(undefined, payload), true);
+    expect(decoded.bundleId).toBe('com.example.app');
+  });
+});

--- a/packages/server/src/__tests__/entitlements.test.ts
+++ b/packages/server/src/__tests__/entitlements.test.ts
@@ -110,6 +110,21 @@ const PREMIUM: EntitlementsConfig = {
   premium: { productIds: ['pro_monthly', 'pro_yearly', 'lifetime_pass'] },
 };
 
+/**
+ * Wrap one method on a live store instance and count how often it is called.
+ * The middleware holds a reference to the same object, and resolves the method
+ * at call time, so patching after `buildServer` is observed by the routes.
+ */
+function countCalls<T extends object, K extends keyof T>(target: T, method: K): () => number {
+  let calls = 0;
+  const original = target[method] as unknown as (...args: unknown[]) => unknown;
+  (target as Record<K, unknown>)[method] = (...args: unknown[]) => {
+    calls++;
+    return original.apply(target, args);
+  };
+  return () => calls;
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // evaluateEntitlement (unit, no HTTP)
 // ─────────────────────────────────────────────────────────────────────────────
@@ -264,6 +279,37 @@ describe('GET /onesub/entitlements (bulk)', () => {
 
     expect(resp.body.entitlements.premium.active).toBe(false);
     expect(resp.body.entitlements.addon.active).toBe(false);
+  });
+
+  // The route's whole cost model is "read the user's records once, evaluate N
+  // entitlements against them". Evaluating each one through
+  // `evaluateEntitlement` instead re-reads both stores per entitlement — 2N
+  // round-trips for a result that needs 2 — and produces an identical
+  // response, so nothing above would catch the regression. Count the reads.
+  it('reads each store exactly once regardless of how many entitlements are configured', async () => {
+    const config: EntitlementsConfig = {
+      premium: { productIds: ['pro_monthly', 'pro_yearly'] },
+      promode: { productIds: ['dev_tools_addon'] },
+      lifetime: { productIds: ['lifetime_pass'] },
+      cosmetics: { productIds: ['skin_pack'] },
+    };
+    const { store, purchaseStore, server } = buildServer({ entitlements: config });
+    await store.save(sub({ userId: 'u_reads', productId: 'pro_yearly' }));
+    await purchaseStore.savePurchase(purchase({ userId: 'u_reads', productId: 'lifetime_pass' }));
+
+    const subReads = countCalls(store, 'getAllByUserId');
+    const purchaseReads = countCalls(purchaseStore, 'getPurchasesByUserId');
+
+    const resp = await server.get<EntitlementsResponse>('/onesub/entitlements?userId=u_reads');
+
+    expect(resp.status).toBe(200);
+    // Sanity: the reads that did happen produced the right answer.
+    expect(resp.body.entitlements.premium.active).toBe(true);
+    expect(resp.body.entitlements.lifetime.active).toBe(true);
+    expect(resp.body.entitlements.cosmetics.active).toBe(false);
+
+    expect(subReads()).toBe(1);
+    expect(purchaseReads()).toBe(1);
   });
 });
 

--- a/packages/server/src/__tests__/metrics-aggregate.test.ts
+++ b/packages/server/src/__tests__/metrics-aggregate.test.ts
@@ -1,0 +1,271 @@
+/**
+ * metrics-aggregate — the reduction behind every /onesub/metrics/* response.
+ *
+ * These semantics were previously only reachable through four HTTP handlers, so
+ * the fiddly parts (inclusive window edges, UTC bucket assignment, which records
+ * a distribution counts) had no direct coverage. They do now, and they are the
+ * contract any future SQL-side aggregation has to reproduce.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { PurchaseInfo, SubscriptionInfo } from '@onesub/shared';
+import {
+  aggregateActive,
+  aggregateRange,
+  emptyDailyBuckets,
+  isActiveSubscription,
+  isEndedSubscription,
+  isNonConsumable,
+  utcDateKey,
+} from '../metrics-aggregate.js';
+
+function sub(overrides?: Partial<SubscriptionInfo>): SubscriptionInfo {
+  return {
+    userId: 'u',
+    productId: 'pro_monthly',
+    platform: 'apple',
+    status: 'active',
+    expiresAt: '2099-01-01T00:00:00.000Z',
+    purchasedAt: '2026-04-10T00:00:00.000Z',
+    originalTransactionId: `orig_${Math.random()}`,
+    willRenew: true,
+    ...overrides,
+  };
+}
+
+function purchase(overrides?: Partial<PurchaseInfo>): PurchaseInfo {
+  return {
+    userId: 'u',
+    productId: 'lifetime_pass',
+    platform: 'apple',
+    type: 'non_consumable',
+    transactionId: `tx_${Math.random()}`,
+    purchasedAt: '2026-04-10T00:00:00.000Z',
+    quantity: 1,
+    ...overrides,
+  };
+}
+
+const ms = (iso: string) => new Date(iso).getTime();
+const APRIL = { fromMs: ms('2026-04-01T00:00:00Z'), toMs: ms('2026-04-30T23:59:59.999Z') };
+
+describe('utcDateKey', () => {
+  it('formats as UTC YYYY-MM-DD regardless of the local zone', () => {
+    expect(utcDateKey(ms('2026-04-10T00:00:00Z'))).toBe('2026-04-10');
+    expect(utcDateKey(ms('2026-04-10T23:59:59Z'))).toBe('2026-04-10');
+    // 23:30 in UTC−05:00 is already the next UTC day.
+    expect(utcDateKey(ms('2026-04-10T23:30:00-05:00'))).toBe('2026-04-11');
+  });
+
+  it('zero-pads single-digit months and days', () => {
+    expect(utcDateKey(ms('2026-01-05T12:00:00Z'))).toBe('2026-01-05');
+  });
+});
+
+describe('emptyDailyBuckets', () => {
+  it('covers both boundary days inclusively', () => {
+    const buckets = emptyDailyBuckets(ms('2026-04-01T10:00:00Z'), ms('2026-04-03T01:00:00Z'));
+    expect(buckets.map((b) => b.date)).toEqual(['2026-04-01', '2026-04-02', '2026-04-03']);
+    expect(buckets.every((b) => b.count === 0)).toBe(true);
+  });
+
+  it('returns a single bucket for a window inside one day', () => {
+    const buckets = emptyDailyBuckets(ms('2026-04-01T01:00:00Z'), ms('2026-04-01T23:00:00Z'));
+    expect(buckets).toEqual([{ date: '2026-04-01', count: 0 }]);
+  });
+});
+
+describe('aggregateRange — window', () => {
+  it('includes records on both bounds and excludes those outside', () => {
+    const records = [
+      sub({ purchasedAt: '2026-03-31T23:59:59.999Z' }), // just before
+      sub({ purchasedAt: '2026-04-01T00:00:00.000Z' }), // exactly from
+      sub({ purchasedAt: '2026-04-15T00:00:00.000Z' }), // inside
+      sub({ purchasedAt: '2026-04-30T23:59:59.999Z' }), // exactly to
+      sub({ purchasedAt: '2026-05-01T00:00:00.000Z' }), // just after
+    ];
+    const result = aggregateRange(records, {
+      ...APRIL,
+      groupBy: 'none',
+      anchor: (s) => s.purchasedAt,
+    });
+    expect(result.total).toBe(3);
+  });
+
+  it('omits buckets unless groupBy is day', () => {
+    const result = aggregateRange([sub()], { ...APRIL, groupBy: 'none', anchor: (s) => s.purchasedAt });
+    expect(result.buckets).toBeUndefined();
+  });
+
+  it('skips records whose anchor is not a parseable timestamp', () => {
+    const result = aggregateRange([sub({ purchasedAt: 'not-a-date' }), sub()], {
+      ...APRIL,
+      groupBy: 'none',
+      anchor: (s) => s.purchasedAt,
+    });
+    expect(result.total).toBe(1);
+  });
+});
+
+describe('aggregateRange — distributions', () => {
+  it('tallies product and platform for included records only', () => {
+    const records = [
+      sub({ productId: 'pro_monthly', platform: 'apple' }),
+      sub({ productId: 'pro_monthly', platform: 'google' }),
+      sub({ productId: 'pro_yearly', platform: 'google' }),
+      sub({ productId: 'excluded_by_window', purchasedAt: '2026-01-01T00:00:00Z' }),
+    ];
+    const result = aggregateRange(records, {
+      ...APRIL,
+      groupBy: 'none',
+      anchor: (s) => s.purchasedAt,
+    });
+
+    expect(result.total).toBe(3);
+    expect(result.byProduct).toEqual({ pro_monthly: 2, pro_yearly: 1 });
+    expect(result.byPlatform).toEqual({ apple: 1, google: 2 });
+  });
+
+  it('applies the include predicate before anything else is counted', () => {
+    const records = [
+      sub({ status: 'expired', expiresAt: '2026-04-10T00:00:00Z', productId: 'gone' }),
+      sub({ status: 'active', expiresAt: '2026-04-11T00:00:00Z', productId: 'still_here' }),
+    ];
+    const result = aggregateRange(records, {
+      ...APRIL,
+      groupBy: 'none',
+      anchor: (s) => s.expiresAt,
+      include: isEndedSubscription,
+    });
+
+    expect(result.total).toBe(1);
+    expect(result.byProduct).toEqual({ gone: 1 });
+    expect(result.byPlatform).toEqual({ apple: 1 });
+  });
+});
+
+describe('aggregateRange — daily buckets', () => {
+  it('zero-fills the whole window and counts into the right UTC day', () => {
+    const records = [
+      sub({ purchasedAt: '2026-04-01T00:00:00Z' }),
+      sub({ purchasedAt: '2026-04-01T23:59:00Z' }),
+      sub({ purchasedAt: '2026-04-03T12:00:00Z' }),
+    ];
+    const result = aggregateRange(records, {
+      fromMs: ms('2026-04-01T00:00:00Z'),
+      toMs: ms('2026-04-04T23:59:59Z'),
+      groupBy: 'day',
+      anchor: (s) => s.purchasedAt,
+    });
+
+    expect(result.buckets).toEqual([
+      { date: '2026-04-01', count: 2 },
+      { date: '2026-04-02', count: 0 },
+      { date: '2026-04-03', count: 1 },
+      { date: '2026-04-04', count: 0 },
+    ]);
+    // Bucket counts must reconcile with the total.
+    expect(result.buckets!.reduce((n, b) => n + b.count, 0)).toBe(result.total);
+  });
+
+  it('keeps bucket sum equal to total when records are filtered out', () => {
+    const records = [
+      purchase({ type: 'non_consumable', purchasedAt: '2026-04-02T00:00:00Z' }),
+      purchase({ type: 'consumable', purchasedAt: '2026-04-02T00:00:00Z' }),
+    ];
+    const result = aggregateRange(records, {
+      fromMs: ms('2026-04-01T00:00:00Z'),
+      toMs: ms('2026-04-03T00:00:00Z'),
+      groupBy: 'day',
+      anchor: (p) => p.purchasedAt,
+      include: isNonConsumable,
+    });
+
+    expect(result.total).toBe(1);
+    expect(result.buckets!.reduce((n, b) => n + b.count, 0)).toBe(1);
+  });
+});
+
+describe('predicates', () => {
+  const now = ms('2026-04-15T00:00:00Z');
+
+  it('isActiveSubscription requires an allowed status AND a future expiry', () => {
+    expect(isActiveSubscription(sub({ status: 'active', expiresAt: '2026-05-01T00:00:00Z' }), now)).toBe(true);
+    expect(isActiveSubscription(sub({ status: 'grace_period', expiresAt: '2026-05-01T00:00:00Z' }), now)).toBe(true);
+    // Right status, already expired — the guard against a missed EXPIRED webhook.
+    expect(isActiveSubscription(sub({ status: 'active', expiresAt: '2026-04-01T00:00:00Z' }), now)).toBe(false);
+    // on_hold is excluded: payment must be fixed before access returns.
+    expect(isActiveSubscription(sub({ status: 'on_hold', expiresAt: '2026-05-01T00:00:00Z' }), now)).toBe(false);
+    expect(isActiveSubscription(sub({ status: 'paused', expiresAt: '2026-05-01T00:00:00Z' }), now)).toBe(false);
+  });
+
+  it('isEndedSubscription covers expired and canceled only', () => {
+    expect(isEndedSubscription(sub({ status: 'expired' }))).toBe(true);
+    expect(isEndedSubscription(sub({ status: 'canceled' }))).toBe(true);
+    expect(isEndedSubscription(sub({ status: 'active' }))).toBe(false);
+    expect(isEndedSubscription(sub({ status: 'on_hold' }))).toBe(false);
+  });
+
+  it('isNonConsumable excludes consumables and subscriptions', () => {
+    expect(isNonConsumable(purchase({ type: 'non_consumable' }))).toBe(true);
+    expect(isNonConsumable(purchase({ type: 'consumable' }))).toBe(false);
+    expect(isNonConsumable(purchase({ type: 'subscription' }))).toBe(false);
+  });
+});
+
+describe('aggregateActive', () => {
+  const now = ms('2026-04-15T00:00:00Z');
+
+  it('counts entitled subscriptions and non-consumable purchases', () => {
+    const subs = [
+      sub({ status: 'active', expiresAt: '2026-05-01T00:00:00Z', productId: 'pro_monthly' }),
+      sub({ status: 'grace_period', expiresAt: '2026-05-01T00:00:00Z', productId: 'pro_monthly' }),
+      sub({ status: 'expired', expiresAt: '2026-04-01T00:00:00Z', productId: 'pro_yearly' }),
+    ];
+    const purchases = [
+      purchase({ type: 'non_consumable', productId: 'lifetime_pass' }),
+      purchase({ type: 'consumable', productId: 'coins_100' }),
+    ];
+
+    const result = aggregateActive(subs, purchases, now);
+
+    expect(result.activeSubscriptions).toBe(2);
+    expect(result.gracePeriodSubscriptions).toBe(1);
+    expect(result.nonConsumablePurchases).toBe(1);
+    expect(result.total).toBe(3); // 2 subs + 1 lifetime
+  });
+
+  it('keeps subscription and purchase product mixes separate', () => {
+    const result = aggregateActive(
+      [sub({ productId: 'pro_monthly' })],
+      [purchase({ productId: 'lifetime_pass' })],
+      now,
+    );
+    expect(result.byProduct).toEqual({ pro_monthly: 1 });
+    expect(result.byProductPurchases).toEqual({ lifetime_pass: 1 });
+  });
+
+  it('merges platforms across subscriptions AND purchases', () => {
+    // byPlatform answers "where are my paying users", which is not a per-kind
+    // question — unlike the two product maps.
+    const result = aggregateActive(
+      [sub({ platform: 'apple' }), sub({ platform: 'google' })],
+      [purchase({ platform: 'google' })],
+      now,
+    );
+    expect(result.byPlatform).toEqual({ apple: 1, google: 2 });
+  });
+
+  it('returns zeroed counts and empty maps for an empty store', () => {
+    const result = aggregateActive([], [], now);
+    expect(result).toEqual({
+      total: 0,
+      activeSubscriptions: 0,
+      gracePeriodSubscriptions: 0,
+      nonConsumablePurchases: 0,
+      byProduct: {},
+      byProductPurchases: {},
+      byPlatform: {},
+    });
+  });
+});

--- a/packages/server/src/__tests__/metrics-cache.test.ts
+++ b/packages/server/src/__tests__/metrics-cache.test.ts
@@ -1,0 +1,191 @@
+/**
+ * createMetricsCache — the freshness bound on aggregate metrics responses.
+ *
+ * Every metrics endpoint reduces the whole store, so this cache is what stops a
+ * dashboard refresh loop from re-scanning it. The behaviours worth pinning down
+ * are the ones that would either defeat the purpose (a key that never repeats)
+ * or serve something wrong (a stale hit past its TTL, a shared entry between
+ * unrelated stores, a remembered failure).
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { createMetricsCache } from '../metrics-cache.js';
+import { InMemoryCacheAdapter } from '../cache.js';
+
+/** A producer that counts invocations. */
+function counted<T>(value: T) {
+  let calls = 0;
+  return { calls: () => calls, produce: async () => { calls++; return value; } };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('quantizeToWindow', () => {
+  it('snaps timestamps onto the TTL grid so repeat requests share a key', () => {
+    // The dashboard sends `to = new Date()` at millisecond precision. Without
+    // this, every request would be a unique key and the cache would never hit.
+    const cache = createMetricsCache(30);
+    expect(cache.quantizeToWindow(0)).toBe(0);
+    expect(cache.quantizeToWindow(29_999)).toBe(0);
+    expect(cache.quantizeToWindow(30_000)).toBe(30_000);
+    expect(cache.quantizeToWindow(59_999)).toBe(30_000);
+    expect(cache.quantizeToWindow(60_001)).toBe(60_000);
+  });
+
+  it('is the identity when caching is disabled', () => {
+    const cache = createMetricsCache(0);
+    expect(cache.quantizeToWindow(12_345)).toBe(12_345);
+  });
+});
+
+describe('resolve — hit / miss', () => {
+  it('computes once per key', async () => {
+    const cache = createMetricsCache(30);
+    const p = counted({ total: 7 });
+
+    expect(await cache.resolve(['active', 0], p.produce)).toEqual({ total: 7 });
+    expect(await cache.resolve(['active', 0], p.produce)).toEqual({ total: 7 });
+    expect(p.calls()).toBe(1);
+  });
+
+  it('treats every key part as significant', async () => {
+    const cache = createMetricsCache(30);
+    const p = counted({ total: 1 });
+
+    await cache.resolve(['started', 0, 30_000, 'none'], p.produce);
+    await cache.resolve(['started', 0, 30_000, 'day'], p.produce);   // groupBy differs
+    await cache.resolve(['started', 0, 60_000, 'none'], p.produce);  // window differs
+    await cache.resolve(['expired', 0, 30_000, 'none'], p.produce);  // endpoint differs
+
+    expect(p.calls()).toBe(4);
+  });
+
+  it('bypasses entirely when the TTL is zero', async () => {
+    const cache = createMetricsCache(0);
+    const p = counted({ total: 1 });
+
+    await cache.resolve(['active', 0], p.produce);
+    await cache.resolve(['active', 0], p.produce);
+    await cache.resolve(['active', 0], p.produce);
+
+    expect(p.calls()).toBe(3);
+  });
+
+  it('recomputes once the TTL has elapsed', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-26T00:00:00.000Z'));
+    const cache = createMetricsCache(30);
+    const p = counted({ total: 1 });
+
+    await cache.resolve(['active', 0], p.produce);
+    vi.setSystemTime(new Date('2026-07-26T00:00:29.000Z'));
+    await cache.resolve(['active', 0], p.produce);
+    expect(p.calls()).toBe(1);
+
+    vi.setSystemTime(new Date('2026-07-26T00:00:31.000Z'));
+    await cache.resolve(['active', 0], p.produce);
+    expect(p.calls()).toBe(2);
+  });
+});
+
+describe('resolve — concurrent callers', () => {
+  it('collapses simultaneous misses into one computation', async () => {
+    // The dashboard overview fires its requests together; on a cold cache each
+    // one would otherwise start its own full scan.
+    const cache = createMetricsCache(30);
+    let calls = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    const produce = async () => { calls++; await gate; return { total: 3 }; };
+
+    const all = Promise.all([
+      cache.resolve(['active', 0], produce),
+      cache.resolve(['active', 0], produce),
+      cache.resolve(['active', 0], produce),
+    ]);
+    release();
+    const results = await all;
+
+    expect(results).toEqual([{ total: 3 }, { total: 3 }, { total: 3 }]);
+    expect(calls).toBe(1);
+  });
+
+  it('does not collapse different keys', async () => {
+    const cache = createMetricsCache(30);
+    let calls = 0;
+    const produce = async () => { calls++; return { total: calls }; };
+
+    await Promise.all([
+      cache.resolve(['active', 0], produce),
+      cache.resolve(['started', 0, 1, 'none'], produce),
+    ]);
+
+    expect(calls).toBe(2);
+  });
+});
+
+describe('resolve — failures', () => {
+  it('propagates and remembers nothing', async () => {
+    const cache = createMetricsCache(30);
+    let calls = 0;
+    const failing = async (): Promise<{ total: number }> => {
+      calls++;
+      throw new Error('store unavailable');
+    };
+
+    await expect(cache.resolve(['active', 0], failing)).rejects.toThrow(/store unavailable/);
+    await expect(cache.resolve(['active', 0], failing)).rejects.toThrow(/store unavailable/);
+    expect(calls).toBe(2);
+
+    // A later success is cached normally — the failure left no poisoned entry.
+    const p = counted({ total: 5 });
+    expect(await cache.resolve(['active', 0], p.produce)).toEqual({ total: 5 });
+    expect(await cache.resolve(['active', 0], p.produce)).toEqual({ total: 5 });
+    expect(p.calls()).toBe(1);
+  });
+
+  it('does not strand concurrent callers when the computation fails', async () => {
+    const cache = createMetricsCache(30);
+    const failing = async (): Promise<{ total: number }> => {
+      throw new Error('boom');
+    };
+    const results = await Promise.allSettled([
+      cache.resolve(['active', 0], failing),
+      cache.resolve(['active', 0], failing),
+    ]);
+    expect(results.every((r) => r.status === 'rejected')).toBe(true);
+  });
+});
+
+describe('resolve — isolation', () => {
+  it('two cache instances never see each other’s entries', async () => {
+    // This is why the metrics cache does not use the shared default adapter: a
+    // metrics key describes "every record in this store" and cannot tell one
+    // store from another, so two middlewares in one process would otherwise
+    // read each other's totals for any matching window.
+    const a = createMetricsCache(30);
+    const b = createMetricsCache(30);
+    const pa = counted({ total: 1 });
+    const pb = counted({ total: 999 });
+
+    expect(await a.resolve(['active', 0], pa.produce)).toEqual({ total: 1 });
+    expect(await b.resolve(['active', 0], pb.produce)).toEqual({ total: 999 });
+    expect(pa.calls()).toBe(1);
+    expect(pb.calls()).toBe(1);
+  });
+
+  it('honours injected storage', async () => {
+    const storage = new InMemoryCacheAdapter();
+    const cache = createMetricsCache(30, storage);
+    const p = counted({ total: 2 });
+
+    await cache.resolve(['active', 0], p.produce);
+    expect(storage.size).toBe(1);
+
+    storage.clear();
+    await cache.resolve(['active', 0], p.produce);
+    expect(p.calls()).toBe(2);
+  });
+});

--- a/packages/server/src/__tests__/metrics.test.ts
+++ b/packages/server/src/__tests__/metrics.test.ts
@@ -66,13 +66,36 @@ function spinUp(handler: express.Express): TestServer {
   };
 }
 
-function buildServer(opts: { adminSecret?: string; subs?: SubscriptionInfo[]; purchases?: PurchaseInfo[] }) {
+/**
+ * Wrap one method on a live store instance and count how often it is called.
+ * The router holds a reference to the same object and resolves the method at
+ * call time, so patching after `buildServer` is observed by the handlers.
+ */
+function countCalls<T extends object, K extends keyof T>(target: T, method: K): () => number {
+  let calls = 0;
+  const original = target[method] as unknown as (...args: unknown[]) => unknown;
+  (target as Record<K, unknown>)[method] = (...args: unknown[]) => {
+    calls++;
+    return original.apply(target, args);
+  };
+  return () => calls;
+}
+
+function buildServer(opts: {
+  adminSecret?: string;
+  subs?: SubscriptionInfo[];
+  purchases?: PurchaseInfo[];
+  metricsCacheTtlSeconds?: number;
+}) {
   const store = new InMemorySubscriptionStore();
   const purchaseStore = new InMemoryPurchaseStore();
   const config: OneSubServerConfig = {
     apple: { bundleId: 'com.example.app', skipJwsVerification: true },
     database: { url: '' },
     adminSecret: opts.adminSecret,
+    ...(opts.metricsCacheTtlSeconds !== undefined
+      ? { metricsCacheTtlSeconds: opts.metricsCacheTtlSeconds }
+      : {}),
   };
   const app = express();
   app.use(createOneSubMiddleware({ ...config, store, purchaseStore }));
@@ -520,5 +543,102 @@ describe('Store listAll', () => {
 
     const all = await purchaseStore.listAll();
     expect(all).toHaveLength(2);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Response caching
+//
+// Each endpoint reduces the entire store, so the cache is what bounds how often
+// that happens under a refreshing dashboard. These assert it from the outside:
+// how many times the store was actually read to answer N requests.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Metrics response caching', () => {
+  it('answers repeat requests without re-reading the store', async () => {
+    const { store, server } = buildServer({ adminSecret: SECRET });
+    await store.save(sub({ userId: 'a', originalTransactionId: 't1' }));
+    const reads = countCalls(store, 'listAll');
+
+    for (let i = 0; i < 5; i++) {
+      const resp = await server.get<MetricsActiveResponse>('/onesub/metrics/active', AUTH);
+      expect(resp.body.activeSubscriptions).toBe(1);
+    }
+
+    expect(reads()).toBe(1);
+  });
+
+  it('caches each endpoint separately', async () => {
+    const { store, server } = buildServer({ adminSecret: SECRET });
+    await store.save(sub({ userId: 'a', purchasedAt: '2026-04-10T00:00:00Z', originalTransactionId: 't1' }));
+    const reads = countCalls(store, 'listAll');
+
+    const range = 'from=2026-04-01T00:00:00Z&to=2026-04-30T00:00:00Z';
+    await server.get(`/onesub/metrics/started?${range}`, AUTH);
+    await server.get(`/onesub/metrics/expired?${range}`, AUTH);
+    await server.get('/onesub/metrics/active', AUTH);
+    // Repeats of all three are served from cache.
+    await server.get(`/onesub/metrics/started?${range}`, AUTH);
+    await server.get(`/onesub/metrics/expired?${range}`, AUTH);
+    await server.get('/onesub/metrics/active', AUTH);
+
+    expect(reads()).toBe(3);
+  });
+
+  it('does not let a different window reuse another window’s counts', async () => {
+    const { store, server } = buildServer({ adminSecret: SECRET });
+    await store.save(sub({ userId: 'a', purchasedAt: '2026-04-10T00:00:00Z', originalTransactionId: 't1' }));
+    await store.save(sub({ userId: 'b', purchasedAt: '2026-06-10T00:00:00Z', originalTransactionId: 't2' }));
+
+    const april = await server.get<MetricsCountResponse>(
+      '/onesub/metrics/started?from=2026-04-01T00:00:00Z&to=2026-04-30T00:00:00Z',
+      AUTH,
+    );
+    const june = await server.get<MetricsCountResponse>(
+      '/onesub/metrics/started?from=2026-06-01T00:00:00Z&to=2026-06-30T00:00:00Z',
+      AUTH,
+    );
+
+    expect(april.body.total).toBe(1);
+    expect(june.body.total).toBe(1);
+    expect(april.body.byProduct).toEqual({ pro_monthly: 1 });
+  });
+
+  it('echoes the caller’s own from/to, not the quantized cache key', async () => {
+    const { server } = buildServer({ adminSecret: SECRET });
+    const from = '2026-04-01T00:00:00.123Z';
+    const to = '2026-04-30T00:00:00.456Z';
+
+    const resp = await server.get<MetricsCountResponse>(
+      `/onesub/metrics/started?from=${from}&to=${to}`,
+      AUTH,
+    );
+
+    expect(resp.body.from).toBe(from);
+    expect(resp.body.to).toBe(to);
+  });
+
+  it('reads the store on every request when the TTL is 0', async () => {
+    const { store, server } = buildServer({ adminSecret: SECRET, metricsCacheTtlSeconds: 0 });
+    await store.save(sub({ userId: 'a', originalTransactionId: 't1' }));
+    const reads = countCalls(store, 'listAll');
+
+    await server.get('/onesub/metrics/active', AUTH);
+    await server.get('/onesub/metrics/active', AUTH);
+    await server.get('/onesub/metrics/active', AUTH);
+
+    expect(reads()).toBe(3);
+  });
+
+  it('with the TTL disabled, a newly saved record shows up immediately', async () => {
+    const { store, server } = buildServer({ adminSecret: SECRET, metricsCacheTtlSeconds: 0 });
+
+    const before = await server.get<MetricsActiveResponse>('/onesub/metrics/active', AUTH);
+    expect(before.body.activeSubscriptions).toBe(0);
+
+    await store.save(sub({ userId: 'a', originalTransactionId: 't1' }));
+
+    const after = await server.get<MetricsActiveResponse>('/onesub/metrics/active', AUTH);
+    expect(after.body.activeSubscriptions).toBe(1);
   });
 });

--- a/packages/server/src/__tests__/redis-store.test.ts
+++ b/packages/server/src/__tests__/redis-store.test.ts
@@ -5,14 +5,20 @@ import { RedisSubscriptionStore, RedisPurchaseStore, RedisCacheAdapter, RedisWeb
 import { SUBSCRIPTION_STATUS } from '@onesub/shared';
 import type { SubscriptionInfo, PurchaseInfo } from '@onesub/shared';
 
+let sharedRedis: Redis | undefined;
+
 async function makeRedis(): Promise<Redis> {
   // ioredis-mock's surface matches ioredis enough for our store's methods
   // (set/get/zadd/zrevrange/sadd/smembers/multi). Cast to keep TS happy.
-  // The mock keeps a process-wide store across instances by default — flush
-  // so each test starts from a clean slate.
-  const r = new IORedisMock() as unknown as Redis;
-  await r.flushall();
-  return r;
+  //
+  // The mock keeps a process-wide store across instances, so a fresh instance
+  // buys no isolation — flushing is what gives each test a clean slate. One
+  // instance is reused because each `new IORedisMock()` registers a listener on
+  // a shared emitter, and this file makes enough of them to trip
+  // MaxListenersExceededWarning — noise that would mask a real leak later.
+  sharedRedis ??= new IORedisMock() as unknown as Redis;
+  await sharedRedis.flushall();
+  return sharedRedis;
 }
 
 const baseSub: SubscriptionInfo = {

--- a/packages/server/src/__tests__/verified-key-cache.test.ts
+++ b/packages/server/src/__tests__/verified-key-cache.test.ts
@@ -1,0 +1,218 @@
+/**
+ * VerifiedKeyCache — the memo behind Apple x5c chain verification.
+ *
+ * This cache sits directly on a security boundary: it decides when an
+ * expensive chain verification may be skipped. The real Apple path cannot be
+ * driven end-to-end in tests (a passing chain must be signed by Apple's private
+ * keys, and `verifyAppleCertChain` correctly refuses anything else), so the
+ * cache takes its verification as an injected function and the invariants are
+ * tested here directly:
+ *
+ *   - a hit skips verification, a miss does not
+ *   - every input participates in the entry identity (chain AND alg)
+ *   - a failed verification is never remembered
+ *   - no entry outlives the certificate chain that produced it
+ *   - eviction never hands back a stale key
+ */
+
+import { describe, it, expect } from 'vitest';
+import { VerifiedKeyCache } from '../providers/verified-key-cache.js';
+
+const HOUR_MS = 60 * 60 * 1000;
+
+/** A verifier that counts calls and hands back a labelled key. */
+function stubVerifier(label: string, notAfter: number) {
+  let calls = 0;
+  return {
+    calls: () => calls,
+    produce: async () => {
+      calls++;
+      return { key: `key:${label}`, notAfter };
+    },
+  };
+}
+
+describe('VerifiedKeyCache — hit / miss', () => {
+  it('verifies once for repeated identical input', async () => {
+    const cache = new VerifiedKeyCache<string>({ now: () => 1_000 });
+    const v = stubVerifier('leaf', 1_000 + 10 * HOUR_MS);
+
+    const first = await cache.resolve(['ES256', 'certA'], v.produce);
+    const second = await cache.resolve(['ES256', 'certA'], v.produce);
+    const third = await cache.resolve(['ES256', 'certA'], v.produce);
+
+    expect(first).toBe('key:leaf');
+    expect(second).toBe('key:leaf');
+    expect(third).toBe('key:leaf');
+    expect(v.calls()).toBe(1);
+  });
+
+  it('re-verifies when any part of the chain differs', async () => {
+    const cache = new VerifiedKeyCache<string>({ now: () => 1_000 });
+    const v = stubVerifier('leaf', 1_000 + 10 * HOUR_MS);
+
+    await cache.resolve(['ES256', 'certA', 'interA'], v.produce);
+    await cache.resolve(['ES256', 'certA', 'interB'], v.produce);
+    await cache.resolve(['ES256', 'certA'], v.produce);
+
+    expect(v.calls()).toBe(3);
+  });
+
+  it('treats the same chain under a different alg as a different entry', async () => {
+    // Otherwise a key imported for ES256 could be served to a caller claiming
+    // RS256 — the cache would be laundering an algorithm substitution.
+    const cache = new VerifiedKeyCache<string>({ now: () => 1_000 });
+    const v = stubVerifier('leaf', 1_000 + 10 * HOUR_MS);
+
+    await cache.resolve(['ES256', 'certA'], v.produce);
+    await cache.resolve(['RS256', 'certA'], v.produce);
+
+    expect(v.calls()).toBe(2);
+  });
+
+  it('does not let part boundaries collide', async () => {
+    // ['a','bc'] and ['ab','c'] concatenate identically; length-prefixed
+    // hashing must still separate them.
+    const cache = new VerifiedKeyCache<string>({ now: () => 1_000 });
+    const v = stubVerifier('leaf', 1_000 + 10 * HOUR_MS);
+
+    await cache.resolve(['a', 'bc'], v.produce);
+    await cache.resolve(['ab', 'c'], v.produce);
+
+    expect(v.calls()).toBe(2);
+    expect(cache.size).toBe(2);
+  });
+});
+
+describe('VerifiedKeyCache — failures are never cached', () => {
+  it('propagates the rejection and stores nothing', async () => {
+    const cache = new VerifiedKeyCache<string>({ now: () => 1_000 });
+    let calls = 0;
+    const failing = async (): Promise<{ key: string; notAfter: number }> => {
+      calls++;
+      throw new Error('cert chain does not terminate at a trusted Apple root');
+    };
+
+    await expect(cache.resolve(['ES256', 'bad'], failing)).rejects.toThrow(/trusted Apple root/);
+    expect(cache.size).toBe(0);
+
+    // A second attempt must re-verify (and re-reject) rather than being served
+    // any remembered outcome.
+    await expect(cache.resolve(['ES256', 'bad'], failing)).rejects.toThrow(/trusted Apple root/);
+    expect(calls).toBe(2);
+    expect(cache.size).toBe(0);
+  });
+
+  it('a later success for the same input is cached normally', async () => {
+    const cache = new VerifiedKeyCache<string>({ now: () => 1_000 });
+    await expect(
+      cache.resolve(['ES256', 'certA'], async () => {
+        throw new Error('transient');
+      }),
+    ).rejects.toThrow(/transient/);
+
+    const v = stubVerifier('leaf', 1_000 + 10 * HOUR_MS);
+    expect(await cache.resolve(['ES256', 'certA'], v.produce)).toBe('key:leaf');
+    expect(await cache.resolve(['ES256', 'certA'], v.produce)).toBe('key:leaf');
+    expect(v.calls()).toBe(1);
+  });
+});
+
+describe('VerifiedKeyCache — entries never outlive the chain', () => {
+  it('expires at the chain notAfter even when maxTtl is longer', async () => {
+    let clock = 1_000;
+    const certExpiry = clock + 5 * 60 * 1000; // 5 minutes of certificate left
+    const cache = new VerifiedKeyCache<string>({ maxTtlMs: 10 * HOUR_MS, now: () => clock });
+    const v = stubVerifier('leaf', certExpiry);
+
+    await cache.resolve(['ES256', 'certA'], v.produce);
+    expect(v.calls()).toBe(1);
+
+    // Still inside the certificate's validity → served from cache.
+    clock = certExpiry - 1;
+    await cache.resolve(['ES256', 'certA'], v.produce);
+    expect(v.calls()).toBe(1);
+
+    // Certificate has now expired. The cache must NOT answer from memory —
+    // full verification runs again (and in production would throw).
+    clock = certExpiry + 1;
+    await cache.resolve(['ES256', 'certA'], v.produce);
+    expect(v.calls()).toBe(2);
+  });
+
+  it('caps the lifetime at maxTtl even for a long-lived certificate', async () => {
+    let clock = 1_000;
+    const cache = new VerifiedKeyCache<string>({ maxTtlMs: HOUR_MS, now: () => clock });
+    const v = stubVerifier('leaf', clock + 365 * 24 * HOUR_MS);
+
+    await cache.resolve(['ES256', 'certA'], v.produce);
+    clock += HOUR_MS - 1;
+    await cache.resolve(['ES256', 'certA'], v.produce);
+    expect(v.calls()).toBe(1);
+
+    clock += 2;
+    await cache.resolve(['ES256', 'certA'], v.produce);
+    expect(v.calls()).toBe(2);
+  });
+
+  it('does not store a chain that expires at this instant', async () => {
+    const clock = 1_000;
+    const cache = new VerifiedKeyCache<string>({ now: () => clock });
+    const v = stubVerifier('leaf', clock);
+
+    // The key is still returned — the verification did pass — but remembering
+    // it would be remembering something already out of validity.
+    expect(await cache.resolve(['ES256', 'certA'], v.produce)).toBe('key:leaf');
+    expect(cache.size).toBe(0);
+  });
+
+  it('never caches when the expiry could not be established', async () => {
+    // The Apple verifier reports notAfter 0 when a certificate's validity end
+    // cannot be parsed. "Unknown expiry" must mean "re-verify every time",
+    // never "hold it for the default TTL".
+    const clock = 1_000;
+    const cache = new VerifiedKeyCache<string>({ now: () => clock });
+    const v = stubVerifier('leaf', 0);
+
+    expect(await cache.resolve(['ES256', 'certA'], v.produce)).toBe('key:leaf');
+    expect(await cache.resolve(['ES256', 'certA'], v.produce)).toBe('key:leaf');
+    expect(cache.size).toBe(0);
+    expect(v.calls()).toBe(2);
+  });
+});
+
+describe('VerifiedKeyCache — bounded', () => {
+  it('stays within maxEntries and keeps serving correct keys', async () => {
+    let clock = 1_000;
+    const cache = new VerifiedKeyCache<string>({ maxEntries: 3, now: () => clock });
+
+    for (let i = 0; i < 10; i++) {
+      const v = stubVerifier(`leaf${i}`, clock + 10 * HOUR_MS);
+      expect(await cache.resolve(['ES256', `cert${i}`], v.produce)).toBe(`key:leaf${i}`);
+      expect(cache.size).toBeLessThanOrEqual(3);
+    }
+
+    // The most recent entry is still a hit; an evicted one re-verifies rather
+    // than returning some other chain's key.
+    const recent = stubVerifier('leaf9-again', clock + 10 * HOUR_MS);
+    expect(await cache.resolve(['ES256', 'cert9'], recent.produce)).toBe('key:leaf9');
+    expect(recent.calls()).toBe(0);
+
+    const evicted = stubVerifier('leaf0-again', clock + 10 * HOUR_MS);
+    expect(await cache.resolve(['ES256', 'cert0'], evicted.produce)).toBe('key:leaf0-again');
+    expect(evicted.calls()).toBe(1);
+  });
+
+  it('clear() drops everything', async () => {
+    const cache = new VerifiedKeyCache<string>({ now: () => 1_000 });
+    const v = stubVerifier('leaf', 1_000 + 10 * HOUR_MS);
+    await cache.resolve(['ES256', 'certA'], v.produce);
+    expect(cache.size).toBe(1);
+
+    cache.clear();
+    expect(cache.size).toBe(0);
+
+    await cache.resolve(['ES256', 'certA'], v.produce);
+    expect(v.calls()).toBe(2);
+  });
+});

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -23,9 +23,13 @@ export async function fetchWithTimeout(
   const controller = new AbortController();
   // Allow caller-provided signal to compose with our timeout.
   const callerSignal = init?.signal;
+  let onCallerAbort: (() => void) | undefined;
   if (callerSignal) {
     if (callerSignal.aborted) controller.abort(callerSignal.reason);
-    else callerSignal.addEventListener('abort', () => controller.abort(callerSignal.reason), { once: true });
+    else {
+      onCallerAbort = () => controller.abort(callerSignal.reason);
+      callerSignal.addEventListener('abort', onCallerAbort, { once: true });
+    }
   }
 
   const timer = setTimeout(() => {
@@ -36,5 +40,10 @@ export async function fetchWithTimeout(
     return await fetch(input, { ...init, signal: controller.signal });
   } finally {
     clearTimeout(timer);
+    // `{ once: true }` only self-removes when the event FIRES. On the normal
+    // path it never does, so a caller that reuses one long-lived signal across
+    // many requests would accumulate a listener per call on it — a slow leak
+    // that surfaces as MaxListenersExceededWarning.
+    if (onCallerAbort) callerSignal?.removeEventListener('abort', onCallerAbort);
   }
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -203,7 +203,10 @@ export { validateGoogleReceipt } from './providers/google.js';
 
 // Entitlement evaluator — exported so hosts can evaluate entitlements
 // in-process (e.g. from non-HTTP background workers, custom routes).
-export { evaluateEntitlement } from './routes/entitlements.js';
+// `evaluateEntitlementFrom` is the store-free variant: read a user's
+// subscriptions/purchases once, then evaluate any number of entitlements
+// against them without further round-trips.
+export { evaluateEntitlement, evaluateEntitlementFrom } from './routes/entitlements.js';
 
 // Logger plumbing — expose so non-middleware callers (direct provider use)
 // can still redirect logs.

--- a/packages/server/src/metrics-aggregate.ts
+++ b/packages/server/src/metrics-aggregate.ts
@@ -1,0 +1,196 @@
+import type {
+  MetricsActiveResponse,
+  MetricsBucket,
+  MetricsGroupBy,
+  PurchaseInfo,
+  SubscriptionInfo,
+} from '@onesub/shared';
+import { PURCHASE_TYPE, SUBSCRIPTION_STATUS } from '@onesub/shared';
+
+/**
+ * In-memory reduction of store records into the metrics responses.
+ *
+ * Split out of the route handlers for two reasons. It was duplicated four times
+ * — each range endpoint re-implemented the same window filter, the same
+ * product/platform tallies, and the same zero-filled daily bucketing — and none
+ * of it was reachable by a test without standing up an HTTP server. Both
+ * problems go away when the reduction is a pure function of the records.
+ *
+ * This is deliberately store-agnostic. Aggregating in the application process
+ * still costs one full read per query, which is the remaining scaling limit for
+ * large deployments; pushing the aggregation down into SQL requires per-store
+ * support and is separate work. What lives here is the semantics every store
+ * must agree on, so a pushdown implementation has something to be tested
+ * against.
+ */
+
+/** Minimum shape the tallies need. Both `SubscriptionInfo` and `PurchaseInfo` satisfy it. */
+interface Countable {
+  productId: string;
+  platform: string;
+}
+
+/** The count-shaped part of a metrics response; the route adds `from`/`to`. */
+export interface RangeAggregate {
+  total: number;
+  byProduct: Record<string, number>;
+  byPlatform: Record<string, number>;
+  /** Present only when `groupBy: 'day'` was requested. */
+  buckets?: MetricsBucket[];
+}
+
+export interface RangeAggregateOptions<T> {
+  /** Inclusive window bounds, ms-since-epoch. */
+  fromMs: number;
+  toMs: number;
+  groupBy: MetricsGroupBy;
+  /**
+   * ISO timestamp that places a record in the window and its daily bucket —
+   * `purchasedAt` for "started", `expiresAt` for "expired".
+   */
+  anchor: (record: T) => string;
+  /** Records this rejects are ignored entirely (status / type gates). */
+  include?: (record: T) => boolean;
+}
+
+const MS_PER_DAY = 86_400_000;
+
+function bump(map: Record<string, number>, key: string): void {
+  map[key] = (map[key] ?? 0) + 1;
+}
+
+/**
+ * UTC `YYYY-MM-DD` for an epoch-ms instant.
+ *
+ * UTC keeps bucket assignment deterministic regardless of server timezone:
+ * Postgres `updated_at` is UTC and `SubscriptionInfo` dates carry explicit zone
+ * offsets, so a local-time key would silently shift every boundary when the
+ * process moved between regions.
+ */
+export function utcDateKey(ms: number): string {
+  const d = new Date(ms);
+  const yyyy = d.getUTCFullYear();
+  const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(d.getUTCDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+/**
+ * Zero-filled daily series across `[fromMs, toMs]`, inclusive of both boundary
+ * days. Zero-filling is what lets a chart render a flat stretch as flat rather
+ * than as a gap.
+ */
+export function emptyDailyBuckets(fromMs: number, toMs: number): MetricsBucket[] {
+  const out: MetricsBucket[] = [];
+  // Snap to UTC midnight so iteration lands on calendar boundaries.
+  const start = new Date(fromMs);
+  start.setUTCHours(0, 0, 0, 0);
+  let cur = start.getTime();
+  while (cur <= toMs) {
+    out.push({ date: utcDateKey(cur), count: 0 });
+    cur += MS_PER_DAY;
+  }
+  return out;
+}
+
+/**
+ * Tally records whose anchor timestamp falls inside the window.
+ *
+ * Records outside the window, and records rejected by `include`, contribute
+ * nothing — not to `total`, not to the distributions, not to a bucket.
+ */
+export function aggregateRange<T extends Countable>(
+  records: readonly T[],
+  opts: RangeAggregateOptions<T>,
+): RangeAggregate {
+  const byProduct: Record<string, number> = {};
+  const byPlatform: Record<string, number> = {};
+  let total = 0;
+
+  const buckets = opts.groupBy === 'day' ? emptyDailyBuckets(opts.fromMs, opts.toMs) : null;
+  // date → index, so bucket assignment stays O(1) per record instead of a scan.
+  const bucketIndex = buckets ? new Map(buckets.map((b, i) => [b.date, i])) : null;
+
+  for (const record of records) {
+    if (opts.include && !opts.include(record)) continue;
+    const anchorMs = new Date(opts.anchor(record)).getTime();
+    if (Number.isNaN(anchorMs)) continue;
+    if (anchorMs < opts.fromMs || anchorMs > opts.toMs) continue;
+
+    total++;
+    bump(byProduct, record.productId);
+    bump(byPlatform, record.platform);
+
+    if (buckets && bucketIndex) {
+      const idx = bucketIndex.get(utcDateKey(anchorMs));
+      if (idx !== undefined) buckets[idx]!.count++;
+    }
+  }
+
+  return { total, byProduct, byPlatform, ...(buckets ? { buckets } : {}) };
+}
+
+/** A subscription counts as currently entitled: allowed status AND not yet expired. */
+export function isActiveSubscription(sub: SubscriptionInfo, nowMs: number): boolean {
+  const statusAllows =
+    sub.status === SUBSCRIPTION_STATUS.ACTIVE || sub.status === SUBSCRIPTION_STATUS.GRACE_PERIOD;
+  return statusAllows && new Date(sub.expiresAt).getTime() > nowMs;
+}
+
+/** A subscription counts as ended: the store recorded it expired or canceled. */
+export function isEndedSubscription(sub: SubscriptionInfo): boolean {
+  return (
+    sub.status === SUBSCRIPTION_STATUS.EXPIRED || sub.status === SUBSCRIPTION_STATUS.CANCELED
+  );
+}
+
+/** Non-consumables grant an ongoing right; consumables are a spent resource. */
+export function isNonConsumable(purchase: PurchaseInfo): boolean {
+  return purchase.type === PURCHASE_TYPE.NON_CONSUMABLE;
+}
+
+/**
+ * Point-in-time entitlement snapshot.
+ *
+ * `byProduct` is subscriptions-only and `byProductPurchases` is
+ * non-consumables-only, so a dashboard can show "subscription mix" and
+ * "lifetime mix" as separate panels. `byPlatform` deliberately spans both —
+ * it answers "where are my paying users", which is not a per-kind question.
+ */
+export function aggregateActive(
+  subs: readonly SubscriptionInfo[],
+  purchases: readonly PurchaseInfo[],
+  nowMs: number,
+): MetricsActiveResponse {
+  const byProduct: Record<string, number> = {};
+  const byProductPurchases: Record<string, number> = {};
+  const byPlatform: Record<string, number> = {};
+  let activeSubscriptions = 0;
+  let gracePeriodSubscriptions = 0;
+  let nonConsumablePurchases = 0;
+
+  for (const sub of subs) {
+    if (!isActiveSubscription(sub, nowMs)) continue;
+    activeSubscriptions++;
+    if (sub.status === SUBSCRIPTION_STATUS.GRACE_PERIOD) gracePeriodSubscriptions++;
+    bump(byProduct, sub.productId);
+    bump(byPlatform, sub.platform);
+  }
+
+  for (const purchase of purchases) {
+    if (!isNonConsumable(purchase)) continue;
+    nonConsumablePurchases++;
+    bump(byProductPurchases, purchase.productId);
+    bump(byPlatform, purchase.platform);
+  }
+
+  return {
+    total: activeSubscriptions + nonConsumablePurchases,
+    activeSubscriptions,
+    gracePeriodSubscriptions,
+    nonConsumablePurchases,
+    byProduct,
+    byProductPurchases,
+    byPlatform,
+  };
+}

--- a/packages/server/src/metrics-cache.ts
+++ b/packages/server/src/metrics-cache.ts
@@ -1,0 +1,104 @@
+import type { CacheAdapter } from './cache.js';
+import { InMemoryCacheAdapter } from './cache.js';
+
+/**
+ * Short-lived cache for aggregate metrics responses.
+ *
+ * The metrics endpoints each reduce every record in the store. The dashboard
+ * overview calls four of them per render and opts out of Next.js fetch caching,
+ * so before this every browser refresh — by every operator — re-scanned the
+ * whole subscription and purchase tables four times. Aggregate counts are the
+ * one part of this server where a few seconds of staleness costs nothing, so
+ * bounding the scan rate is the cheapest protection available and it works for
+ * every store implementation rather than just Postgres.
+ *
+ * Only the admin-gated `/onesub/metrics/*` responses go through here. Nothing
+ * that decides entitlement (`/onesub/status`, `/onesub/entitlement(s)`,
+ * validation) is ever cached — those must reflect the store as of the request.
+ *
+ * Storage is private to the cache instance, NOT the shared `getDefaultCache()`
+ * adapter, and that is deliberate. Metrics keys describe "every record in this
+ * store", which the key itself cannot discriminate: two middlewares in one
+ * process, or two deployments pointed at one Redis database, would read each
+ * other's totals for any query whose window happened to match. Sharing would
+ * also make correctness depend on a globally mutable default that a host can
+ * swap at any time. The cost of keeping it private is that a K-process
+ * deployment recomputes up to K times per TTL window instead of once — still a
+ * fixed bound, where the uncached behaviour had none.
+ */
+
+/** Bypass marker: a TTL of zero or less disables caching entirely. */
+function isDisabled(ttlSeconds: number): boolean {
+  return !Number.isFinite(ttlSeconds) || ttlSeconds <= 0;
+}
+
+export interface MetricsCache {
+  /**
+   * Return the value for `keyParts`, computing it via `produce` on a miss.
+   *
+   * `keyParts` must not contain a raw request timestamp — see
+   * `quantizeToWindow`.
+   */
+  resolve<T>(keyParts: readonly (string | number)[], produce: () => Promise<T>): Promise<T>;
+  /** Snap a millisecond timestamp onto the TTL grid, for use in a cache key. */
+  quantizeToWindow(ms: number): number;
+}
+
+/**
+ * @param ttlSeconds Freshness bound. `0` (or less) disables the cache.
+ * @param storage    Backing store. Defaults to storage private to this
+ *                   instance — see the note above on why this is not the shared
+ *                   adapter. Injectable for tests.
+ */
+export function createMetricsCache(
+  ttlSeconds: number,
+  storage: CacheAdapter = new InMemoryCacheAdapter(),
+): MetricsCache {
+  // Thundering-herd guard, mirroring the Google OAuth token minter: without it,
+  // the four dashboard requests that arrive together on a cold cache each start
+  // their own full scan. Keyed the same as the cache entry.
+  const inflight = new Map<string, Promise<unknown>>();
+
+  const gridMs = Math.max(1, Math.floor(ttlSeconds * 1000));
+
+  return {
+    quantizeToWindow(ms: number): number {
+      if (isDisabled(ttlSeconds)) return ms;
+      // Floor onto the TTL grid. Callers pass request-supplied `from`/`to`,
+      // which carry millisecond precision — the dashboard sends `new Date()` as
+      // `to`, so an unquantized key would be unique per request and never hit.
+      // Note this only groups requests into a shared key: the value stored is
+      // the one computed for whichever request missed first, using ITS exact
+      // window. So the counts always describe a real window, at most one TTL
+      // stale — the response's own `from`/`to` echo stays the caller's values.
+      return Math.floor(ms / gridMs) * gridMs;
+    },
+
+    async resolve<T>(keyParts: readonly (string | number)[], produce: () => Promise<T>): Promise<T> {
+      if (isDisabled(ttlSeconds)) return produce();
+
+      const key = `metrics:${keyParts.join(':')}`;
+      const cache = storage;
+
+      const hit = await cache.get<T>(key);
+      if (hit !== null && hit !== undefined) return hit;
+
+      const pending = inflight.get(key) as Promise<T> | undefined;
+      if (pending) return pending;
+
+      const promise = (async () => {
+        const value = await produce();
+        await cache.set(key, value, ttlSeconds);
+        return value;
+      })();
+      inflight.set(key, promise);
+      try {
+        return await promise;
+      } finally {
+        // Always cleared, including on failure — a rejected computation must not
+        // be handed to later callers, and nothing was written to the cache.
+        inflight.delete(key);
+      }
+    },
+  };
+}

--- a/packages/server/src/providers/apple.ts
+++ b/packages/server/src/providers/apple.ts
@@ -11,6 +11,7 @@ import { APPLE_ROOT_CA_PEMS } from './apple-root-ca.js';
 import { log } from '../logger.js';
 import { fetchWithTimeout } from '../http.js';
 import { getDefaultCache } from '../cache.js';
+import { VerifiedKeyCache } from './verified-key-cache.js';
 import {
   mockValidateAppleSubscription,
   mockValidateAppleProduct,
@@ -96,28 +97,53 @@ export function assertIssuerCanSign(cert: Pick<X509Certificate, 'ca'>, index: nu
   }
 }
 
+/** A chain that passed `verifyAppleCertChain`. */
+interface VerifiedAppleChain {
+  /** PEM of the leaf certificate whose public key signs the JWS. */
+  leafPem: string;
+  /**
+   * Earliest `validTo` across the chain, as ms-since-epoch. Callers that cache
+   * anything derived from this chain must not keep it past this instant, or
+   * they would be honouring an expired certificate.
+   */
+  notAfter: number;
+}
+
 /**
  * Validate that the x5c chain from the JWS terminates at one of Apple's
  * bundled root CAs. Each cert in the chain must be signed by the next (or
  * the bundled root), every issuing cert must be a CA (BasicConstraints), and
  * all certs must currently be within their validity window.
  *
- * Returns the leaf certificate PEM on success. Throws on any failure.
+ * Returns the leaf certificate PEM and the chain's earliest expiry on success.
+ * Throws on any failure.
  */
-function verifyAppleCertChain(x5c: string[]): string {
+function verifyAppleCertChain(x5c: string[]): VerifiedAppleChain {
   if (x5c.length === 0) {
     throw new Error('[onesub/apple] empty x5c');
   }
 
   const chain = x5c.map((der) => new X509Certificate(derBase64ToPem(der)));
   const now = new Date();
+  let notAfter = Infinity;
 
   // Validity window + leaf→intermediate→... signature chain
   for (let i = 0; i < chain.length; i++) {
     const cert = chain[i];
-    if (new Date(cert.validFrom) > now || new Date(cert.validTo) < now) {
+    const validTo = new Date(cert.validTo).getTime();
+    if (new Date(cert.validFrom) > now || validTo < now.getTime()) {
       throw new Error(`[onesub/apple] cert[${i}] outside validity window`);
     }
+    // The whole chain is only as valid as its soonest-expiring link.
+    //
+    // An unparseable `validTo` yields NaN, and every comparison against NaN is
+    // false — so the window check above lets it through (pre-existing, and not
+    // reachable via a cert node itself parsed and formatted). Guard it here
+    // anyway: a chain whose expiry cannot be established reports notAfter 0,
+    // which is in the past, so the caller refuses to cache it and re-verifies
+    // every time. Accept/reject behaviour is deliberately left unchanged.
+    if (Number.isNaN(validTo)) notAfter = 0;
+    else if (validTo < notAfter) notAfter = validTo;
     // Every cert above the leaf signs the cert below it → must be a CA.
     if (i >= 1) assertIssuerCanSign(cert, i);
     if (i + 1 < chain.length) {
@@ -144,7 +170,25 @@ function verifyAppleCertChain(x5c: string[]): string {
     throw new Error('[onesub/apple] cert chain does not terminate at a trusted Apple root');
   }
 
-  return chain[0].toString();
+  return { leafPem: chain[0].toString(), notAfter };
+}
+
+/**
+ * Verified x5c chain → imported leaf key. See `verified-key-cache.ts` for why
+ * this is process-local rather than going through the pluggable `CacheAdapter`,
+ * and for the invariants it maintains.
+ *
+ * Every receipt validation and every Apple webhook lands in `decodeJws`, and
+ * without this each one re-ran the full chain walk (X509 parse per cert, an
+ * ECDSA verify per link, plus the root comparison) and re-imported the leaf —
+ * all synchronous, all on the event loop, all with the same result for weeks at
+ * a time.
+ */
+const appleLeafKeys = new VerifiedKeyCache<Awaited<ReturnType<typeof importX509>>>();
+
+/** Test/diagnostic hook — drop every memoised chain verification. */
+export function clearAppleCertCache(): void {
+  appleLeafKeys.clear();
 }
 
 /**
@@ -174,9 +218,14 @@ export async function decodeJws<T>(jws: string, skipVerification = false): Promi
     throw new Error('[onesub/apple] JWS header missing x5c certificate chain');
   }
 
-  const leafPem = verifyAppleCertChain(x5c);
   const alg = header.alg ?? 'ES256';
-  const key = await importX509(leafPem, alg);
+  // `alg` is part of the cache identity, not just the x5c: it is caller-supplied
+  // and decides what the key is imported for, so a chain claiming a different
+  // alg must never be served a key imported for another one.
+  const key = await appleLeafKeys.resolve([alg, ...x5c], async () => {
+    const { leafPem, notAfter } = verifyAppleCertChain(x5c);
+    return { key: await importX509(leafPem, alg), notAfter };
+  });
 
   const { payload } = await jwtVerify(jws, key);
   return payload as T;

--- a/packages/server/src/providers/verified-key-cache.ts
+++ b/packages/server/src/providers/verified-key-cache.ts
@@ -1,0 +1,152 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Memo for "this certificate chain was verified, and here is the key it
+ * authorises" — the result of an expensive, purely local verification.
+ *
+ * Why this exists: Apple's StoreKit JWS verification re-parses the x5c chain,
+ * re-checks every issuer signature against a bundled Apple root, and re-imports
+ * the leaf public key on EVERY receipt and EVERY webhook. All of it is
+ * synchronous CPU work on the event loop, and Apple's leaf certificates are
+ * stable for weeks — so the same chain is verified over and over with the same
+ * outcome.
+ *
+ * Why this is NOT the pluggable `CacheAdapter`: that adapter exists to share
+ * *rate-limited network* results (Apple API JWTs, Google OAuth tokens) between
+ * cluster nodes, and it serialises values as JSON. An imported key is not
+ * JSON-serialisable — a Redis-backed adapter would silently round-trip it to
+ * `{}` — and what is being avoided here is local CPU, not a network call or a
+ * quota. A Redis round-trip would plausibly cost more than the verification it
+ * replaces. So this cache is deliberately process-local.
+ *
+ * Security invariants, all enforced below and covered by tests:
+ *
+ *   - The entry key covers EVERY input to the verification, including the
+ *     algorithm the key was imported for. A different chain, or the same chain
+ *     claiming a different `alg`, is a different entry — it can never reuse a
+ *     key that was authorised for something else.
+ *   - A failed verification is never stored. A rejected `produce` propagates and
+ *     leaves the cache untouched, so a bad chain is re-verified (and re-rejected)
+ *     every time rather than being remembered either way.
+ *   - No entry outlives the chain that produced it. `notAfter` (the earliest
+ *     expiry in the verified chain) is a hard ceiling on the entry's lifetime,
+ *     so an expired certificate can never be served from cache.
+ */
+
+/** What a successful verification yields: the key, and when it stops being valid. */
+export interface VerifiedKey<K> {
+  key: K;
+  /**
+   * Earliest `notAfter` across the verified chain, as ms-since-epoch. The cache
+   * entry is dropped at or before this instant, never after it.
+   */
+  notAfter: number;
+}
+
+export interface VerifiedKeyCacheOptions {
+  /**
+   * Upper bound on entries. Only successfully verified chains are stored, so in
+   * practice this holds a handful (Apple production + sandbox leaves, across a
+   * rotation). The cap is defence in depth against unbounded growth.
+   */
+  maxEntries?: number;
+  /** Upper bound on an entry's lifetime, independent of certificate expiry. */
+  maxTtlMs?: number;
+  /** Injectable clock. Tests drive expiry with it; production uses `Date.now`. */
+  now?: () => number;
+}
+
+interface Entry<K> {
+  key: K;
+  /** ms-since-epoch; never greater than the chain's own `notAfter`. */
+  expiresAt: number;
+}
+
+const DEFAULT_MAX_ENTRIES = 32;
+const DEFAULT_MAX_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+export class VerifiedKeyCache<K> {
+  private readonly entries = new Map<string, Entry<K>>();
+  private readonly maxEntries: number;
+  private readonly maxTtlMs: number;
+  private readonly now: () => number;
+
+  constructor(opts: VerifiedKeyCacheOptions = {}) {
+    this.maxEntries = opts.maxEntries ?? DEFAULT_MAX_ENTRIES;
+    this.maxTtlMs = opts.maxTtlMs ?? DEFAULT_MAX_TTL_MS;
+    this.now = opts.now ?? Date.now;
+  }
+
+  /**
+   * Return the key for `parts`, verifying via `produce` only on a miss.
+   *
+   * `parts` must contain every input the verification depends on — for Apple
+   * that is the JWS `alg` plus the full x5c chain. Anything left out would let
+   * one input's result be served for a different input.
+   */
+  async resolve(parts: readonly string[], produce: () => Promise<VerifiedKey<K>>): Promise<K> {
+    const cacheKey = digest(parts);
+    const now = this.now();
+
+    const hit = this.entries.get(cacheKey);
+    if (hit) {
+      if (hit.expiresAt > now) return hit.key;
+      // Past its ceiling — drop it and fall through to a full re-verification
+      // rather than serving a key whose chain may have expired.
+      this.entries.delete(cacheKey);
+    }
+
+    // A throw here propagates untouched and stores nothing: an unverifiable
+    // chain must never become a cache entry, positive or negative.
+    const verified = await produce();
+
+    const expiresAt = Math.min(now + this.maxTtlMs, verified.notAfter);
+    // Already at or past its ceiling (a chain expiring within this instant):
+    // usable right now, but not worth remembering.
+    if (expiresAt > now) {
+      this.prune(now);
+      this.entries.set(cacheKey, { key: verified.key, expiresAt });
+    }
+    return verified.key;
+  }
+
+  /** Entries currently held, including any not yet pruned. Test/diagnostic use. */
+  get size(): number {
+    return this.entries.size;
+  }
+
+  /** Drop everything. Test/diagnostic use. */
+  clear(): void {
+    this.entries.clear();
+  }
+
+  /** Make room: expired entries first, then the oldest insertions. */
+  private prune(now: number): void {
+    for (const [key, entry] of this.entries) {
+      if (entry.expiresAt <= now) this.entries.delete(key);
+    }
+    // Map iterates in insertion order, so `keys().next()` is the oldest.
+    while (this.entries.size >= this.maxEntries) {
+      const oldest = this.entries.keys().next();
+      if (oldest.done) break;
+      this.entries.delete(oldest.value);
+    }
+  }
+}
+
+/**
+ * Collision-resistant key for an ordered list of strings.
+ *
+ * Each part is length-prefixed so that concatenation is unambiguous — without
+ * it, `['a', 'bc']` and `['ab', 'c']` would hash identically, and for this cache
+ * that would mean one chain's verified key being served for another.
+ */
+function digest(parts: readonly string[]): string {
+  const hash = createHash('sha256');
+  for (const part of parts) {
+    hash.update(String(part.length));
+    hash.update(':');
+    hash.update(part);
+  }
+  return hash.digest('base64');
+}

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -12,7 +12,7 @@ import type {
 } from '@onesub/shared';
 import { PURCHASE_TYPE, ONESUB_ERROR_CODE, ROUTES, SUBSCRIPTION_STATUS } from '@onesub/shared';
 import type { PurchaseStore, SubscriptionStore } from '../store.js';
-import { evaluateEntitlement } from './entitlements.js';
+import { evaluateEntitlementFrom } from './entitlements.js';
 import { sendError, sendZodError } from '../errors.js';
 import type { WebhookQueue } from '../webhook-queue.js';
 import { fetchAppleSubscriptionStatus } from '../providers/apple.js';
@@ -260,11 +260,16 @@ export function createAdminRouter(
 
       // Evaluate entitlements only when configured. Hosts that don't use the
       // entitlement abstraction get the field omitted (dashboard hides panel).
+      //
+      // Reuses the records fetched above — `evaluateEntitlement` would re-read
+      // both stores for every entitlement, so a host with N entitlements paid
+      // 2N extra round-trips, serially, on every customer page load.
       let entitlements: Record<string, EntitlementStatus> | undefined;
       if (config.entitlements && Object.keys(config.entitlements).length > 0) {
+        const now = Date.now();
         entitlements = {};
         for (const [id, def] of Object.entries(config.entitlements)) {
-          entitlements[id] = await evaluateEntitlement(params.userId, def, store, purchaseStore);
+          entitlements[id] = evaluateEntitlementFrom(subscriptions, purchases, def, now);
         }
       }
 

--- a/packages/server/src/routes/entitlements.ts
+++ b/packages/server/src/routes/entitlements.ts
@@ -17,7 +17,12 @@ import { log } from '../logger.js';
 import { sendError } from '../errors.js';
 
 /**
- * Evaluate a single entitlement for a user.
+ * Evaluate one entitlement against records the caller already holds.
+ *
+ * This is the whole decision, with no store access — so a caller evaluating N
+ * entitlements for one user reads that user's records ONCE and calls this N
+ * times, instead of paying 2N store round-trips. `evaluateEntitlement` below
+ * is the convenience wrapper for the single-entitlement case.
  *
  * A user is entitled when EITHER condition holds for any productId in
  * `entitlement.productIds`:
@@ -31,18 +36,19 @@ import { sendError } from '../errors.js';
  * Subscription is preferred over purchase when both match (subs carry an
  * expiry; non-consumables are forever) so the source field skews toward the
  * more "interesting" signal for ops/analytics.
+ *
+ * `now` is injected so a batch evaluation scores every entitlement against one
+ * consistent instant rather than drifting across awaits.
  */
-export async function evaluateEntitlement(
-  userId: string,
+export function evaluateEntitlementFrom(
+  subs: readonly SubscriptionInfo[],
+  purchases: readonly PurchaseInfo[],
   entitlement: Entitlement,
-  store: SubscriptionStore,
-  purchaseStore: PurchaseStore,
-): Promise<EntitlementStatus> {
+  now: number = Date.now(),
+): EntitlementStatus {
   const productIdSet = new Set(entitlement.productIds);
-  const now = Date.now();
 
   // 1. Check subscriptions first (richer signal — has expiry).
-  const subs = await store.getAllByUserId(userId);
   for (const sub of subs) {
     if (!productIdSet.has(sub.productId)) continue;
     const statusAllows =
@@ -59,7 +65,6 @@ export async function evaluateEntitlement(
   }
 
   // 2. Check non-consumable purchases.
-  const purchases = await purchaseStore.getPurchasesByUserId(userId);
   for (const p of purchases) {
     if (p.type !== PURCHASE_TYPE.NON_CONSUMABLE) continue;
     if (!productIdSet.has(p.productId)) continue;
@@ -71,6 +76,32 @@ export async function evaluateEntitlement(
   }
 
   return { active: false, source: null };
+}
+
+/**
+ * Evaluate a single entitlement for a user, reading the records it needs.
+ *
+ * Thin wrapper over `evaluateEntitlementFrom` — see there for the entitlement
+ * rules. Evaluating several entitlements for the same user through this
+ * function costs 2 store reads each; prefer reading once and calling
+ * `evaluateEntitlementFrom` directly in that case.
+ */
+export async function evaluateEntitlement(
+  userId: string,
+  entitlement: Entitlement,
+  store: SubscriptionStore,
+  purchaseStore: PurchaseStore,
+): Promise<EntitlementStatus> {
+  const now = Date.now();
+  // Read subscriptions first and skip the purchase read entirely when one of
+  // them already grants the entitlement — same laziness this function had
+  // before `evaluateEntitlementFrom` was split out of it.
+  const subs = await store.getAllByUserId(userId);
+  const fromSubs = evaluateEntitlementFrom(subs, [], entitlement, now);
+  if (fromSubs.active) return fromSubs;
+
+  const purchases = await purchaseStore.getPurchasesByUserId(userId);
+  return evaluateEntitlementFrom([], purchases, entitlement, now);
 }
 
 const userIdSchema = z.string().min(1).max(256);
@@ -137,11 +168,17 @@ export function createEntitlementRouter(
     }
 
     try {
-      const entries = await Promise.all(
-        Object.entries(entitlements).map(async ([id, entitlement]) => {
-          const status = await evaluateEntitlement(userId, entitlement, store, purchaseStore);
-          return [id, status] as const;
-        }),
+      // Read this user's records ONCE for the whole map. Evaluating each
+      // entitlement through `evaluateEntitlement` would re-read them per
+      // entitlement — 2N store round-trips for a result that needs 2.
+      const [subs, purchases] = await Promise.all([
+        store.getAllByUserId(userId),
+        purchaseStore.getPurchasesByUserId(userId),
+      ]);
+      const now = Date.now();
+      const entries = Object.entries(entitlements).map(
+        ([id, entitlement]) =>
+          [id, evaluateEntitlementFrom(subs, purchases, entitlement, now)] as const,
       );
       const response: EntitlementsResponse = {
         entitlements: Object.fromEntries(entries),

--- a/packages/server/src/routes/metrics.ts
+++ b/packages/server/src/routes/metrics.ts
@@ -3,24 +3,30 @@ import type { Request, Response } from 'express';
 import { z } from 'zod';
 import type {
   MetricsActiveResponse,
-  MetricsBucket,
   MetricsCountResponse,
+  MetricsGroupBy,
   OneSubServerConfig,
   PurchaseInfo,
   SubscriptionInfo,
 } from '@onesub/shared';
-import {
-  ROUTES,
-  SUBSCRIPTION_STATUS,
-  PURCHASE_TYPE,
-  ONESUB_ERROR_CODE,
-} from '@onesub/shared';
+import { ROUTES, ONESUB_ERROR_CODE } from '@onesub/shared';
 import type { PurchaseStore, SubscriptionStore } from '../store.js';
 import { log } from '../logger.js';
 import { sendError } from '../errors.js';
 import { secretsEqual } from './secret-compare.js';
+import {
+  aggregateActive,
+  aggregateRange,
+  isEndedSubscription,
+  isNonConsumable,
+  type RangeAggregate,
+} from '../metrics-aggregate.js';
+import { createMetricsCache } from '../metrics-cache.js';
 
 const ADMIN_SECRET_HEADER = 'x-admin-secret';
+
+/** Freshness bound when the host does not configure one. */
+export const DEFAULT_METRICS_CACHE_TTL_SECONDS = 30;
 
 /**
  * Read-only aggregate metrics endpoints — gated behind `config.adminSecret`.
@@ -30,9 +36,12 @@ const ADMIN_SECRET_HEADER = 'x-admin-secret';
  * server doesn't currently track; deferred to a follow-up release that adds
  * `config.products: { 'pro_monthly': { price: 9.99, currency: 'USD' } }`.
  *
- * Aggregation strategy: pulls every record via `store.listAll()` and reduces
- * in memory. Fine up to ~100k records; large deployments should optimise the
- * Postgres path with SQL aggregates (separate PR).
+ * Aggregation strategy: reads every record via `store.listAll()` and reduces in
+ * memory (see `metrics-aggregate.ts` for the reduction, which is where the
+ * semantics are tested). That is one full read per computed response, so
+ * responses are cached for `config.metricsCacheTtlSeconds` to bound how often
+ * it happens — see `metrics-cache.ts`. Removing the per-response scan entirely
+ * needs SQL-side aggregation, which is per-store work and still pending.
  */
 export function createMetricsRouter(
   config: OneSubServerConfig,
@@ -43,6 +52,9 @@ export function createMetricsRouter(
 
   const router = Router();
   const adminSecret = config.adminSecret;
+  const metricsCache = createMetricsCache(
+    config.metricsCacheTtlSeconds ?? DEFAULT_METRICS_CACHE_TTL_SECONDS,
+  );
 
   // Auth middleware — only protects /onesub/metrics/* (siblings unaffected
   // even when this router is mounted on the parent root).
@@ -55,65 +67,19 @@ export function createMetricsRouter(
     next();
   });
 
-  // ── helpers ──────────────────────────────────────────────────────────────
-
-  const isActiveSub = (sub: SubscriptionInfo, now: number): boolean => {
-    const statusAllows =
-      sub.status === SUBSCRIPTION_STATUS.ACTIVE ||
-      sub.status === SUBSCRIPTION_STATUS.GRACE_PERIOD;
-    return statusAllows && new Date(sub.expiresAt).getTime() > now;
-  };
-
-  const bump = (map: Record<string, number>, key: string) => {
-    map[key] = (map[key] ?? 0) + 1;
-  };
-
   // ── GET /onesub/metrics/active ───────────────────────────────────────────
 
   router.get(ROUTES.METRICS_ACTIVE, async (_req: Request, res: Response) => {
     try {
-      const [subs, purchases] = await Promise.all([
-        store.listAll(),
-        purchaseStore.listAll(),
-      ]);
-      const now = Date.now();
-
-      const byProduct: Record<string, number> = {};
-      const byProductPurchases: Record<string, number> = {};
-      const byPlatform: Record<string, number> = {};
-      let activeSubscriptions = 0;
-      let gracePeriodSubscriptions = 0;
-      let nonConsumablePurchases = 0;
-
-      for (const sub of subs) {
-        if (!isActiveSub(sub, now)) continue;
-        activeSubscriptions++;
-        if (sub.status === SUBSCRIPTION_STATUS.GRACE_PERIOD) {
-          gracePeriodSubscriptions++;
-        }
-        bump(byProduct, sub.productId);
-        bump(byPlatform, sub.platform);
-      }
-
-      for (const p of purchases) {
-        if (p.type !== PURCHASE_TYPE.NON_CONSUMABLE) continue;
-        nonConsumablePurchases++;
-        // byProductPurchases is purchase-only; byProduct (subs-only) stays clean
-        // so dashboards can render distinct "subscription mix" vs "lifetime mix"
-        // panels without untangling them client-side.
-        bump(byProductPurchases, p.productId);
-        bump(byPlatform, p.platform);
-      }
-
-      const response: MetricsActiveResponse = {
-        total: activeSubscriptions + nonConsumablePurchases,
-        activeSubscriptions,
-        gracePeriodSubscriptions,
-        nonConsumablePurchases,
-        byProduct,
-        byProductPurchases,
-        byPlatform,
-      };
+      // Keyed on the TTL grid rather than the exact instant, so concurrent and
+      // rapid-repeat refreshes share one computation.
+      const response = await metricsCache.resolve<MetricsActiveResponse>(
+        ['active', metricsCache.quantizeToWindow(Date.now())],
+        async () => {
+          const [subs, purchases] = await Promise.all([store.listAll(), purchaseStore.listAll()]);
+          return aggregateActive(subs, purchases, Date.now());
+        },
+      );
       res.status(200).json(response);
     } catch (err) {
       log.error('[onesub/metrics/active] error:', err);
@@ -121,7 +87,7 @@ export function createMetricsRouter(
     }
   });
 
-  // ── GET /onesub/metrics/started?from=&to=&groupBy= ───────────────────────
+  // ── windowed endpoints ───────────────────────────────────────────────────
 
   const rangeSchema = z.object({
     from: z.string().min(1),
@@ -129,7 +95,7 @@ export function createMetricsRouter(
     groupBy: z.enum(['none', 'day']).optional(),
   });
 
-  type Range = { fromMs: number; toMs: number; groupBy: 'none' | 'day' };
+  type Range = { fromMs: number; toMs: number; groupBy: MetricsGroupBy };
 
   // groupBy=day zero-fills one bucket object per calendar day, so an
   // unbounded range (e.g. from=0001-01-01) would allocate millions of
@@ -156,184 +122,96 @@ export function createMetricsRouter(
     return { fromMs, toMs, groupBy };
   }
 
-  // UTC `YYYY-MM-DD` for a given epoch-ms. Used to assign each record to a
-  // calendar-day bucket; UTC keeps the result deterministic regardless of
-  // server timezone (Postgres `updated_at` is UTC; SubscriptionInfo dates are
-  // ISO with explicit zone offsets).
-  function utcDateKey(ms: number): string {
-    const d = new Date(ms);
-    const yyyy = d.getUTCFullYear();
-    const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
-    const dd = String(d.getUTCDate()).padStart(2, '0');
-    return `${yyyy}-${mm}-${dd}`;
-  }
-
-  // Zero-fill a daily series across [fromMs, toMs] (inclusive of both
-  // boundary days). The route handler then increments the counts.
-  function emptyDailyBuckets(fromMs: number, toMs: number): MetricsBucket[] {
-    const out: MetricsBucket[] = [];
-    // Snap `from` to UTC midnight so iteration steps land on calendar boundaries.
-    const start = new Date(fromMs);
-    start.setUTCHours(0, 0, 0, 0);
-    let cur = start.getTime();
-    while (cur <= toMs) {
-      out.push({ date: utcDateKey(cur), count: 0 });
-      cur += 86_400_000;
-    }
-    return out;
-  }
-
-  router.get(ROUTES.METRICS_STARTED, async (req: Request, res: Response) => {
-    const range = parseRange(req);
-    if ('error' in range) {
-      sendError(res, 400, ONESUB_ERROR_CODE.INVALID_INPUT, range.error);
-      return;
-    }
-    try {
-      const subs = await store.listAll();
-      const byProduct: Record<string, number> = {};
-      const byPlatform: Record<string, number> = {};
-      let total = 0;
-
-      // Build a date→index map only when bucketing is requested — keeps the
-      // non-bucketed path identical to the previous implementation.
-      const buckets =
-        range.groupBy === 'day' ? emptyDailyBuckets(range.fromMs, range.toMs) : null;
-      const bucketIndex =
-        buckets ? new Map(buckets.map((b, i) => [b.date, i])) : null;
-
-      for (const sub of subs) {
-        const purchasedMs = new Date(sub.purchasedAt).getTime();
-        if (purchasedMs < range.fromMs || purchasedMs > range.toMs) continue;
-        total++;
-        bump(byProduct, sub.productId);
-        bump(byPlatform, sub.platform);
-        if (buckets && bucketIndex) {
-          const idx = bucketIndex.get(utcDateKey(purchasedMs));
-          if (idx !== undefined) buckets[idx]!.count++;
-        }
+  /**
+   * Shared handler for the three windowed endpoints. They differ only in which
+   * store they read, which records qualify, and which timestamp anchors a
+   * record in the window — so that is all each one supplies.
+   *
+   * The response echoes the caller's own `from`/`to`, not the quantized cache
+   * key, so a client always sees the window it asked about.
+   */
+  function windowed<T extends { productId: string; platform: string }>(
+    name: string,
+    load: () => Promise<readonly T[]>,
+    anchor: (record: T) => string,
+    include?: (record: T) => boolean,
+  ) {
+    return async (req: Request, res: Response): Promise<void> => {
+      const range = parseRange(req);
+      if ('error' in range) {
+        sendError(res, 400, ONESUB_ERROR_CODE.INVALID_INPUT, range.error);
+        return;
       }
+      try {
+        const aggregate = await metricsCache.resolve<RangeAggregate>(
+          [
+            name,
+            metricsCache.quantizeToWindow(range.fromMs),
+            metricsCache.quantizeToWindow(range.toMs),
+            range.groupBy,
+          ],
+          async () =>
+            aggregateRange(await load(), {
+              fromMs: range.fromMs,
+              toMs: range.toMs,
+              groupBy: range.groupBy,
+              anchor,
+              ...(include ? { include } : {}),
+            }),
+        );
 
-      const response: MetricsCountResponse = {
-        from: req.query['from'] as string,
-        to: req.query['to'] as string,
-        total,
-        byProduct,
-        byPlatform,
-        ...(buckets ? { buckets } : {}),
-      };
-      res.status(200).json(response);
-    } catch (err) {
-      log.error('[onesub/metrics/started] error:', err);
-      sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, 'Internal server error');
-    }
-  });
+        const response: MetricsCountResponse = {
+          from: req.query['from'] as string,
+          to: req.query['to'] as string,
+          ...aggregate,
+        };
+        res.status(200).json(response);
+      } catch (err) {
+        log.error(`[onesub/metrics/${name}] error:`, err);
+        sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, 'Internal server error');
+      }
+    };
+  }
+
+  // ── GET /onesub/metrics/started?from=&to=&groupBy= ───────────────────────
+  // Subscriptions whose purchasedAt falls in the window, regardless of their
+  // current status — this is a cohort-start count, not a live-state count.
+  router.get(
+    ROUTES.METRICS_STARTED,
+    windowed<SubscriptionInfo>('started', () => store.listAll(), (sub) => sub.purchasedAt),
+  );
 
   // ── GET /onesub/metrics/expired?from=&to= ────────────────────────────────
-
-  router.get(ROUTES.METRICS_EXPIRED, async (req: Request, res: Response) => {
-    const range = parseRange(req);
-    if ('error' in range) {
-      sendError(res, 400, ONESUB_ERROR_CODE.INVALID_INPUT, range.error);
-      return;
-    }
-    try {
-      const subs = await store.listAll();
-      const byProduct: Record<string, number> = {};
-      const byPlatform: Record<string, number> = {};
-      let total = 0;
-
-      const buckets =
-        range.groupBy === 'day' ? emptyDailyBuckets(range.fromMs, range.toMs) : null;
-      const bucketIndex =
-        buckets ? new Map(buckets.map((b, i) => [b.date, i])) : null;
-
-      for (const sub of subs) {
-        // Counted only if currently expired or canceled — a record that's
-        // still active doesn't qualify even if its expiresAt happened to fall
-        // inside the window (e.g. mid-period billing renewal).
-        if (
-          sub.status !== SUBSCRIPTION_STATUS.EXPIRED &&
-          sub.status !== SUBSCRIPTION_STATUS.CANCELED
-        ) continue;
-        const expiredMs = new Date(sub.expiresAt).getTime();
-        if (expiredMs < range.fromMs || expiredMs > range.toMs) continue;
-        total++;
-        bump(byProduct, sub.productId);
-        bump(byPlatform, sub.platform);
-        if (buckets && bucketIndex) {
-          const idx = bucketIndex.get(utcDateKey(expiredMs));
-          if (idx !== undefined) buckets[idx]!.count++;
-        }
-      }
-
-      const response: MetricsCountResponse = {
-        from: req.query['from'] as string,
-        to: req.query['to'] as string,
-        total,
-        byProduct,
-        byPlatform,
-        ...(buckets ? { buckets } : {}),
-      };
-      res.status(200).json(response);
-    } catch (err) {
-      log.error('[onesub/metrics/expired] error:', err);
-      sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, 'Internal server error');
-    }
-  });
+  // Counted only if currently expired or canceled — a record that's still
+  // active doesn't qualify even if its expiresAt happened to fall inside the
+  // window (e.g. mid-period billing renewal).
+  router.get(
+    ROUTES.METRICS_EXPIRED,
+    windowed<SubscriptionInfo>(
+      'expired',
+      () => store.listAll(),
+      (sub) => sub.expiresAt,
+      isEndedSubscription,
+    ),
+  );
 
   // ── GET /onesub/metrics/purchases/started?from=&to=&groupBy= ─────────────
   // Counts non-consumable purchases (lifetime products) by purchasedAt within
-  // the window. Backs the dashboard's Purchases timeseries chart so hosts that
-  // sell only lifetime products (e.g. coffee's Welcome Pass) get a meaningful
-  // growth signal even when they have no subscription data.
+  // the window. Backs the dashboard's Purchases timeseries so hosts that
+  // sell only lifetime products get a meaningful growth signal even when they
+  // have no subscription data.
   //
   // Consumables are excluded — they grant a one-time resource (coins, lives),
   // not an ongoing entitlement, and would dominate the count noisily.
-  router.get(ROUTES.METRICS_PURCHASES_STARTED, async (req: Request, res: Response) => {
-    const range = parseRange(req);
-    if ('error' in range) {
-      sendError(res, 400, ONESUB_ERROR_CODE.INVALID_INPUT, range.error);
-      return;
-    }
-    try {
-      const purchases = await purchaseStore.listAll();
-      const byProduct: Record<string, number> = {};
-      const byPlatform: Record<string, number> = {};
-      let total = 0;
-
-      const buckets =
-        range.groupBy === 'day' ? emptyDailyBuckets(range.fromMs, range.toMs) : null;
-      const bucketIndex =
-        buckets ? new Map(buckets.map((b, i) => [b.date, i])) : null;
-
-      for (const p of purchases) {
-        if (p.type !== PURCHASE_TYPE.NON_CONSUMABLE) continue;
-        const purchasedMs = new Date(p.purchasedAt).getTime();
-        if (purchasedMs < range.fromMs || purchasedMs > range.toMs) continue;
-        total++;
-        bump(byProduct, p.productId);
-        bump(byPlatform, p.platform);
-        if (buckets && bucketIndex) {
-          const idx = bucketIndex.get(utcDateKey(purchasedMs));
-          if (idx !== undefined) buckets[idx]!.count++;
-        }
-      }
-
-      const response: MetricsCountResponse = {
-        from: req.query['from'] as string,
-        to: req.query['to'] as string,
-        total,
-        byProduct,
-        byPlatform,
-        ...(buckets ? { buckets } : {}),
-      };
-      res.status(200).json(response);
-    } catch (err) {
-      log.error('[onesub/metrics/purchases/started] error:', err);
-      sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, 'Internal server error');
-    }
-  });
+  router.get(
+    ROUTES.METRICS_PURCHASES_STARTED,
+    windowed<PurchaseInfo>(
+      'purchases-started',
+      () => purchaseStore.listAll(),
+      (purchase) => purchase.purchasedAt,
+      isNonConsumable,
+    ),
+  );
 
   return router;
 }

--- a/packages/server/src/store.ts
+++ b/packages/server/src/store.ts
@@ -57,8 +57,9 @@ export interface SubscriptionStore {
    * see all of a user's active subscriptions to decide whether any of them
    * grants the requested entitlement.
    *
-   * Implementations: in-memory currently coalesces by userId so this returns
-   * at most one row; Postgres returns the full history.
+   * All three built-in implementations return the user's full set, one record
+   * per `originalTransactionId`. "Most-recent-first" is last-written-first for
+   * the in-memory store and `updated_at DESC` for Postgres/Redis.
    */
   getAllByUserId(userId: string): Promise<SubscriptionInfo[]>;
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -346,6 +346,23 @@ export interface OneSubServerConfig {
    */
   adminSecret?: string;
   /**
+   * How long an aggregate `/onesub/metrics/*` response may be reused, in
+   * seconds. Defaults to 30. Set `0` to disable caching and reduce the store on
+   * every request.
+   *
+   * Each metrics endpoint reduces every record in the store, and the dashboard
+   * overview calls four of them per render with no client-side caching — so an
+   * uncached deployment re-scans both tables on every browser refresh, by every
+   * operator. These are aggregate counts, where a few seconds of staleness is
+   * unremarkable; nothing that decides entitlement is ever cached.
+   *
+   * The cache is private to each middleware instance rather than shared through
+   * the `cache` adapter, because a metrics key describes "every record in this
+   * store" and cannot distinguish one store from another. So a K-process
+   * deployment recomputes at most K times per window, not once.
+   */
+  metricsCacheTtlSeconds?: number;
+  /**
    * Structured logger to receive onesub's runtime logs. If omitted, logs go
    * to `console.info/warn/error`. Any object that implements `OneSubLogger`
    * (`pino`, `winston`, `bunyan`, `console`) works.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,25 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // Resolve @onesub/shared to SOURCE, not to its gitignored `dist`.
+      //
+      // Dependents import the compiled output, which is not rebuilt
+      // automatically and has no tsconfig path mapping. Vitest transpiles
+      // without type-checking, so before this alias a newly added value export
+      // that was missing from a stale `dist` was simply `undefined` at
+      // runtime — a comparison would quietly never match and the suite stayed
+      // green. That failure mode is silent and specific to `npm test`; `tsc`
+      // catches the same staleness loudly via the stale `.d.ts`.
+      //
+      // Builds and type-checks still go through `dist`, so this does not
+      // remove the need to run `npm run build -w @onesub/shared` before a
+      // dependent build or type-check.
+      '@onesub/shared': fileURLToPath(new URL('./packages/shared/src/index.ts', import.meta.url)),
+    },
+  },
   test: {
     globals: true,
     environment: 'node',


### PR DESCRIPTION
Four performance fixes found while reviewing the repository, plus hygiene. No
route, persisted field, or error code changes; one additive config field.

## What changed

| Commit | Problem |
|---|---|
| `chore` | `fetchWithTimeout` leaked an `abort` listener per call on a reused signal; `ioredis-mock` test noise masked it; Vitest resolved `@onesub/shared` to a stale `dist` |
| `perf(server)` | Entitlement evaluation re-read both stores **per entitlement** — 2N queries where 2 suffice, on the SDK's app-launch path |
| `perf(sdk)` | Context value rebuilt every render, so every `useOneSub()` consumer re-rendered on any render above the provider |
| `perf(server)` | `decodeJws` re-verified the full Apple x5c chain on every receipt and webhook — synchronous CPU on the event loop, same answer for weeks |
| `perf(server)` | Every `/onesub/metrics/*` request scanned the whole store; the dashboard calls four of them per render with no client caching |

## Verification

Each of the 5 commits was checked out individually — `build`, `test`, and `size`
pass at every one, so a bisect cannot land on a broken commit.

Final state: **674 tests** (was 617), `build`, `type-check`, `size`
(34.17/34.55 KB against 36), `docs:check`, `validate-unity-packages.ps1`, and the
dashboard build all pass.

`e2e.yml` was dispatched on this branch and passed (run 30201623547). That run is
load-bearing here, not a formality: the Apple certificate cache's success path
cannot be exercised locally, because a chain that passes verification must be
signed by Apple's private keys. The e2e script posts a **real** Apple-signed JWS
(no `mockMode`, no `skipJwsVerification`), then posts a tampered copy that reuses
the same header — so the same x5c chain and `alg`, which means the second call is
a cache **hit**. It was still rejected:

```
PASS  purchase validate (real Apple JWS) → 200 valid
PASS  tampered JWS → 422 rejected
```

The Google job also passed, exercising the `fetchWithTimeout` change against the
real Play Developer API.

## Deliberate trade-offs

- **Entitlements**: the bulk route now always issues both reads in parallel. For
  a host with one entitlement satisfied by a subscription that is one extra query
  at equal latency; for anything more, or for a user without a matching
  subscription, it is a large net reduction. A purchase-store failure now
  surfaces as a 500 there rather than being invisible when every entitlement
  happened to match a subscription — reporting a user as unentitled because a
  store was unreachable would be worse.
- **Metrics cache is per-middleware-instance**, not the shared `cache` adapter. A
  metrics key describes "every record in this store" and cannot discriminate one
  store from another; sharing let two middlewares in one process read each
  other's totals, which is how the existing tests caught it. Cost: a K-process
  deployment recomputes up to K times per window instead of once — still a fixed
  bound where there was none.
- **Apple cert cache is process-local** because an imported key is not
  JSON-serialisable (a Redis adapter would round-trip it to `{}`) and the cost
  being avoided is local CPU, not a rate-limited call.

Nothing that decides entitlement is cached: `/onesub/status`,
`/onesub/entitlement(s)`, and both validate routes are untouched.

## Known gaps

- **`perf(sdk)` has no test coverage.** This package has no provider-render test
  and no tooling to add one (`@testing-library/react-native` /
  `react-test-renderer` are not dependencies). Verified by review and type-check
  only.
- **Metrics still cost one full store read per computed response.** Pushing the
  aggregation into SQL is the remaining win for large Postgres deployments, but
  there is no Postgres test coverage, no local database, and no CI service
  container — so it was left out rather than shipped unexercised. The extracted
  pure functions are the contract such an implementation must reproduce.
- Apple's certificate **revocation** is still not checked, unchanged from before.
  Relatedly, the pre-existing validity-window check passes an unparseable
  `validTo` (every NaN comparison is false); this PR does not change that
  accept/reject behaviour, but does ensure such a chain is never cached.

## Release

Carries three changesets, so merging opens a **Version Packages** PR:
`@onesub/shared` minor, `@onesub/server` minor, `@jeonghwanko/onesub-sdk` patch
(with `mcp-server` / `cli` picking up internal-dependency patches). Merging
**this** PR also republishes the dashboard Docker image immediately, since
`packages/shared/**` is in that workflow's trigger paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)