### PR TITLE
fix(server): warn at startup when the Google RTDN route is left open

### DIFF
--- a/.changeset/loud-webhooks-warn.md
+++ b/.changeset/loud-webhooks-warn.md
@@ -1,0 +1,32 @@
+---
+'@onesub/server': patch
+---
+
+Warn at startup when the Google RTDN route is left open.
+
+`POST /onesub/webhook/google` verifies the Pub/Sub OIDC token only when a
+configured app declares `pushAudience`; with none declaring one, the verification
+step is skipped and the route accepts any well-formed notification body. Separately,
+when no app declares `google.packageName` the route runs in legacy open mode and
+serves notifications for any package. The route is mounted whether or not Google is
+configured at all, so an Apple-only deployment has both conditions.
+
+Neither is new, and `SECURITY.md` mentioned the `pushAudience` condition — but not
+its consequence, and nothing said so at runtime. The consequence is narrower than it
+first looks and worth stating precisely: the subscription paths re-fetch state from
+Google before writing, so a forged notification cannot fabricate an entitlement. The
+voided-purchase path does not re-fetch. It acts on the payload alone, setting a
+subscription to `canceled` by `purchaseToken` or deleting a one-time purchase row by
+`orderId`. So the exposure is entitlement *revocation* by a caller who knows or
+guesses one of those ids.
+
+`createOneSubMiddleware` now logs a warning through the configured logger for each
+condition. It warns rather than refusing, because rejecting would break deployments
+that legitimately front the route with their own Pub/Sub verification — changing that
+default is a breaking change and belongs in its own release. Gated on
+`NODE_ENV=production`, matching the existing mockMode guard: neither condition is
+meaningful locally, where no real notification arrives, and an unconditional warning
+would fire on nearly every test and drown itself out.
+
+`SECURITY.md` and `DEPLOYMENT.md` now state the consequence rather than only the
+condition.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -196,6 +196,14 @@ quota — and the two routes differ in whether you get it by default:
   notification can move subscription state. Configure them rather than reaching for
   a rate limit.
 
+  Note that the route is mounted whether or not Google is configured, and that a
+  server where no app declares `google.packageName` runs in open mode — it serves
+  notifications for any package. An Apple-only deployment therefore has an
+  unauthenticated `/onesub/webhook/google` whose voided-purchase path can still
+  delete a purchase row by `orderId`. As of `@onesub/server@0.21.2` the server warns
+  at startup for both conditions when `NODE_ENV=production`; block the path at your
+  proxy if the deployment does not serve Google Play.
+
 ### Limiting in Express
 
 `express-rate-limit` is not a onesub dependency; install it in the host. Register limiters **before**

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -36,7 +36,14 @@
 ### Webhook Endpoints
 - **Apple**: Only JWS-signed `signedPayload` accepted. The embedded `x5c` certificate chain is
   validated to the pinned Apple Root CA G3, then the leaf key verifies the payload signature
-- **Google**: When `pushAudience` is configured, `Authorization: Bearer` JWT is verified against Google JWKS with audience claim check
+- **Google**: When `pushAudience` is configured, `Authorization: Bearer` JWT is verified against
+  Google JWKS with audience claim check. **When no configured app sets it, the verification step is
+  skipped and the route accepts any well-formed notification body** — and the route is mounted whether
+  or not Google is configured at all. The subscription paths re-fetch state from Google before
+  writing, so a forged notification cannot fabricate an entitlement; the voided-purchase path acts on
+  the payload alone, so a caller who knows a `purchaseToken` or `orderId` can cancel a subscription or
+  delete a one-time purchase row. Configure `pushAudience` and `pushServiceAccountEmail`. As of
+  `@onesub/server@0.21.2` the server warns at startup when this applies and `NODE_ENV=production`
 
 ### Validate / Status Endpoints
 - Currently open by design (consumer adds their own auth middleware)

--- a/packages/server/.size-limit.cjs
+++ b/packages/server/.size-limit.cjs
@@ -24,17 +24,24 @@
 //
 // 2026-07-26: 34.17/34.55 KB after the metrics aggregation split and response
 // cache (`metrics-aggregate.ts`, `metrics-cache.ts`). Limit unchanged.
