### PR TITLE
perf(server): look up purchases by product instead of scanning a user's history

### DIFF
--- a/.changeset/tidy-owls-lookup.md
+++ b/.changeset/tidy-owls-lookup.md
@@ -1,0 +1,32 @@
+---
+'@onesub/server': minor
+---
+
+Look up purchases by product instead of reading a user's whole history.
+
+Non-consumable validation asked "does this user own this product?" by fetching
+every purchase row the user had and filtering in process. An account with a long
+consumable history — coins, lives, refills — paid to transfer all of those rows on
+every single lifetime-product purchase, on a hot path.
+
+`PurchaseStore` gains an optional `getPurchasesForProduct(userId, productId)`, and
+both call sites use it when the store provides one: the non-consumable ownership
+check, and `GET /onesub/purchase/status?productId=`. All three built-in stores
+implement it from an index — `WHERE user_id = $1 AND product_id = $2` in Postgres,
+the `user_product` set that already backed `hasPurchased` in Redis.
+
+The method is optional, so a custom `PurchaseStore` written before it existed keeps
+compiling and keeps working: those call sites fall back to the previous
+full-history read and in-process filter. Responses are identical on both paths.
+
+`GET /onesub/purchase/status` without a `productId` still returns the user's full
+history and still has no pagination — bounding it means either a default limit,
+which would silently truncate for hosts relying on completeness, or new query
+parameters. That is a route-contract decision and is not included here.
+
+Also fixes an ordering divergence between the stores. `InMemoryPurchaseStore`
+appended new rows, so it returned purchases oldest-first while Postgres
+(`ORDER BY purchased_at DESC`) and Redis returned newest-first — meaning
+`/onesub/purchase/status` came back in the opposite order under `onesub dev` and in
+most tests than it does in production, for the same data. All three now return
+most-recent-first, and the interface states it.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -72,7 +72,8 @@ createOneSubMiddleware(config)
       ├── POST /onesub/purchase/validate  → zod → provider.validate → purchaseStore.save
       │                                     (Google consumable: consumeGoogleProductReceipt fire-and-forget)
       │                                     (Google non-consumable: acknowledgeGoogleProduct fire-and-forget)
-      ├── GET  /onesub/purchase/status    → purchaseStore.getPurchasesByUserId → { purchases }
+      ├── GET  /onesub/purchase/status    → getPurchasesForProduct (with ?productId)
+      │                                     else getPurchasesByUserId → { purchases }
       │
       │── Entitlements (only if config.entitlements is set):
       ├── GET  /onesub/entitlement        → evaluate one configured entitlement
