### PR TITLE
fix(server): stop 500 responses from describing the server, unify input validation

### DIFF
--- a/.changeset/plain-errors-settle.md
+++ b/.changeset/plain-errors-settle.md
@@ -1,0 +1,28 @@
+---
+'@onesub/server': patch
+---
+
+Stop 500 responses from describing the server, and unify input validation.
+
+Seven handlers forwarded `(err as Error).message` straight to the caller on a 500
+— six admin routes and the Apple promotional-offer route. With a Postgres store
+that means the driver's message, which can carry the host, port, role name, and
+fragments of the failing statement. The offer route is the worst of them: it signs
+with the promotional-offer private key, so a JOSE or crypto failure message was the
+last thing to hand back. All seven now log the real error server-side through the
+configured logger and return a generic message. `errorCode` is unchanged, so
+programmatic handling is unaffected — it was always the machine-readable contract.
+
+Input validation went through a new internal `parseOrSend` helper. The routes had
+three different shapes for the same job: a `try/catch` that re-threw non-zod errors
+(correct, five lines, repeated a dozen times), a `try/catch {}` that swallowed
+everything into one generic 400, and `safeParse`. The swallowing variant was the
+actual defect — a bug inside a schema, such as a throwing transform, was reported
+to the caller as "400 bad input", which is both the wrong status and hides the
+cause. The helper keeps the correct behaviour and makes it the short one: zod
+failures become a 400, anything else propagates.
+
+Each route keeps the error response it had. Routes that returned per-issue zod
+detail still do; routes that returned a single fixed message still do; and the
+route-specific shape on the error path (`subscription: null`, `purchases: []`, and
+so on) is preserved. Route handlers lost about 80 lines net.