+//
+// 2026-07-26: raised 36 → 38 KB. Measured 35.12/35.47 KB after the
+// product-scoped purchase lookup, the `parseOrSend` consolidation (which cut
+// ~80 lines from the route handlers but adds a shared helper), and the Google
+// webhook startup warning. Cumulative growth this session: 32.78 → 35.47 KB,
+// each step recorded above. Raised because 0.53 KB of headroom means the next
+// unrelated commit fails this gate rather than the change that earned it.
 module.exports = [
   {
     name: 'esm bundle (gzipped)',
     path: 'dist/index.js',
-    limit: '36 KB',
+    limit: '38 KB',
     gzip: true,
   },
   {
     name: 'cjs bundle (gzipped)',
     path: 'dist/index.cjs',
-    limit: '36 KB',
+    limit: '38 KB',
     gzip: true,
   },
 ];

--- a/packages/server/src/__tests__/google-webhook-open-warning.test.ts
+++ b/packages/server/src/__tests__/google-webhook-open-warning.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Startup warning for the two conditions that leave the Google RTDN route open.
+ *
+ * `POST /onesub/webhook/google` verifies the Pub/Sub OIDC token only when an app
+ * declares `pushAudience`, and serves any `packageName` when none declares one.
+ * The route is mounted either way. Both behaviours are pre-existing and
+ * deliberate — a host may front the route with its own verification — so this
+ * warns instead of refusing, and these tests pin down that it says so exactly
+ * when it should and stays quiet otherwise.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { OneSubLogger, OneSubServerConfig } from '@onesub/shared';
+import { createOneSubMiddleware } from '../index.js';
+import { InMemorySubscriptionStore, InMemoryPurchaseStore } from '../store.js';
+
+/** Captures what the configured logger was told. */
+function recordingLogger() {
+  const warns: string[] = [];
+  const logger: OneSubLogger = {
+    info: () => {},
+    warn: (...args: unknown[]) => {
+      warns.push(args.map(String).join(' '));
+    },
+    error: () => {},
+  };
+  return { logger, warns, joined: () => warns.join('\n') };
+}
+
+function build(config: Partial<OneSubServerConfig>, logger: OneSubLogger) {
+  createOneSubMiddleware({
+    database: { url: '' },
+    logger,
+    store: new InMemorySubscriptionStore(),
+    purchaseStore: new InMemoryPurchaseStore(),
+    ...config,
+  });
+}
+
+const originalNodeEnv = process.env['NODE_ENV'];
+
+beforeEach(() => {
+  process.env['NODE_ENV'] = 'production';
+});
+
+afterEach(() => {
+  if (originalNodeEnv === undefined) delete process.env['NODE_ENV'];
+  else process.env['NODE_ENV'] = originalNodeEnv;
+  vi.restoreAllMocks();
+});
+
+describe('unauthenticated Google webhook', () => {
+  it('warns when a Google app has no pushAudience', () => {
+    const { logger, joined } = recordingLogger();
+    build({ google: { packageName: 'com.example.app', serviceAccountKey: '{}' } }, logger);
+
+    expect(joined()).toContain('accepts unauthenticated requests');
+    expect(joined()).toContain('google.pushAudience');
+  });
+
+  it('names the actual consequence, not just the setting', () => {
+    // The subscription paths re-fetch from Google, so the exposure is
+    // revocation rather than forged entitlement. The warning has to say which.
+    const { logger, joined } = recordingLogger();
+    build({ google: { packageName: 'com.example.app', serviceAccountKey: '{}' } }, logger);
+
+    expect(joined()).toMatch(/cancel a subscription or delete a one-time purchase/);
+  });
+
+  it('stays quiet once pushAudience is configured', () => {
+    const { logger, joined } = recordingLogger();
+    build(
+      {
+        google: {
+          packageName: 'com.example.app',
+          serviceAccountKey: '{}',
+          pushAudience: 'https://api.example.com/onesub/webhook/google',
+        },
+      },
+      logger,
+    );
+
+    expect(joined()).not.toContain('accepts unauthenticated requests');
+  });
+
+  it('is satisfied when any app in a multi-app config sets pushAudience', () => {
+    const { logger, joined } = recordingLogger();
+    build(
+      {
+        apps: [
+          {
+            id: 'a',
+            google: {
+              packageName: 'com.example.a',
+              pushAudience: 'https://api.example.com/onesub/webhook/google',
+            },
+          },
+          { id: 'b', google: { packageName: 'com.example.b' } },
+        ],
+      },
+      logger,
+    );
+
+    // One shared push endpoint across apps is the documented topology, so this
+    // must not nag when it is set on the app that actually receives the push.
+    expect(joined()).not.toContain('accepts unauthenticated requests');
+  });
+
+  it('does not warn about authentication when Google is not configured at all', () => {
+    // Nothing to authenticate against; the open-mode warning covers the fact
+    // that the route is mounted regardless.
+    const { logger, joined } = recordingLogger();
+    build({ apple: { bundleId: 'com.example.app' } }, logger);
+
+    expect(joined()).not.toContain('accepts unauthenticated requests');
+  });
+});
+
+describe('open mode (no packageName declared)', () => {
+  it('warns for an Apple-only deployment, which still mounts the route', () => {
+    const { logger, joined } = recordingLogger();
+    build({ apple: { bundleId: 'com.example.app' } }, logger);
+
+    expect(joined()).toContain('open mode');
+    expect(joined()).toContain('ANY package');
+  });
+
+  it('warns when google is configured without a packageName', () => {
+    const { logger, joined } = recordingLogger();
+    build({ google: { serviceAccountKey: '{}' } as OneSubServerConfig['google'] }, logger);
+    expect(joined()).toContain('open mode');
+  });
+
+  it('stays quiet once a packageName is declared', () => {
+    const { logger, joined } = recordingLogger();
+    build(
+      {
+        google: {
+          packageName: 'com.example.app',
+          serviceAccountKey: '{}',
+          pushAudience: 'https://api.example.com/onesub/webhook/google',
+        },
+      },
+      logger,
+    );
+
+    expect(joined()).not.toContain('open mode');
+  });
+});
+
+describe('outside production', () => {
+  it('says nothing, so it cannot drown itself out in dev and tests', () => {
+    // A missing pushAudience is normal locally — no real RTDN arrives — and an
+    // unconditional warning would fire on nearly every test in this repo.
+    delete process.env['NODE_ENV'];
+    const { logger, warns } = recordingLogger();
+    build({ apple: { bundleId: 'com.example.app' } }, logger);
+    expect(warns).toEqual([]);
+
+    process.env['NODE_ENV'] = 'development';
+    const dev = recordingLogger();
+    build({ google: { packageName: 'com.example.app' } }, dev.logger);
+    expect(dev.warns).toEqual([]);
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -6,6 +6,7 @@ import type { SubscriptionStore, PurchaseStore } from './store.js';
 import { createValidateRouter } from './routes/validate.js';
 import { createStatusRouter } from './routes/status.js';
 import { createWebhookRouter } from './routes/webhook.js';
+import { warnIfGoogleWebhookOpen } from './routes/webhook-google.js';
 import { createPurchaseRouter } from './routes/purchase.js';
 import { createAdminRouter } from './routes/admin.js';
 import { createEntitlementRouter } from './routes/entitlements.js';
@@ -94,6 +95,13 @@ export function createOneSubMiddleware(config: OneSubMiddlewareConfig): Router {
       '[onesub] apple.mockMode / google.mockMode cannot be enabled when NODE_ENV=production — these modes accept any receipt as valid.',
     );
   }
+
+  // Google's webhook only verifies the Pub/Sub token when an app declares a
+  // pushAudience, and serves any packageName when none declares one. Both are
+  // deliberate (a host may front the route with its own verification), so this
+  // warns rather than refusing — but silently accepting unauthenticated
+  // state-changing requests in production is worth saying out loud.
+  warnIfGoogleWebhookOpen(config);
 
   const store: SubscriptionStore = config.store ?? new InMemorySubscriptionStore();
   const purchaseStore: PurchaseStore = config.purchaseStore ?? new InMemoryPurchaseStore();

--- a/packages/server/src/routes/webhook-google.ts
+++ b/packages/server/src/routes/webhook-google.ts
@@ -96,6 +96,52 @@ const GOOGLE_FAILURE_MESSAGES: Record<GoogleWebhookWork['kind'], { logPrefix: st
 };
 
 /**
+ * Startup check for the two conditions that leave `POST /onesub/webhook/google`
+ * open. Called once from `createOneSubMiddleware`; warns rather than throws
+ * because rejecting would break deployments that front the route with their own
+ * Pub/Sub verification.
+ *
+ * Gated on `NODE_ENV=production` for the same reason the mockMode guard is:
+ * neither condition is meaningful locally, where no real RTDN arrives, and
+ * warning unconditionally would fire on nearly every test and drown itself out.
+ *
+ * Why it matters. The subscription paths re-fetch state from Google before
+ * writing, so a forged notification cannot fabricate an entitlement. The voided
+ * path does not: it acts on the payload alone, setting a subscription to
+ * `canceled` by `purchaseToken` or deleting a one-time purchase row by
+ * `orderId`. So the exposure is entitlement *revocation* for a caller who knows
+ * or guesses one of those ids — not free entitlement.
+ */
+export function warnIfGoogleWebhookOpen(config: OneSubServerConfig): void {
+  if (process.env['NODE_ENV'] !== 'production') return;
+
+  const apps = getAppRegistry(config).apps;
+  const googleApps = apps.map((a) => a.google).filter((g): g is NonNullable<typeof g> => !!g);
+
+  // Authentication is skipped entirely when no app declares a pushAudience —
+  // see handleGoogleWebhook, which only verifies when it has one to verify.
+  if (googleApps.length > 0 && !googleApps.some((g) => g.pushAudience)) {
+    log.warn(
+      '[onesub] SECURITY: POST /onesub/webhook/google accepts unauthenticated requests — ' +
+        'no configured app sets google.pushAudience, so the Pub/Sub OIDC token is never verified. ' +
+        'A caller who knows a purchaseToken or orderId can cancel a subscription or delete a ' +
+        'one-time purchase. Set google.pushAudience (and google.pushServiceAccountEmail).',
+    );
+  }
+
+  // Open mode: any packageName is served, so a notification does not even have
+  // to name an app this server knows.
+  if (!apps.some((a) => a.google?.packageName)) {
+    log.warn(
+      '[onesub] POST /onesub/webhook/google is in open mode — no configured app declares ' +
+        'google.packageName, so notifications for ANY package are accepted. The route is mounted ' +
+        'whether or not Google is configured; set google.packageName, or block the path at your ' +
+        'proxy if this deployment does not serve Google Play.',
+    );
+  }
+}
+
+/**
  * Resolves an RTDN's package to an app.
  *
  * When no configured app declares a packageName the instance is in legacy "open


### PR DESCRIPTION
Found while writing the request-limits docs in #128, which documented the condition
but could not make it visible at runtime.

## The two conditions

`POST /onesub/webhook/google` is left open by two independent, pre-existing
defaults:

1. **No authentication** — the Pub/Sub OIDC token is verified only when a configured
   app declares `pushAudience`. `handleGoogleWebhook` collects the configured push
   identities and skips the whole auth block when there are none.
2. **Open mode** — when no app declares `google.packageName`, `googleResolver` marks
   the instance unrestricted and serves notifications for *any* package.

The route is mounted whether or not Google is configured at all, so an **Apple-only
deployment has both**.

## What the exposure actually is

Worth stating precisely rather than as "forged notifications move state", because
the two write paths differ:

- The subscription paths re-fetch from Google via `validateGoogleReceipt` before
  writing. A forged notification **cannot fabricate an entitlement**.
- The **voided-purchase path does not re-fetch.** It acts on the payload alone —
  setting a subscription to `canceled` by `purchaseToken`, or deleting a one-time
  purchase row by `orderId`.

So the exposure is entitlement **revocation** by a caller who knows or guesses one
of those ids, not free entitlement.

## What this PR does

`createOneSubMiddleware` warns through the configured logger for each condition,
naming that consequence rather than only the missing setting.

It **warns rather than refusing.** Rejecting would break deployments that
legitimately front the route with their own Pub/Sub verification — that is a
breaking change and belongs in its own release with a `MIGRATION.md` note. See
*Follow-up* below.

Gated on `NODE_ENV=production`, matching the existing mockMode guard: neither
condition is meaningful locally, where no real notification arrives, and an
unconditional warning would fire on nearly every test in this repo and drown itself
out — the same failure mode as the `ioredis-mock` noise cleaned up in #124. A test
asserts the silence outside production so that stays true.

`SECURITY.md` and `DEPLOYMENT.md` now state the consequence, not just the condition.

## Verification

713 tests (was 704). `build`, `type-check`, `size`, `docs:check`,
`validate-unity-packages.ps1`, and the dashboard build pass.

Two mutations confirm the tests are real guards: removing the `pushAudience` check
fails 2, and removing the production gate fails the silence test.

`e2e.yml` passed on this branch (run 30204822363). The Google job is the relevant
one: it configures `pushAudience`, so it exercises the **authenticated** path and
confirms this change did not disturb it — real OIDC token 200, wrong audience 401,
missing `Authorization` 401.

Also raises the bundle ceiling 36 → 38 KB with the measurement recorded (35.12/35.47
KB). At 0.53 KB of headroom the next unrelated commit would have failed that gate
instead of the change that earned it.

## Follow-up, not included

The fail-open defaults themselves are unchanged. Two candidates, both breaking:

- Refuse to start when a Google app has no `pushAudience` in production, mirroring
  how mockMode throws.
- Skip mounting `/onesub/webhook/google` when no Google config exists at all, which
  removes the Apple-only exposure entirely — note this needs handling in
  `openapi.test.ts`, which asserts mounted routes match the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)