@@ -139,6 +140,7 @@ interface SubscriptionStore {
 interface PurchaseStore {
   savePurchase(purchase: PurchaseInfo): Promise<void>;
   getPurchasesByUserId(userId: string): Promise<PurchaseInfo[]>;
+  getPurchasesForProduct?(userId: string, productId: string): Promise<PurchaseInfo[]>; // 0.21.0+, optional
   getPurchaseByTransactionId(txId: string): Promise<PurchaseInfo | null>;
   listAll(): Promise<PurchaseInfo[]>;
   hasPurchased(userId: string, productId: string): Promise<boolean>;
@@ -147,6 +149,19 @@ interface PurchaseStore {
   deletePurchaseByTransactionId(transactionId: string): Promise<boolean>;             // 0.8.0+
 }
 ```
+
+Both read methods return **most-recent-first** by `purchasedAt`. All three built-in
+stores agree on that; a custom store should too, since `/onesub/purchase/status`
+surfaces the order directly.
+
+`getPurchasesForProduct` is optional. Non-consumable validation and
+`/onesub/purchase/status?productId=` use it when present and otherwise read the
+full history and filter in process — correct either way, but the unscoped read
+transfers every row a user owns, so an account with a long consumable history paid
+for all of them on each lifetime-product purchase. The built-in stores serve it
+from an index (`WHERE user_id = $1 AND product_id = $2` in Postgres, the
+`user_product` set in Redis). It is optional so that custom `PurchaseStore`
+implementations written before it existed keep compiling.
 
 `deletePurchaseByTransactionId` is the precise single-row removal used by IAP refund paths (Apple `REFUND`/`REVOKE` for `Consumable`/`Non-Consumable`, Google `voidedPurchaseNotification` `productType=2`). Distinct from `deletePurchases(userId, productId)` which wipes all rows for that pair — using the userId/productId variant on a refund would also remove sibling consumable purchases the user still owns.
 

--- a/packages/server/src/__tests__/purchase-product-lookup.test.ts
+++ b/packages/server/src/__tests__/purchase-product-lookup.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Product-scoped purchase lookup — `PurchaseStore.getPurchasesForProduct`.
+ *
+ * Non-consumable validation used to read a user's entire purchase history and
+ * filter it in process, so an account with a long consumable history paid for
+ * every one of those rows on each lifetime-product purchase. The optional
+ * store method pushes the filter into an index instead.
+ *
+ * Covered here:
+ *   - the store contract, including the most-recent-first ordering all three
+ *     built-in stores must agree on
+ *   - that the route actually uses the index-backed method when a store has one
+ *     (responses are identical either way, so only a call count shows it)
+ *   - that a store without the method still works, since it is optional
+ */
+
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import type { PurchaseInfo } from '@onesub/shared';
+import { createOneSubMiddleware } from '../index.js';
+import { InMemorySubscriptionStore, InMemoryPurchaseStore } from '../store.js';
+import type { PurchaseStore } from '../store.js';
+
+function purchase(overrides?: Partial<PurchaseInfo>): PurchaseInfo {
+  return {
+    userId: 'u',
+    productId: 'coins_100',
+    platform: 'apple',
+    type: 'consumable',
+    transactionId: `tx_${Math.random()}`,
+    purchasedAt: '2026-04-10T00:00:00.000Z',
+    quantity: 1,
+    ...overrides,
+  };
+}
+
+/** Counts calls to one method while leaving its behaviour intact. */
+function countCalls<T extends object, K extends keyof T>(target: T, method: K): () => number {
+  let calls = 0;
+  const original = target[method] as unknown as (...args: unknown[]) => unknown;
+  (target as Record<K, unknown>)[method] = (...args: unknown[]) => {
+    calls++;
+    return original.apply(target, args);
+  };
+  return () => calls;
+}
+
+/**
+ * A store that deliberately does NOT implement `getPurchasesForProduct`, standing
+ * in for a host's own `PurchaseStore` written before the method existed.
+ */
+function storeWithoutProductLookup(): PurchaseStore {
+  const inner = new InMemoryPurchaseStore();
+  const shim: PurchaseStore = {
+    savePurchase: (p) => inner.savePurchase(p),
+    getPurchasesByUserId: (u) => inner.getPurchasesByUserId(u),
+    getPurchaseByTransactionId: (t) => inner.getPurchaseByTransactionId(t),
+    listAll: () => inner.listAll(),
+    hasPurchased: (u, p) => inner.hasPurchased(u, p),
+    deletePurchases: (u, p) => inner.deletePurchases(u, p),
+    deletePurchaseByTransactionId: (t) => inner.deletePurchaseByTransactionId(t),
+    reassignPurchase: (t, u) => inner.reassignPurchase(t, u),
+  };
+  return shim;
+}
+
+function buildApp(purchaseStore: PurchaseStore) {
+  const app = express();
+  app.use(
+    createOneSubMiddleware({
+      database: { url: '' },
+      apple: { bundleId: 'com.test.mock', mockMode: true },
+      google: { packageName: 'com.test.mock', mockMode: true },
+      store: new InMemorySubscriptionStore(),
+      purchaseStore,
+    }),
+  );
+  return app;
+}
+
+describe('InMemoryPurchaseStore.getPurchasesForProduct', () => {
+  it('returns only the requested product', async () => {
+    const store = new InMemoryPurchaseStore();
+    await store.savePurchase(purchase({ userId: 'a', productId: 'coins_100', transactionId: 't1' }));
+    await store.savePurchase(purchase({ userId: 'a', productId: 'coins_100', transactionId: 't2' }));
+    await store.savePurchase(purchase({ userId: 'a', productId: 'lifetime_pass', transactionId: 't3' }));
+    // Another user's row for the same product must not leak.
+    await store.savePurchase(purchase({ userId: 'b', productId: 'coins_100', transactionId: 't4' }));
+
+    const rows = await store.getPurchasesForProduct('a', 'coins_100');
+    expect(rows).toHaveLength(2);
+    expect(rows.every((p) => p.productId === 'coins_100' && p.userId === 'a')).toBe(true);
+  });
+
+  it('returns an empty array for an unknown user or product', async () => {
+    const store = new InMemoryPurchaseStore();
+    await store.savePurchase(purchase({ userId: 'a', productId: 'coins_100' }));
+    expect(await store.getPurchasesForProduct('a', 'nothing')).toEqual([]);
+    expect(await store.getPurchasesForProduct('nobody', 'coins_100')).toEqual([]);
+  });
+});
+
+describe('InMemoryPurchaseStore ordering', () => {
+  // Postgres orders `purchased_at DESC` and Redis reads a reverse-scored set, so
+  // the in-memory store has to agree or `/onesub/purchase/status` returns a
+  // different order under `onesub dev` than in production for the same data.
+  it('returns purchases most-recent-first regardless of insertion order', async () => {
+    const store = new InMemoryPurchaseStore();
+    await store.savePurchase(purchase({ userId: 'a', purchasedAt: '2026-04-10T00:00:00Z', transactionId: 'mid' }));
+    await store.savePurchase(purchase({ userId: 'a', purchasedAt: '2026-01-01T00:00:00Z', transactionId: 'oldest' }));
+    await store.savePurchase(purchase({ userId: 'a', purchasedAt: '2026-08-01T00:00:00Z', transactionId: 'newest' }));
+
+    expect((await store.getPurchasesByUserId('a')).map((p) => p.transactionId)).toEqual([
+      'newest',
+      'mid',
+      'oldest',
+    ]);
+  });
+
+  it('applies the same ordering to the product-scoped lookup', async () => {
+    const store = new InMemoryPurchaseStore();
+    await store.savePurchase(purchase({ userId: 'a', purchasedAt: '2026-04-10T00:00:00Z', transactionId: 'mid' }));
+    await store.savePurchase(purchase({ userId: 'a', purchasedAt: '2026-08-01T00:00:00Z', transactionId: 'newest' }));
+    await store.savePurchase(purchase({ userId: 'a', purchasedAt: '2026-01-01T00:00:00Z', transactionId: 'oldest' }));
+
+    expect((await store.getPurchasesForProduct('a', 'coins_100')).map((p) => p.transactionId)).toEqual([
+      'newest',
+      'mid',
+      'oldest',
+    ]);
+  });
+
+  it('does not hand out a reference to its own list', async () => {
+    const store = new InMemoryPurchaseStore();
+    await store.savePurchase(purchase({ userId: 'a', transactionId: 't1' }));
+
+    const first = await store.getPurchasesByUserId('a');
+    first.push(purchase({ userId: 'a', transactionId: 'injected' }));
+
+    expect(await store.getPurchasesByUserId('a')).toHaveLength(1);
+  });
+});
+
+describe('non-consumable validation uses the index-backed lookup', () => {
+  it('does not read the user’s whole purchase history', async () => {
+    const purchaseStore = new InMemoryPurchaseStore();
+    // A consumable-heavy account: these rows are irrelevant to owning `premium`
+    // and must not be transferred to answer the ownership question.
+    for (let i = 0; i < 20; i++) {
+      await purchaseStore.savePurchase(
+        purchase({ userId: 'user_1', productId: 'coins_100', transactionId: `coin_${i}` }),
+      );
+    }
+    const app = buildApp(purchaseStore);
+    const fullReads = countCalls(purchaseStore, 'getPurchasesByUserId');
+    const scopedReads = countCalls(purchaseStore, 'getPurchasesForProduct');
+
+    const res = await request(app).post('/onesub/purchase/validate').send({
+      platform: 'apple',
+      receipt: 'MOCK_VALID_p4_first',
+      userId: 'user_1',
+      productId: 'premium',
+      type: 'non_consumable',
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.valid).toBe(true);
+    expect(scopedReads()).toBe(1);
+    expect(fullReads()).toBe(0);
+  });
+
+  it('still reports an owned non-consumable as a restore', async () => {
+    const purchaseStore = new InMemoryPurchaseStore();
+    const app = buildApp(purchaseStore);
+    const body = {
+      platform: 'apple',
+      receipt: 'MOCK_VALID_p4_owned',
+      userId: 'user_1',
+      productId: 'premium',
+      type: 'non_consumable',
+    };
+
+    const first = await request(app).post('/onesub/purchase/validate').send(body);
+    expect(first.body.action).toBe('new');
+
+    // Second call with a DIFFERENT receipt for the same product — the ownership
+    // check, not transactionId dedup, is what has to catch this.
+    const second = await request(app)
+      .post('/onesub/purchase/validate')
+      .send({ ...body, receipt: 'MOCK_VALID_p4_owned_again' });
+
+    expect(second.status).toBe(200);
+    expect(second.body.valid).toBe(true);
+    expect(second.body.action).toBe('restored');
+    expect(second.body.purchase.transactionId).toBe(first.body.purchase.transactionId);
+  });
+});
+
+describe('a store without getPurchasesForProduct still works', () => {
+  it('falls back to reading the full history and filtering', async () => {
+    const purchaseStore = storeWithoutProductLookup();
+    expect(purchaseStore.getPurchasesForProduct).toBeUndefined();
+    const app = buildApp(purchaseStore);
+    const fullReads = countCalls(purchaseStore, 'getPurchasesByUserId');
+
+    const first = await request(app).post('/onesub/purchase/validate').send({
+      platform: 'apple',
+      receipt: 'MOCK_VALID_p4_fallback',
+      userId: 'user_1',
+      productId: 'premium',
+      type: 'non_consumable',
+    });
+    expect(first.status).toBe(200);
+    expect(first.body.action).toBe('new');
+
+    const second = await request(app).post('/onesub/purchase/validate').send({
+      platform: 'apple',
+      receipt: 'MOCK_VALID_p4_fallback_2',
+      userId: 'user_1',
+      productId: 'premium',
+      type: 'non_consumable',
+    });
+    expect(second.body.action).toBe('restored');
+
+    // The fallback is the whole point: it must have used the unscoped read.
+    expect(fullReads()).toBeGreaterThan(0);
+  });
+
+  it('serves GET /onesub/purchase/status?productId= through the fallback', async () => {
+    const purchaseStore = storeWithoutProductLookup();
+    await purchaseStore.savePurchase(purchase({ userId: 'a', productId: 'coins_100', transactionId: 'c1' }));
+    await purchaseStore.savePurchase(purchase({ userId: 'a', productId: 'lifetime_pass', transactionId: 'l1' }));
+    const app = buildApp(purchaseStore);
+
+    const res = await request(app).get('/onesub/purchase/status?userId=a&productId=coins_100');
+    expect(res.status).toBe(200);
+    expect(res.body.purchases).toHaveLength(1);
+    expect(res.body.purchases[0].productId).toBe('coins_100');
+  });
+});
+
+describe('GET /onesub/purchase/status', () => {
+  it('scopes to the store when productId is given', async () => {
+    const purchaseStore = new InMemoryPurchaseStore();
+    await purchaseStore.savePurchase(purchase({ userId: 'a', productId: 'coins_100', transactionId: 'c1' }));
+    await purchaseStore.savePurchase(purchase({ userId: 'a', productId: 'coins_100', transactionId: 'c2' }));
+    await purchaseStore.savePurchase(purchase({ userId: 'a', productId: 'lifetime_pass', transactionId: 'l1' }));
+    const app = buildApp(purchaseStore);
+    const fullReads = countCalls(purchaseStore, 'getPurchasesByUserId');
+
+    const res = await request(app).get('/onesub/purchase/status?userId=a&productId=coins_100');
+
+    expect(res.status).toBe(200);
+    expect(res.body.purchases).toHaveLength(2);
+    expect(res.body.purchases.every((p: PurchaseInfo) => p.productId === 'coins_100')).toBe(true);
+    expect(fullReads()).toBe(0);
+  });
+
+  it('returns the full history when no productId is given', async () => {
+    const purchaseStore = new InMemoryPurchaseStore();
+    await purchaseStore.savePurchase(purchase({ userId: 'a', productId: 'coins_100', transactionId: 'c1' }));
+    await purchaseStore.savePurchase(purchase({ userId: 'a', productId: 'lifetime_pass', transactionId: 'l1' }));
+    const app = buildApp(purchaseStore);
+
+    const res = await request(app).get('/onesub/purchase/status?userId=a');
+
+    expect(res.status).toBe(200);
+    expect(res.body.purchases).toHaveLength(2);
+  });
+
+  it('does not leak another user’s purchases', async () => {
+    const purchaseStore = new InMemoryPurchaseStore();
+    await purchaseStore.savePurchase(purchase({ userId: 'a', productId: 'coins_100', transactionId: 'c1' }));
+    await purchaseStore.savePurchase(purchase({ userId: 'b', productId: 'coins_100', transactionId: 'c2' }));
+    const app = buildApp(purchaseStore);
+
+    const res = await request(app).get('/onesub/purchase/status?userId=a&productId=coins_100');
+    expect(res.body.purchases).toHaveLength(1);
+    expect(res.body.purchases[0].transactionId).toBe('c1');
+  });
+});

--- a/packages/server/src/__tests__/redis-store.test.ts
+++ b/packages/server/src/__tests__/redis-store.test.ts
@@ -199,6 +199,43 @@ describe('RedisPurchaseStore', () => {
     expect(await store.hasPurchased('alice', 'other_product')).toBe(false);
   });
 
+  it('getPurchasesForProduct reads only the requested product', async () => {
+    await store.savePurchase(basePurchase);
+    await store.savePurchase({ ...basePurchase, transactionId: 'p-2', productId: 'coins_100', type: 'consumable' });
+    await store.savePurchase({ ...basePurchase, transactionId: 'p-3', productId: 'coins_100', type: 'consumable' });
+    // Another user holding the same product must not leak in.
+    await store.savePurchase({ ...basePurchase, transactionId: 'p-4', userId: 'bob', productId: 'coins_100', type: 'consumable' });
+
+    const rows = await store.getPurchasesForProduct('alice', 'coins_100');
+    expect(rows).toHaveLength(2);
+    expect(rows.every((p) => p.userId === 'alice' && p.productId === 'coins_100')).toBe(true);
+    expect(await store.getPurchasesForProduct('alice', 'nothing')).toEqual([]);
+    expect(await store.getPurchasesForProduct('nobody', 'coins_100')).toEqual([]);
+  });
+
+  it('getPurchasesForProduct returns most-recent-first', async () => {
+    // The user_product index is an unordered SET, unlike the per-user sorted
+    // set, so the ordering contract depends on an explicit sort.
+    await store.savePurchase({ ...basePurchase, transactionId: 'mid', productId: 'coins_100', purchasedAt: '2026-04-10T00:00:00.000Z' });
+    await store.savePurchase({ ...basePurchase, transactionId: 'newest', productId: 'coins_100', purchasedAt: '2026-08-01T00:00:00.000Z' });
+    await store.savePurchase({ ...basePurchase, transactionId: 'oldest', productId: 'coins_100', purchasedAt: '2026-01-01T00:00:00.000Z' });
+
+    const rows = await store.getPurchasesForProduct('alice', 'coins_100');
+    expect(rows.map((p) => p.transactionId)).toEqual(['newest', 'mid', 'oldest']);
+  });
+
+  it('getPurchasesForProduct reflects deletions and reassignment', async () => {
+    await store.savePurchase({ ...basePurchase, transactionId: 'p-1', productId: 'coins_100' });
+    await store.savePurchase({ ...basePurchase, transactionId: 'p-2', productId: 'coins_100' });
+
+    await store.deletePurchaseByTransactionId('p-1');
+    expect(await store.getPurchasesForProduct('alice', 'coins_100')).toHaveLength(1);
+
+    await store.reassignPurchase('p-2', 'bob');
+    expect(await store.getPurchasesForProduct('alice', 'coins_100')).toEqual([]);
+    expect(await store.getPurchasesForProduct('bob', 'coins_100')).toHaveLength(1);
+  });
+
   it('reassignPurchase moves ownership without losing the row', async () => {
     await store.savePurchase(basePurchase);
     expect(await store.reassignPurchase('p-1', 'bob')).toBe(true);

--- a/packages/server/src/routes/purchase.ts
+++ b/packages/server/src/routes/purchase.ts
@@ -36,6 +36,26 @@ const purchaseStatusQuerySchema = z.object({
   productId: z.string().min(1).max(256).optional(),
 });
 
+/**
+ * Purchases for one user + product, most-recent-first.
+ *
+ * Uses the store's index-backed `getPurchasesForProduct` when it has one, and
+ * otherwise reads the user's full history and filters here. The fallback is what
+ * this code always did; it stays for custom `PurchaseStore` implementations,
+ * which cannot be required to grow a method without breaking.
+ */
+async function purchasesForProduct(
+  purchaseStore: PurchaseStore,
+  userId: string,
+  productId: string,
+): Promise<PurchaseInfo[]> {
+  if (purchaseStore.getPurchasesForProduct) {
+    return purchaseStore.getPurchasesForProduct(userId, productId);
+  }
+  const all = await purchaseStore.getPurchasesByUserId(userId);
+  return all.filter((p) => p.productId === productId);
+}
+
 export function createPurchaseRouter(
   config: OneSubServerConfig,
   purchaseStore: PurchaseStore
@@ -94,9 +114,10 @@ export function createPurchaseRouter(
       // purchase recorded under this userId (same idempotent-restore semantics
       // as the transactionId-match path below).
       if (type === PURCHASE_TYPE.NON_CONSUMABLE) {
-        const owned = (await purchaseStore.getPurchasesByUserId(userId)).find(
-          (p) => p.productId === productId,
-        );
+        // Scoped to this product rather than reading the user's whole purchase
+        // history — a consumable-heavy account otherwise paid for every one of
+        // its rows on each lifetime-product purchase.
+        const owned = (await purchasesForProduct(purchaseStore, userId, productId))[0];
         if (owned) {
           const response: ValidatePurchaseResponse = {
             valid: true,
@@ -279,11 +300,13 @@ export function createPurchaseRouter(
     const { userId, productId } = query;
 
     try {
-      let purchases = await purchaseStore.getPurchasesByUserId(userId);
-
-      if (productId !== undefined) {
-        purchases = purchases.filter((p) => p.productId === productId);
-      }
+      // With a productId, push the filter into the store instead of reading
+      // every row and discarding most of them. Without one, the route's contract
+      // is the user's full history, so a full read is what it asks for.
+      const purchases =
+        productId !== undefined
+          ? await purchasesForProduct(purchaseStore, userId, productId)
+          : await purchaseStore.getPurchasesByUserId(userId);
 
       const response: PurchaseStatusResponse = { purchases };
       res.status(200).json(response);

--- a/packages/server/src/store.ts
+++ b/packages/server/src/store.ts
@@ -148,7 +148,28 @@ export class InMemorySubscriptionStore implements SubscriptionStore {
  */
 export interface PurchaseStore {
   savePurchase(purchase: PurchaseInfo): Promise<void>;
+  /**
+   * Every purchase for the user, most-recent-first (by `purchasedAt`).
+   *
+   * Unbounded: a user with a long consumable history has a long row set. Prefer
+   * `getPurchasesForProduct` when only one product matters.
+   */
   getPurchasesByUserId(userId: string): Promise<PurchaseInfo[]>;
+  /**
+   * Purchases for one `userId` + `productId`, most-recent-first.
+   *
+   * OPTIONAL. When a store does not implement it, callers fall back to
+   * `getPurchasesByUserId` and filter in process — correct, but it transfers
+   * every row the user has. That is the hot path for non-consumable validation:
+   * a user who has bought thousands of consumables paid for all of them on every
+   * lifetime-product purchase. Implement this and the same answer comes from an
+   * index (`WHERE user_id = $1 AND product_id = $2` in Postgres, the
+   * `user_product` set in Redis).
+   *
+   * Optional rather than required so existing custom `PurchaseStore`
+   * implementations keep compiling; all three built-in stores implement it.
+   */
+  getPurchasesForProduct?(userId: string, productId: string): Promise<PurchaseInfo[]>;
   getPurchaseByTransactionId(txId: string): Promise<PurchaseInfo | null>;
   /** Returns every purchase record. Used by metrics aggregation; admin-gated. */
   listAll(): Promise<PurchaseInfo[]>;
@@ -199,12 +220,28 @@ export class InMemoryPurchaseStore implements PurchaseStore {
     }
     this.byTransactionId.set(purchase.transactionId, purchase);
     const list = this.byUserId.get(purchase.userId) ?? [];
-    list.push(purchase);
+    // Insert so the list stays most-recent-first by purchasedAt, matching what
+    // Postgres (`ORDER BY purchased_at DESC`) and Redis (`zrevrange`) return.
+    // This used to push to the end, so the in-memory store — the one behind
+    // `onesub dev` and most tests — handed back the opposite order from the
+    // stores used in production, and `/onesub/purchase/status` changed order
+    // between dev and prod for the same data.
+    const at = Date.parse(purchase.purchasedAt);
+    const idx = list.findIndex((p) => Date.parse(p.purchasedAt) < at);
+    if (idx === -1) list.push(purchase);
+    else list.splice(idx, 0, purchase);
     this.byUserId.set(purchase.userId, list);
   }
 
   async getPurchasesByUserId(userId: string): Promise<PurchaseInfo[]> {
-    return this.byUserId.get(userId) ?? [];
+    return [...(this.byUserId.get(userId) ?? [])];
+  }
+
+  async getPurchasesForProduct(userId: string, productId: string): Promise<PurchaseInfo[]> {
+    // No secondary index here — this store is for development and tests, where
+    // the row count is small. It exists so all three built-ins agree on the
+    // interface and on ordering.
+    return (this.byUserId.get(userId) ?? []).filter((p) => p.productId === productId);
   }
 
   async getPurchaseByTransactionId(txId: string): Promise<PurchaseInfo | null> {

--- a/packages/server/src/stores/postgres.ts
+++ b/packages/server/src/stores/postgres.ts
@@ -323,6 +323,27 @@ export class PostgresPurchaseStore implements PurchaseStore {
     return result.rows.map(rowToPurchaseInfo);
   }
 
+  /**
+   * Purchases for one user + product, most-recent-first.
+   *
+   * Same shape and ordering as `getPurchasesByUserId`, with `product_id` pushed
+   * into the WHERE clause instead of filtered in process. Non-consumables also
+   * have a partial unique index on `(user_id, product_id)`, so the ownership
+   * check this backs is a single index lookup rather than a full read of the
+   * user's purchase history.
+   */
+  async getPurchasesForProduct(userId: string, productId: string): Promise<PurchaseInfo[]> {
+    const pool = await this.getPool();
+    const result = await pool.query<PurchaseDbRow>(
+      `SELECT *
+         FROM onesub_purchases
+        WHERE user_id = $1 AND product_id = $2
+        ORDER BY purchased_at DESC`,
+      [userId, productId]
+    );
+    return result.rows.map(rowToPurchaseInfo);
+  }
+
   async getPurchaseByTransactionId(txId: string): Promise<PurchaseInfo | null> {
     const pool = await this.getPool();
     const result = await pool.query<PurchaseDbRow>(

--- a/packages/server/src/stores/redis.ts
+++ b/packages/server/src/stores/redis.ts
@@ -210,6 +210,27 @@ export class RedisPurchaseStore implements PurchaseStore {
     return raws.filter((r): r is string => r != null).map((r) => JSON.parse(r) as PurchaseInfo);
   }
 
+  /**
+   * Purchases for one user + product, most-recent-first.
+   *
+   * Served from the `user_product` set that `savePurchase` already maintains for
+   * `hasPurchased`, so this reads only the rows for this product rather than the
+   * user's whole purchase history.
+   *
+   * That set is unordered — unlike the per-user sorted set — so the
+   * most-recent-first contract is restored by an explicit sort here. The row
+   * count is per-product, so this is small.
+   */
+  async getPurchasesForProduct(userId: string, productId: string): Promise<PurchaseInfo[]> {
+    const ids = await this.redis.smembers(PUR_USER_PRODUCT_PREFIX + userId + ':' + productId);
+    if (ids.length === 0) return [];
+    const raws = await this.redis.mget(...ids.map((id) => PUR_TX_PREFIX + id));
+    return raws
+      .filter((r): r is string => r != null)
+      .map((r) => JSON.parse(r) as PurchaseInfo)
+      .sort((a, b) => Date.parse(b.purchasedAt) - Date.parse(a.purchasedAt));
+  }
+
   async getPurchaseByTransactionId(txId: string): Promise<PurchaseInfo | null> {
     const raw = await this.redis.get(PUR_TX_PREFIX + txId);
     return raw ? (JSON.parse(raw) as PurchaseInfo) : null;


### PR DESCRIPTION
Follow-up to #124 — the P4 item from that review.

## Problem

Non-consumable validation answered "does this user own this product?" by fetching
**every** purchase row the user had and filtering in process. An account with a
long consumable history — coins, lives, refills — paid to transfer all of those
rows on every single lifetime-product purchase, on a hot path. The same unscoped
read backed `GET /onesub/purchase/status?productId=`, which then discarded most
of it.

## Change

`PurchaseStore` gains an optional `getPurchasesForProduct(userId, productId)`, and
both call sites use it when the store has one. All three built-in stores serve it
from an index — `WHERE user_id = $1 AND product_id = $2` in Postgres, and in Redis
the `user_product` set that already backed `hasPurchased`.

Optional rather than required so a custom `PurchaseStore` written before it
existed keeps compiling and keeps working; those call sites fall back to the
previous full-history read and filter. Responses are identical on both paths, so
the tests assert **which path ran** by counting store calls — nothing else would
catch a regression to the unscoped read.

## Ordering divergence, found and fixed

`InMemoryPurchaseStore` appended new rows, so it returned purchases oldest-first
while Postgres (`ORDER BY purchased_at DESC`) and Redis both return newest-first.
`/onesub/purchase/status` therefore came back in the **opposite order** under
`onesub dev`, and in most tests, than it does in production for the same data. No
test asserted the order, so nothing caught it.

All three stores now return most-recent-first and the interface states it — which
is what makes the new method's ordering contract mean anything across
implementations. `getPurchasesByUserId` also no longer hands out a reference to
the store's own array.

## Verification

689 tests (was 674). `build`, `type-check`, `size` (35.09/36 KB), `docs:check`,
`validate-unity-packages.ps1`, and the dashboard build all pass.

Three mutations confirm the new tests are real guards: making the route ignore the
index-backed method fails 2, removing the Redis sort fails 1, reverting the
in-memory ordering fails 2.

The Redis implementation is genuinely executed, via `ioredis-mock`.

`e2e.yml` dispatched on this branch and passed (run 30202959327). It is relevant
here rather than incidental: the configured e2e transaction is a **Non-Consumable**
(`battlepass_season1`), so it posts a real Apple-signed JWS to
`/onesub/purchase/validate` with `type: non_consumable` — exactly the ownership
check this PR rewrites — and got `200 valid`.

## Not verified

- **The Postgres query was never executed.** There is no Postgres test coverage,
  no local database, and no CI service container, so it was written by strict
  analogy to the existing queries in that file. Unlike a wrong aggregation it
  fails loudly — a mistake throws and surfaces as a 500 on the first
  non-consumable validate, not as plausible-looking data — but it wants a staging
  check before it is trusted. The e2e run above uses `InMemoryPurchaseStore`, so it
  does not cover this path.
- Adding Postgres coverage (`pg` devDependency + a CI service container) would
  close this and would also unblock the metrics SQL pushdown deferred from #124.

## Out of scope

`GET /onesub/purchase/status` without a `productId` still returns the full history
with no pagination. Bounding it needs either a default limit — which would
silently truncate for hosts relying on completeness — or new query parameters.
Both are route-contract decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)