--- a/packages/server/src/__tests__/errors.test.ts
+++ b/packages/server/src/__tests__/errors.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Error-response helpers, and the guarantee that a 500 does not describe the
+ * server's internals to the caller.
+ *
+ * `parseOrSend` replaced three hand-rolled input-validation shapes across the
+ * routes. The parts worth pinning down are the ones a caller can observe: the
+ * status, the `errorCode`, whether the route's response shape survives on the
+ * error path, and — for the admin routes, which used to forward
+ * `(err as Error).message` verbatim — that internal failure text stays server-side.
+ */
+
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import { z } from 'zod';
+import type { Response } from 'express';
+import { ONESUB_ERROR_CODE } from '@onesub/shared';
+import { parseOrSend } from '../errors.js';
+import { createOneSubMiddleware } from '../index.js';
+import { InMemorySubscriptionStore, InMemoryPurchaseStore } from '../store.js';
+import type { SubscriptionStore } from '../store.js';
+
+/** Minimal Response stand-in that records what a handler sent. */
+function fakeRes() {
+  const sent: { status?: number; body?: unknown } = {};
+  const res = {
+    status(code: number) {
+      sent.status = code;
+      return this;
+    },
+    json(body: unknown) {
+      sent.body = body;
+      return this;
+    },
+  };
+  return { res: res as unknown as Response, sent };
+}
+
+const schema = z.object({ userId: z.string().min(1), count: z.coerce.number().int() });
+
+describe('parseOrSend', () => {
+  it('returns the parsed value and sends nothing on success', () => {
+    const { res, sent } = fakeRes();
+    const out = parseOrSend(res, schema, { userId: 'u', count: '3' });
+    expect(out).toEqual({ userId: 'u', count: 3 });
+    expect(sent.status).toBeUndefined();
+  });
+
+  it('sends 400 INVALID_INPUT with per-issue detail by default', () => {
+    const { res, sent } = fakeRes();
+    const out = parseOrSend(res, schema, { userId: '', count: 'abc' });
+    expect(out).toBeUndefined();
+    expect(sent.status).toBe(400);
+    const body = sent.body as { errorCode: string; error: string };
+    expect(body.errorCode).toBe(ONESUB_ERROR_CODE.INVALID_INPUT);
+    // Detail comes from the schema's own issues rather than a fixed string.
+    expect(body.error.length).toBeGreaterThan(0);
+  });
+
+  it('sends the given message instead of the detail when asked', () => {
+    const { res, sent } = fakeRes();
+    const out = parseOrSend(res, schema, {}, { message: 'userId and count are required' });
+    expect(out).toBeUndefined();
+    const body = sent.body as { errorCode: string; error: string };
+    expect(body.error).toBe('userId and count are required');
+    expect(body.errorCode).toBe(ONESUB_ERROR_CODE.INVALID_INPUT);
+  });
+
+  it('merges the route shape into the error body', () => {
+    const { res, sent } = fakeRes();
+    parseOrSend(res, schema, {}, { extra: { valid: false, subscription: null } });
+    expect(sent.body).toMatchObject({ valid: false, subscription: null });
+  });
+
+  it('lets a non-zod failure inside the schema propagate', () => {
+    // A throwing refinement is a bug in the server, not bad input from the
+    // caller. The old `catch {}` shape reported it as a 400; this must not.
+    const exploding = z.string().transform(() => {
+      throw new Error('refinement blew up');
+    });
+    const { res } = fakeRes();
+    expect(() => parseOrSend(res, exploding, 'anything')).toThrow(/refinement blew up/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 500 responses must not describe the server
+// ---------------------------------------------------------------------------
+
+const SECRET = 's3cr3t';
+const AUTH = { 'x-admin-secret': SECRET };
+/** Distinctive text that must never reach the client. */
+const INTERNAL = 'connection to db-primary.internal:5432 refused (role "onesub_rw")';
+
+/** A store whose reads fail the way a real outage would. */
+function explodingStore(): SubscriptionStore {
+  const inner = new InMemorySubscriptionStore();
+  return {
+    save: (s) => inner.save(s),
+    getByUserId: () => Promise.reject(new Error(INTERNAL)),
+    getByTransactionId: () => Promise.reject(new Error(INTERNAL)),
+    getAllByUserId: () => Promise.reject(new Error(INTERNAL)),
+    listAll: () => Promise.reject(new Error(INTERNAL)),
+    listFiltered: () => Promise.reject(new Error(INTERNAL)),
+  };
+}
+
+function buildApp() {
+  const app = express();
+  app.use(
+    createOneSubMiddleware({
+      database: { url: '' },
+      apple: { bundleId: 'com.test.mock', mockMode: true },
+      adminSecret: SECRET,
+      // Disable the metrics cache so each request actually reaches the store.
+      metricsCacheTtlSeconds: 0,
+      store: explodingStore(),
+      purchaseStore: new InMemoryPurchaseStore(),
+    }),
+  );
+  return app;
+}
+
+describe('a failing store does not leak internals through admin routes', () => {
+  const cases: Array<{ name: string; path: string }> = [
+    { name: 'subscription list', path: '/onesub/admin/subscriptions' },
+    { name: 'subscription detail', path: '/onesub/admin/subscriptions/tx-1' },
+    { name: 'customer profile', path: '/onesub/admin/customers/alice' },
+    { name: 'metrics active', path: '/onesub/metrics/active' },
+    {
+      name: 'metrics started',
+      path: '/onesub/metrics/started?from=2026-01-01T00:00:00Z&to=2026-12-31T00:00:00Z',
+    },
+  ];
+
+  for (const { name, path } of cases) {
+    it(`${name} → 500 with a generic message`, async () => {
+      const res = await request(buildApp()).get(path).set(AUTH);
+
+      expect(res.status).toBe(500);
+      expect(res.body.errorCode).toBe(ONESUB_ERROR_CODE.STORE_ERROR);
+      // The whole point: the driver's message stays in the server log.
+      expect(JSON.stringify(res.body)).not.toContain('db-primary.internal');
+      expect(JSON.stringify(res.body)).not.toContain('onesub_rw');
+      expect(res.body.error).toBe('Internal server error');
+    });
+  }
+
+  it('still reports a 401 before touching the store', async () => {
+    // Ordering check: a bad secret must not produce a store error at all.
+    const res = await request(buildApp()).get('/onesub/admin/subscriptions').set({
+      'x-admin-secret': 'wrong',
+    });
+    expect(res.status).toBe(401);
+    expect(res.body.errorCode).toBe(ONESUB_ERROR_CODE.INVALID_ADMIN_SECRET);
+  });
+});
+
+describe('validation errors keep each route’s response shape', () => {
+  function okApp() {
+    const app = express();
+    app.use(
+      createOneSubMiddleware({
+        database: { url: '' },
+        apple: { bundleId: 'com.test.mock', mockMode: true },
+        store: new InMemorySubscriptionStore(),
+        purchaseStore: new InMemoryPurchaseStore(),
+      }),
+    );
+    return app;
+  }
+
+  it('POST /onesub/validate keeps valid/subscription on a 400', async () => {
+    const res = await request(okApp()).post('/onesub/validate').send({ platform: 'apple' });
+    expect(res.status).toBe(400);
+    expect(res.body.errorCode).toBe(ONESUB_ERROR_CODE.INVALID_INPUT);
+    expect(res.body.valid).toBe(false);
+    expect(res.body.subscription).toBeNull();
+  });
+
+  it('POST /onesub/purchase/validate keeps valid/purchase on a 400', async () => {
+    const res = await request(okApp()).post('/onesub/purchase/validate').send({ platform: 'apple' });
+    expect(res.status).toBe(400);
+    expect(res.body.valid).toBe(false);
+    expect(res.body.purchase).toBeNull();
+  });
+
+  it('GET /onesub/purchase/status keeps an empty purchases array on a 400', async () => {
+    const res = await request(okApp()).get('/onesub/purchase/status');
+    expect(res.status).toBe(400);
+    expect(res.body.purchases).toEqual([]);
+  });
+
+  it('GET /onesub/status keeps active/subscription on a 400', async () => {
+    const res = await request(okApp()).get('/onesub/status');
+    expect(res.status).toBe(400);
+    expect(res.body.active).toBe(false);
+    expect(res.body.subscription).toBeNull();
+  });
+});

--- a/packages/server/src/errors.ts
+++ b/packages/server/src/errors.ts
@@ -37,3 +37,54 @@ export function sendZodError(
     extra,
   );
 }
+
+export interface ParseOrSendOptions {
+  /**
+   * Route-specific fields to merge into the error body, so a 400 keeps the
+   * shape the route's success response has (`subscription: null`,
+   * `purchases: []`, and so on).
+   */
+  extra?: Record<string, unknown>;
+  /**
+   * Send this one message instead of the per-issue zod detail. Use it where the
+   * route deliberately does not echo the input shape back — URL params, and the
+   * entitlement routes. Omit it to get the field-level detail.
+   */
+  message?: string;
+}
+
+/**
+ * Parse `input` with `schema`, or send a 400 and return `undefined`.
+ *
+ * ```ts
+ * const body = parseOrSend(res, validateSchema, req.body, { extra: NO_SUB });
+ * if (!body) return;
+ * ```
+ *
+ * Every route was hand-rolling this, and in three different shapes: a
+ * `try/catch` that re-threw non-zod errors, a `try/catch {}` that swallowed
+ * everything into one generic message, and `safeParse`. The first is correct but
+ * five lines per call site; the second silently turns a genuine bug inside the
+ * schema — a bad refinement, a throwing transform — into "400 bad input", which
+ * is the wrong status and hides the cause.
+ *
+ * This keeps the correct behaviour and makes it the short one: zod failures
+ * become a 400, and anything else propagates to the route's own error handling
+ * rather than being reported as the caller's fault.
+ */
+export function parseOrSend<S extends z.ZodType>(
+  res: Response,
+  schema: S,
+  input: unknown,
+  opts: ParseOrSendOptions = {},
+): z.output<S> | undefined {
+  const result = schema.safeParse(input);
+  if (result.success) return result.data;
+
+  if (opts.message !== undefined) {
+    sendError(res, 400, ONESUB_ERROR_CODE.INVALID_INPUT, opts.message, opts.extra ?? {});
+  } else {
+    sendZodError(res, result.error, opts.extra ?? {});
+  }
+  return undefined;
+}

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -13,7 +13,7 @@ import type {
 import { PURCHASE_TYPE, ONESUB_ERROR_CODE, ROUTES, SUBSCRIPTION_STATUS } from '@onesub/shared';
 import type { PurchaseStore, SubscriptionStore } from '../store.js';
 import { evaluateEntitlementFrom } from './entitlements.js';
-import { sendError, sendZodError } from '../errors.js';
+import { sendError, parseOrSend } from '../errors.js';
 import type { WebhookQueue } from '../webhook-queue.js';
 import { fetchAppleSubscriptionStatus } from '../providers/apple.js';
 import { secretsEqual } from './secret-compare.js';
@@ -80,13 +80,10 @@ export function createAdminRouter(
     productId: z.string().min(1).max(256),
   });
   router.delete('/onesub/purchase/admin/:userId/:productId', async (req: Request, res: Response) => {
-    let params;
-    try {
-      params = resetParamsSchema.parse(req.params);
-    } catch {
-      sendError(res, 400, ONESUB_ERROR_CODE.INVALID_INPUT, 'userId and productId required');
-      return;
-    }
+    const params = parseOrSend(res, resetParamsSchema, req.params, {
+      message: 'userId and productId required',
+    });
+    if (!params) return;
     const deleted = await purchaseStore.deletePurchases(params.userId, params.productId);
     res.json({ ok: true, deleted });
   });
@@ -98,16 +95,8 @@ export function createAdminRouter(
     newUserId: z.string().min(1).max(256),
   });
   router.post('/onesub/purchase/admin/transfer', async (req: Request, res: Response) => {
-    let body;
-    try {
-      body = transferSchema.parse(req.body);
-    } catch (err) {
-      if (err instanceof z.ZodError) {
-        sendZodError(res, err);
-        return;
-      }
-      throw err;
-    }
+    const body = parseOrSend(res, transferSchema, req.body);
+    if (!body) return;
     const existing = await purchaseStore.getPurchaseByTransactionId(body.transactionId);
     if (!existing) {
       sendError(res, 404, ONESUB_ERROR_CODE.TRANSACTION_NOT_FOUND, 'TRANSACTION_NOT_FOUND');
@@ -136,16 +125,8 @@ export function createAdminRouter(
   });
 
   router.post('/onesub/purchase/admin/grant', async (req: Request, res: Response) => {
-    let body;
-    try {
-      body = grantSchema.parse(req.body);
-    } catch (err) {
-      if (err instanceof z.ZodError) {
-        sendZodError(res, err);
-        return;
-      }
-      throw err;
-    }
+    const body = parseOrSend(res, grantSchema, req.body);
+    if (!body) return;
 
     const transactionId = body.transactionId ?? `admin_grant_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
     const purchase: PurchaseInfo = {
@@ -183,16 +164,8 @@ export function createAdminRouter(
   });
 
   router.get(ROUTES.ADMIN_SUBSCRIPTIONS, async (req: Request, res: Response) => {
-    let query: z.infer<typeof listQuerySchema>;
-    try {
-      query = listQuerySchema.parse(req.query);
-    } catch (err) {
-      if (err instanceof z.ZodError) {
-        sendZodError(res, err);
-        return;
-      }
-      throw err;
-    }
+    const query = parseOrSend(res, listQuerySchema, req.query);
+    if (!query) return;
 
     try {
       const result = await store.listFiltered(query);
@@ -205,7 +178,8 @@ export function createAdminRouter(
       res.status(200).json(response);
     } catch (err) {
       // Bubble the message up but not the stack — admin clients log status code
-      sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, (err as Error).message ?? 'list error');
+      log.error('[onesub/admin/subscriptions] list error:', err);
+      sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, 'Internal server error');
     }
   });
 
@@ -215,13 +189,10 @@ export function createAdminRouter(
     transactionId: z.string().min(1).max(256),
   });
   router.get('/onesub/admin/subscriptions/:transactionId', async (req: Request, res: Response) => {
-    let params;
-    try {
-      params = detailParamsSchema.parse(req.params);
-    } catch {
-      sendError(res, 400, ONESUB_ERROR_CODE.INVALID_INPUT, 'transactionId required');
-      return;
-    }
+    const params = parseOrSend(res, detailParamsSchema, req.params, {
+      message: 'transactionId required',
+    });
+    if (!params) return;
     try {
       const sub = await store.getByTransactionId(params.transactionId);
       if (!sub) {
@@ -230,7 +201,8 @@ export function createAdminRouter(
       }
       res.status(200).json(sub);
     } catch (err) {
-      sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, (err as Error).message ?? 'detail error');
+      log.error('[onesub/admin/subscriptions/:transactionId] detail error:', err);
+      sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, 'Internal server error');
     }
   });
 
@@ -245,13 +217,10 @@ export function createAdminRouter(
     userId: z.string().min(1).max(256),
   });
   router.get('/onesub/admin/customers/:userId', async (req: Request, res: Response) => {
-    let params;
-    try {
-      params = customerParamsSchema.parse(req.params);
-    } catch {
-      sendError(res, 400, ONESUB_ERROR_CODE.INVALID_INPUT, 'userId required');
-      return;
-    }
+    const params = parseOrSend(res, customerParamsSchema, req.params, {
+      message: 'userId required',
+    });
+    if (!params) return;
     try {
       const [subscriptions, purchases] = await Promise.all([
         store.getAllByUserId(params.userId),
@@ -281,7 +250,8 @@ export function createAdminRouter(
       };
       res.status(200).json(response);
     } catch (err) {
-      sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, (err as Error).message ?? 'customer error');
+      log.error('[onesub/admin/customers/:userId] error:', err);
+      sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, 'Internal server error');
     }
   });
 
@@ -292,13 +262,10 @@ export function createAdminRouter(
     originalTransactionId: z.string().min(1).max(256),
   });
   router.post(ROUTES.ADMIN_SYNC_APPLE, async (req: Request, res: Response) => {
-    let params;
-    try {
-      params = syncAppleParamsSchema.parse(req.params);
-    } catch {
-      sendError(res, 400, ONESUB_ERROR_CODE.INVALID_INPUT, 'originalTransactionId required');
-      return;
-    }
+    const params = parseOrSend(res, syncAppleParamsSchema, req.params, {
+      message: 'originalTransactionId required',
+    });
+    if (!params) return;
 
     if (!config.apple?.issuerId || !config.apple?.keyId || !config.apple?.privateKey) {
       sendError(res, 400, ONESUB_ERROR_CODE.APPLE_CONFIG_MISSING, 'Apple API credentials not configured');
@@ -323,7 +290,8 @@ export function createAdminRouter(
       await store.save(fresh);
       res.status(200).json({ ok: true, subscription: fresh });
     } catch (err) {
-      sendError(res, 500, ONESUB_ERROR_CODE.INTERNAL_ERROR, (err as Error).message ?? 'sync error');
+      log.error('[onesub/admin/sync-apple] error:', err);
+      sendError(res, 500, ONESUB_ERROR_CODE.INTERNAL_ERROR, 'Internal server error');
     }
   });
 
@@ -340,19 +308,10 @@ export function createAdminRouter(
   });
 
   router.put(ROUTES.ADMIN_TEST_OVERRIDE, (req: Request, res: Response) => {
-    let params;
-    let body;
-    try {
-      params = overrideParamsSchema.parse(req.params);
-      body = overrideBodySchema.parse(req.body);
-    } catch (err) {
-      if (err instanceof z.ZodError) {
-        sendZodError(res, err);
-      } else {
-        sendError(res, 400, ONESUB_ERROR_CODE.INVALID_INPUT, 'userId and { entitled: boolean } required');
-      }
-      return;
-    }
+    const params = parseOrSend(res, overrideParamsSchema, req.params);
+    if (!params) return;
+    const body = parseOrSend(res, overrideBodySchema, req.body);
+    if (!body) return;
     setTestOverride(params.userId, body.entitled);
     log.warn(
       `[onesub/admin] sandbox test override set for ${params.userId}: entitled=${body.entitled}`,
@@ -361,13 +320,10 @@ export function createAdminRouter(
   });
 
   router.delete(ROUTES.ADMIN_TEST_OVERRIDE, (req: Request, res: Response) => {
-    let params;
-    try {
-      params = overrideParamsSchema.parse(req.params);
-    } catch {
-      sendError(res, 400, ONESUB_ERROR_CODE.INVALID_INPUT, 'userId required');
-      return;
-    }
+    const params = parseOrSend(res, overrideParamsSchema, req.params, {
+      message: 'userId required',
+    });
+    if (!params) return;
     const cleared = clearTestOverride(params.userId);
     res.json({ ok: true, userId: params.userId, cleared });
   });
@@ -383,7 +339,8 @@ export function createAdminRouter(
         const items = await webhookQueue.listDeadLetters!();
         res.status(200).json({ items });
       } catch (err) {
-        sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, (err as Error).message ?? 'list error');
+        log.error('[onesub/admin/webhook-deadletters] error:', err);
+        sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, 'Internal server error');
       }
     });
   }
@@ -391,18 +348,14 @@ export function createAdminRouter(
   if (webhookQueue?.replayDeadLetter) {
     const replayParamsSchema = z.object({ id: z.string().min(1).max(256) });
     router.post('/onesub/admin/webhook-replay/:id', async (req: Request, res: Response) => {
-      let params;
-      try {
-        params = replayParamsSchema.parse(req.params);
-      } catch {
-        sendError(res, 400, ONESUB_ERROR_CODE.INVALID_INPUT, 'id required');
-        return;
-      }
+      const params = parseOrSend(res, replayParamsSchema, req.params, { message: 'id required' });
+      if (!params) return;
       try {
         await webhookQueue.replayDeadLetter!(params.id);
         res.status(200).json({ ok: true });
       } catch (err) {
-        sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, (err as Error).message ?? 'replay error');
+        log.error('[onesub/admin/webhook-replay] error:', err);
+        sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, 'Internal server error');
       }
     });
   }

--- a/packages/server/src/routes/apple-offer.ts
+++ b/packages/server/src/routes/apple-offer.ts
@@ -4,8 +4,9 @@ import { z } from 'zod';
 import type { OneSubServerConfig } from '@onesub/shared';
 import { ONESUB_ERROR_CODE } from '@onesub/shared';
 import { signApplePromotionalOffer } from '../providers/apple.js';
-import { sendError, sendZodError } from '../errors.js';
+import { sendError, parseOrSend } from '../errors.js';
 import { secretsEqual } from './secret-compare.js';
+import { log } from '../logger.js';
 
 const OFFER_SECRET_HEADER = 'x-onesub-offer-secret';
 
@@ -46,16 +47,8 @@ export function createAppleOfferRouter(config: OneSubServerConfig): Router | nul
         return;
       }
     }
-    let body: z.infer<typeof offerBodySchema>;
-    try {
-      body = offerBodySchema.parse(req.body);
-    } catch (err) {
-      if (err instanceof z.ZodError) {
-        sendZodError(res, err);
-        return;
-      }
-      throw err;
-    }
+    const body = parseOrSend(res, offerBodySchema, req.body);
+    if (!body) return;
 
     if (!apple.bundleId) {
       sendError(res, 400, ONESUB_ERROR_CODE.APPLE_CONFIG_MISSING, 'config.apple.bundleId is required for offer signing');
@@ -74,7 +67,11 @@ export function createAppleOfferRouter(config: OneSubServerConfig): Router | nul
       );
       res.status(200).json(result);
     } catch (err) {
-      sendError(res, 500, ONESUB_ERROR_CODE.INTERNAL_ERROR, (err as Error).message ?? 'Offer signing failed');
+      // The message is deliberately generic: this route signs with the
+      // promotional-offer private key, so a crypto/JOSE failure message is the
+      // last thing to hand an unauthenticated-until-proven caller.
+      log.error('[onesub/apple/offer] signing error:', err);
+      sendError(res, 500, ONESUB_ERROR_CODE.INTERNAL_ERROR, 'Offer signing failed');
     }
   });
 

--- a/packages/server/src/routes/entitlements.ts
+++ b/packages/server/src/routes/entitlements.ts
@@ -14,7 +14,7 @@ import type {
 import { ROUTES, SUBSCRIPTION_STATUS, ONESUB_ERROR_CODE, PURCHASE_TYPE } from '@onesub/shared';
 import type { PurchaseStore, SubscriptionStore } from '../store.js';
 import { log } from '../logger.js';
-import { sendError } from '../errors.js';
+import { sendError, parseOrSend } from '../errors.js';
 
 /**
  * Evaluate one entitlement against records the caller already holds.
@@ -107,6 +107,9 @@ export async function evaluateEntitlement(
 const userIdSchema = z.string().min(1).max(256);
 const entitlementIdSchema = z.string().min(1).max(128);
 
+const entitlementQuerySchema = z.object({ userId: userIdSchema, id: entitlementIdSchema });
+const entitlementsQuerySchema = z.object({ userId: userIdSchema });
+
 export function createEntitlementRouter(
   config: OneSubServerConfig,
   store: SubscriptionStore,
@@ -127,15 +130,11 @@ export function createEntitlementRouter(
    * Single entitlement check.
    */
   router.get(ROUTES.ENTITLEMENT, async (req: Request, res: Response) => {
-    let userId: string;
-    let id: string;
-    try {
-      userId = userIdSchema.parse(req.query['userId']);
-      id = entitlementIdSchema.parse(req.query['id']);
-    } catch {
-      sendError(res, 400, ONESUB_ERROR_CODE.INVALID_INPUT, 'userId and id are required');
-      return;
-    }
+    const query = parseOrSend(res, entitlementQuerySchema, req.query, {
+      message: 'userId and id are required',
+    });
+    if (!query) return;
+    const { userId, id } = query;
 
     const entitlement = entitlements[id];
     if (!entitlement) {
@@ -159,13 +158,11 @@ export function createEntitlementRouter(
    * app launch / login when the host wants the full entitlement map.
    */
   router.get(ROUTES.ENTITLEMENTS, async (req: Request, res: Response) => {
-    let userId: string;
-    try {
-      userId = userIdSchema.parse(req.query['userId']);
-    } catch {
-      sendError(res, 400, ONESUB_ERROR_CODE.INVALID_INPUT, 'userId is required');
-      return;
-    }
+    const query = parseOrSend(res, entitlementsQuerySchema, req.query, {
+      message: 'userId is required',
+    });
+    if (!query) return;
+    const { userId } = query;
 
     try {
       // Read this user's records ONCE for the whole map. Evaluating each

--- a/packages/server/src/routes/purchase.ts
+++ b/packages/server/src/routes/purchase.ts
@@ -17,7 +17,7 @@ import {
   acknowledgeGoogleProduct,
 } from '../providers/google.js';
 import { log } from '../logger.js';
-import { sendError, sendZodError } from '../errors.js';
+import { sendError, parseOrSend } from '../errors.js';
 
 const NO_PURCHASE = { valid: false, purchase: null } as const;
 
@@ -78,17 +78,8 @@ export function createPurchaseRouter(
    *   enforces 72h receipt age, uses orderId as the dedup key
    */
   router.post(ROUTES.VALIDATE_PURCHASE, async (req: Request, res: Response) => {
-    let body: z.infer<typeof validatePurchaseSchema>;
-
-    try {
-      body = validatePurchaseSchema.parse(req.body);
-    } catch (err) {
-      if (err instanceof z.ZodError) {
-        sendZodError(res, err, NO_PURCHASE);
-        return;
-      }
-      throw err;
-    }
+    const body = parseOrSend(res, validatePurchaseSchema, req.body, { extra: NO_PURCHASE });
+    if (!body) return;
 
     const { platform, receipt, userId, productId, type, appId } = body;
 
@@ -285,17 +276,10 @@ export function createPurchaseRouter(
    * Returns all purchases for a user, optionally filtered by productId.
    */
   router.get(ROUTES.PURCHASE_STATUS, async (req: Request, res: Response) => {
-    let query: z.infer<typeof purchaseStatusQuerySchema>;
-
-    try {
-      query = purchaseStatusQuerySchema.parse(req.query);
-    } catch (err) {
-      if (err instanceof z.ZodError) {
-        sendZodError(res, err, { purchases: [] });
-        return;
-      }
-      throw err;
-    }
+    const query = parseOrSend(res, purchaseStatusQuerySchema, req.query, {
+      extra: { purchases: [] },
+    });
+    if (!query) return;
 
     const { userId, productId } = query;
 

--- a/packages/server/src/routes/validate.ts
+++ b/packages/server/src/routes/validate.ts
@@ -7,7 +7,7 @@ import type { SubscriptionStore } from '../store.js';
 import { validateAppleReceipt } from '../providers/apple.js';
 import { validateGoogleReceipt, acknowledgeGoogleSubscription } from '../providers/google.js';
 import { log } from '../logger.js';
-import { sendError, sendZodError } from '../errors.js';
+import { sendError, parseOrSend } from '../errors.js';
 import { getAppRegistry, peekAppleBundleId } from '../apps.js';
 import { getTestOverride } from '../test-overrides.js';
 
@@ -30,21 +30,9 @@ export function createValidateRouter(
   const registry = getAppRegistry(config);
 
   router.post(ROUTES.VALIDATE, async (req: Request, res: Response) => {
-    let platform: string;
-    let receipt: string;
-    let userId: string;
-    let productId: string;
-    let appId: string | undefined;
-
-    try {
-      ({ platform, receipt, userId, productId, appId } = validateSchema.parse(req.body));
-    } catch (err) {
-      if (err instanceof z.ZodError) {
-        sendZodError(res, err, NO_SUB);
-        return;
-      }
-      throw err;
-    }
+    const body = parseOrSend(res, validateSchema, req.body, { extra: NO_SUB });
+    if (!body) return;
+    const { platform, receipt, userId, productId, appId } = body;
 
     try {
       let sub = null;


### PR DESCRIPTION
The D5 item from the #124 review.

## Information disclosure on 500

**Seven** handlers forwarded `(err as Error).message` straight to the caller — six
in `admin.ts` and one in `apple-offer.ts`. (The review said four; the actual count
was seven.) With a Postgres store that means the driver's message, which can carry
the host, port, role name, and fragments of the failing statement.

The offer route is the worst of them: it signs with the promotional-offer **private
key**, so a JOSE or crypto failure message was the last thing to hand back.

All seven now log the real error server-side through the configured logger and
return a generic message. `errorCode` is unchanged, so programmatic handling is
unaffected — it was always the machine-readable half of the contract.

Nothing asserted anything about a 500 body before, so nothing would have caught a
regression. `errors.test.ts` now drives a store that fails the way an outage does
and asserts the driver's text never appears in the response.

## Input validation

Three different shapes existed for the same job:

| Shape | Where | Problem |
|---|---|---|
| `try/catch` + `instanceof ZodError` + re-throw | validate, purchase, 4 admin sites, apple-offer | Correct, but five lines, repeated a dozen times |
| `try/catch {}` | entitlements, 6 admin sites | **Reports a schema bug as the caller's fault** |
| `safeParse` | metrics | Fine; has its own range validation, left alone |

The swallowing variant was the real defect: a bug inside a schema — a throwing
transform, a bad refinement — reached the caller as `400 bad input`, which is the
wrong status and hides the cause. A new internal `parseOrSend` keeps the correct
behaviour and makes it the short one.

**Each route keeps the error response it had.** Whether a route returns per-issue
zod detail or one fixed message is now an option name at the call site rather than a
different control-flow shape, and the route-specific fields on the error path
(`subscription: null`, `purchases: []`) are preserved — also now asserted, since
`error-codes.test.ts` only checked status and `errorCode`.

One dead branch removed rather than carried over: the test-override `PUT` had an
`else` sending a fixed message for non-`ZodError` failures, but `.parse()` only
throws `ZodError`, so it was unreachable.

Route handlers lost **~80 lines net** (79 insertions, 160 deletions).

## Verification

704 tests (was 689). `build`, `type-check`, `size` (35.1/36 KB), `docs:check`,
`validate-unity-packages.ps1`, and the dashboard build all pass.

Two mutations confirm the new tests are real guards: restoring one `err.message`
leak fails the disclosure test, and dropping the `extra` merge fails four
response-shape tests.

`e2e.yml` dispatched on this branch and passed (run 30204300235) — a real
Apple-signed JWS still validates through the rewritten parse path, and a tampered
one is still rejected with 422.

`parseOrSend` is internal: `errors.ts` is not re-exported from the package entry, so
there is no public API addition. Changeset is `patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)