### PR TITLE
fix(server): mount the Google webhook only when the config serves Google Play

### DIFF
--- a/.changeset/quiet-google-route.md
+++ b/.changeset/quiet-google-route.md
@@ -1,0 +1,27 @@
+---
+'@onesub/server': minor
+---
+
+Mount `POST /onesub/webhook/google` only when the config serves Google Play.
+
+The route was registered unconditionally. It is now registered only when there is a
+top-level `google` block or a `google` block on an `apps[]` entry.
+
+Unlike the Apple webhook, this route does not authenticate unconditionally — the
+Pub/Sub OIDC token is verified only when an app declares a `pushAudience` — and its
+`voidedPurchaseNotification` branch needs no Google credentials to run: it cancels a
+subscription by `purchaseToken`, or deletes a one-time purchase row by `orderId`,
+straight from the payload. An Apple-only deployment therefore exposed an
+unauthenticated endpoint that could revoke entitlement, with no Google purchases for
+it to be about. It now returns 404 there.
+
+The Apple webhook stays unconditional: it verifies the `signedPayload` JWS against
+the bundled Apple roots on every request regardless of config, so it is not open in
+the same way. A test asserts that asymmetry rather than leaving it to be inferred.
+
+If you serve Google Play nothing changes. If you do not, drop any monitoring that
+expects a 2xx/4xx on that path — see `docs/MIGRATION.md`.
+
+The startup warnings added in 0.21.2 now stay silent for a deployment that does not
+serve Google, since there is no longer an exposed route to warn about. Mounting and
+warning share one predicate so they cannot disagree.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -196,13 +196,16 @@ quota — and the two routes differ in whether you get it by default:
   notification can move subscription state. Configure them rather than reaching for
   a rate limit.
 
-  Note that the route is mounted whether or not Google is configured, and that a
-  server where no app declares `google.packageName` runs in open mode — it serves
-  notifications for any package. An Apple-only deployment therefore has an
-  unauthenticated `/onesub/webhook/google` whose voided-purchase path can still
-  delete a purchase row by `orderId`. As of `@onesub/server@0.21.2` the server warns
-  at startup for both conditions when `NODE_ENV=production`; block the path at your
-  proxy if the deployment does not serve Google Play.
+  Note also that a server where no app declares `google.packageName` runs in open
+  mode — it serves notifications for any package. As of `@onesub/server@0.21.2` the
+  server warns at startup for both conditions when `NODE_ENV=production`.
+
+  As of `0.22.0` the route is mounted only when the config serves Google Play — a
+  top-level `google` block, or a `google` block on any `apps[]` entry. An Apple-only
+  deployment gets a 404 there instead of an unauthenticated endpoint whose
+  voided-purchase path could delete a purchase row by `orderId`. If you serve Google
+  Play, nothing changes; if you do not, you no longer need to block the path at your
+  proxy.
 
 ### Limiting in Express
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,6 +1,35 @@
 # Migration Guide
 
-Upgrade notes for breaking releases of `@onesub/server`. Minor/patch releases within the same major are drop-in.
+Upgrade notes for releases of `@onesub/server` that need one. While the package is pre-1.0, a minor release may narrow behaviour — anything that is not drop-in has an entry here, so check this file for the versions you are skipping.
+
+---
+
+## `@onesub/server` 0.21.x → 0.22.0
+
+### `POST /onesub/webhook/google` is mounted only when the config serves Google Play
+
+The route used to be mounted unconditionally. It is now registered only when the
+config has a top-level `google` block, or a `google` block on any `apps[]` entry.
+
+**Why.** Unlike the Apple webhook, this route does not authenticate
+unconditionally — the Pub/Sub OIDC token is verified only when an app declares a
+`pushAudience` — and its `voidedPurchaseNotification` branch needs no Google
+credentials to run: it cancels a subscription by `purchaseToken`, or deletes a
+one-time purchase row by `orderId`, straight from the payload. An Apple-only
+deployment therefore exposed an unauthenticated endpoint that could revoke
+entitlement, with no Google purchases for it to be about.
+
+**Impact.** If you serve Google Play, nothing changes. If you do not, requests to
+that path now get `404` instead of being processed, and you no longer need to block
+it at your proxy. Drop any monitoring that expects a 2xx/4xx there.
+
+The Apple webhook remains unconditional: it verifies the `signedPayload` JWS
+against the bundled Apple roots on every request regardless of config, so it is not
+open in the same way.
+
+Configuring Google without a `packageName` still mounts the route and still runs it
+in legacy open mode (any package accepted). Since `0.21.2` the server warns at
+startup about that and about a missing `pushAudience` when `NODE_ENV=production`.
 
 ---
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -38,12 +38,13 @@
   validated to the pinned Apple Root CA G3, then the leaf key verifies the payload signature
 - **Google**: When `pushAudience` is configured, `Authorization: Bearer` JWT is verified against
   Google JWKS with audience claim check. **When no configured app sets it, the verification step is
-  skipped and the route accepts any well-formed notification body** — and the route is mounted whether
-  or not Google is configured at all. The subscription paths re-fetch state from Google before
-  writing, so a forged notification cannot fabricate an entitlement; the voided-purchase path acts on
-  the payload alone, so a caller who knows a `purchaseToken` or `orderId` can cancel a subscription or
-  delete a one-time purchase row. Configure `pushAudience` and `pushServiceAccountEmail`. As of
-  `@onesub/server@0.21.2` the server warns at startup when this applies and `NODE_ENV=production`
+  skipped and the route accepts any well-formed notification body**. The subscription paths re-fetch
+  state from Google before writing, so a forged notification cannot fabricate an entitlement; the
+  voided-purchase path acts on the payload alone, so a caller who knows a `purchaseToken` or `orderId`
+  can cancel a subscription or delete a one-time purchase row. Configure `pushAudience` and
+  `pushServiceAccountEmail`. As of `@onesub/server@0.21.2` the server warns at startup when this
+  applies and `NODE_ENV=production`; as of `0.22.0` the route is mounted only when the config serves
+  Google Play at all, so an Apple-only deployment no longer exposes it
 
 ### Validate / Status Endpoints
 - Currently open by design (consumer adds their own auth middleware)

--- a/packages/server/src/__tests__/error-codes.test.ts
+++ b/packages/server/src/__tests__/error-codes.test.ts
@@ -137,9 +137,25 @@ describe('server error codes', () => {
   });
 
   // ── /onesub/webhook/google ───────────────────────────────────
+  // Needs its own app: the shared config above has no `google` block on purpose
+  // (the GOOGLE_CONFIG_MISSING case depends on it), and the route is only mounted
+  // for deployments that serve Google Play.
   describe('POST /onesub/webhook/google', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let googleApp: any;
+
+    beforeEach(() => {
+      googleApp = express();
+      googleApp.use(createOneSubMiddleware({
+        database: { url: '' },
+        google: { packageName: 'com.test.google' },
+        store: new InMemorySubscriptionStore(),
+        purchaseStore: new InMemoryPurchaseStore(),
+      }));
+    });
+
     it('missing message.data → errorCode: MISSING_MESSAGE_DATA', async () => {
-      const res = await request(app).post('/onesub/webhook/google').send({});
+      const res = await request(googleApp).post('/onesub/webhook/google').send({});
       expect(res.status).toBe(400);
       expect(res.body.errorCode).toBe(ONESUB_ERROR_CODE.MISSING_MESSAGE_DATA);
     });

--- a/packages/server/src/__tests__/google-webhook-open-warning.test.ts
+++ b/packages/server/src/__tests__/google-webhook-open-warning.test.ts
@@ -117,12 +117,14 @@ describe('unauthenticated Google webhook', () => {
 });
 
 describe('open mode (no packageName declared)', () => {
-  it('warns for an Apple-only deployment, which still mounts the route', () => {
-    const { logger, joined } = recordingLogger();
+  it('says nothing for an Apple-only deployment, which does not mount the route', () => {
+    // The route is no longer mounted without a Google config, so there is no
+    // open-mode exposure to report. `webhook-google-mount.test.ts` asserts the
+    // mounting side of this; here the point is that the two agree.
+    const { logger, warns } = recordingLogger();
     build({ apple: { bundleId: 'com.example.app' } }, logger);
 
-    expect(joined()).toContain('open mode');
-    expect(joined()).toContain('ANY package');
+    expect(warns).toEqual([]);
   });
 
   it('warns when google is configured without a packageName', () => {

--- a/packages/server/src/__tests__/webhook-google-mount.test.ts
+++ b/packages/server/src/__tests__/webhook-google-mount.test.ts
@@ -1,0 +1,151 @@
+/**
+ * `POST /onesub/webhook/google` is mounted only for deployments that serve
+ * Google Play.
+ *
+ * Why it is conditional at all: unlike Apple's route, it does not authenticate
+ * unconditionally — the Pub/Sub OIDC token is verified only when an app declares
+ * a `pushAudience` — and its voided-purchase branch needs no Google credentials
+ * to run. It cancels a subscription by `purchaseToken`, or deletes a purchase row
+ * by `orderId`, straight from the payload. So an Apple-only deployment used to
+ * expose an unauthenticated endpoint that could revoke entitlement, with no
+ * Google purchases for it to be about.
+ *
+ * Apple's route stays unconditional, and this file asserts that too: it verifies
+ * the `signedPayload` JWS against the bundled Apple roots on every request
+ * regardless of config, so it is not open in the same way.
+ */
+
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import type { OneSubServerConfig } from '@onesub/shared';
+import { ONESUB_ERROR_CODE } from '@onesub/shared';
+import { createOneSubMiddleware } from '../index.js';
+import { InMemorySubscriptionStore, InMemoryPurchaseStore } from '../store.js';
+
+function app(config: Partial<OneSubServerConfig>) {
+  const server = express();
+  server.use(
+    createOneSubMiddleware({
+      database: { url: '' },
+      store: new InMemorySubscriptionStore(),
+      purchaseStore: new InMemoryPurchaseStore(),
+      ...config,
+    }),
+  );
+  return server;
+}
+
+/** Reaching validation (400) proves the route is mounted; 404 proves it is not. */
+const probe = (server: express.Express) =>
+  request(server).post('/onesub/webhook/google').send({});
+
+describe('mounted when the deployment serves Google', () => {
+  it('top-level google config mounts it', async () => {
+    const res = await probe(app({ google: { packageName: 'com.example.app' } }));
+    expect(res.status).toBe(400);
+    expect(res.body.errorCode).toBe(ONESUB_ERROR_CODE.MISSING_MESSAGE_DATA);
+  });
+
+  it('a google block on any apps[] entry mounts it', async () => {
+    const res = await probe(
+      app({
+        apple: { bundleId: 'com.example.app' },
+        apps: [
+          { id: 'ios-only', apple: { bundleId: 'com.example.ios' } },
+          { id: 'android', google: { packageName: 'com.example.android' } },
+        ],
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.errorCode).toBe(ONESUB_ERROR_CODE.MISSING_MESSAGE_DATA);
+  });
+
+  it('mounts even without a packageName, since google is still configured', async () => {
+    const res = await probe(app({ google: {} as OneSubServerConfig['google'] }));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('not mounted when the deployment does not serve Google', () => {
+  it('an Apple-only deployment returns 404', async () => {
+    const res = await probe(app({ apple: { bundleId: 'com.example.app' } }));
+    expect(res.status).toBe(404);
+  });
+
+  it('a config with no providers at all returns 404', async () => {
+    const res = await probe(app({}));
+    expect(res.status).toBe(404);
+  });
+
+  it('an apps[] list with no google block returns 404', async () => {
+    const res = await probe(
+      app({ apps: [{ id: 'a', apple: { bundleId: 'com.example.a' } }] }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('the voided-purchase path is unreachable, not merely unauthenticated', async () => {
+    // This is the behaviour the change exists for. `voidedPurchaseNotification`
+    // deletes by orderId with no Google credentials and no token verification, so
+    // on an Apple-only deployment it must not be reachable at all.
+    const purchaseStore = new InMemoryPurchaseStore();
+    await purchaseStore.savePurchase({
+      transactionId: 'apple-tx-1',
+      userId: 'alice',
+      productId: 'lifetime_pass',
+      platform: 'apple',
+      type: 'non_consumable',
+      quantity: 1,
+      purchasedAt: '2026-04-01T00:00:00.000Z',
+    });
+
+    const server = express();
+    server.use(
+      createOneSubMiddleware({
+        database: { url: '' },
+        apple: { bundleId: 'com.example.app' },
+        store: new InMemorySubscriptionStore(),
+        purchaseStore,
+      }),
+    );
+
+    const voided = Buffer.from(
+      JSON.stringify({
+        voidedPurchaseNotification: {
+          orderId: 'apple-tx-1',
+          purchaseToken: 'apple-tx-1',
+          productType: 2,
+          refundType: 1,
+        },
+        packageName: 'com.anything.at.all',
+        eventTimeMillis: '1',
+        version: '1.0',
+      }),
+    ).toString('base64');
+
+    const res = await request(server)
+      .post('/onesub/webhook/google')
+      .send({ message: { data: voided, messageId: 'm1' }, subscription: 's' });
+
+    expect(res.status).toBe(404);
+    // The purchase survives — the row was never reachable.
+    expect(await purchaseStore.getPurchaseByTransactionId('apple-tx-1')).not.toBeNull();
+  });
+});
+
+describe('the Apple webhook stays unconditional', () => {
+  it('is mounted even with no apple config', async () => {
+    const res = await request(app({})).post('/onesub/webhook/apple').send({});
+    expect(res.status).toBe(400);
+    expect(res.body.errorCode).toBe(ONESUB_ERROR_CODE.MISSING_SIGNED_PAYLOAD);
+  });
+
+  it('rejects an unsigned payload rather than acting on it', async () => {
+    const res = await request(app({ apple: { bundleId: 'com.example.app' } }))
+      .post('/onesub/webhook/apple')
+      .send({ signedPayload: 'not-a-jws' });
+    expect(res.status).toBe(400);
+    expect(res.body.errorCode).toBe(ONESUB_ERROR_CODE.INVALID_SIGNED_PAYLOAD);
+  });
+});

--- a/packages/server/src/routes/webhook-google.ts
+++ b/packages/server/src/routes/webhook-google.ts
@@ -96,6 +96,20 @@ const GOOGLE_FAILURE_MESSAGES: Record<GoogleWebhookWork['kind'], { logPrefix: st
 };
 
 /**
+ * Whether this config serves Google Play at all — top-level `google`, or any
+ * entry in `apps[]` with a `google` block.
+ *
+ * Single source of truth for two decisions that have to agree: whether
+ * `createWebhookRouter` mounts `POST /onesub/webhook/google`, and whether
+ * `warnIfGoogleWebhookOpen` has anything to warn about. If they disagreed, a
+ * deployment would either be warned about a route it does not expose, or expose
+ * one nothing warned about.
+ */
+export function servesGoogle(config: OneSubServerConfig): boolean {
+  return getAppRegistry(config).apps.some((app) => !!app.google);
+}
+
+/**
  * Startup check for the two conditions that leave `POST /onesub/webhook/google`
  * open. Called once from `createOneSubMiddleware`; warns rather than throws
  * because rejecting would break deployments that front the route with their own
@@ -114,13 +128,15 @@ const GOOGLE_FAILURE_MESSAGES: Record<GoogleWebhookWork['kind'], { logPrefix: st
  */
 export function warnIfGoogleWebhookOpen(config: OneSubServerConfig): void {
   if (process.env['NODE_ENV'] !== 'production') return;
+  // Nothing to warn about when the route is not mounted at all.
+  if (!servesGoogle(config)) return;
 
   const apps = getAppRegistry(config).apps;
   const googleApps = apps.map((a) => a.google).filter((g): g is NonNullable<typeof g> => !!g);
 
   // Authentication is skipped entirely when no app declares a pushAudience —
   // see handleGoogleWebhook, which only verifies when it has one to verify.
-  if (googleApps.length > 0 && !googleApps.some((g) => g.pushAudience)) {
+  if (!googleApps.some((g) => g.pushAudience)) {
     log.warn(
       '[onesub] SECURITY: POST /onesub/webhook/google accepts unauthenticated requests — ' +
         'no configured app sets google.pushAudience, so the Pub/Sub OIDC token is never verified. ' +
@@ -134,9 +150,8 @@ export function warnIfGoogleWebhookOpen(config: OneSubServerConfig): void {
   if (!apps.some((a) => a.google?.packageName)) {
     log.warn(
       '[onesub] POST /onesub/webhook/google is in open mode — no configured app declares ' +
-        'google.packageName, so notifications for ANY package are accepted. The route is mounted ' +
-        'whether or not Google is configured; set google.packageName, or block the path at your ' +
-        'proxy if this deployment does not serve Google Play.',
+        'google.packageName, so notifications for ANY package are accepted. ' +
+        'Set google.packageName on each app you serve.',
     );
   }
 }

--- a/packages/server/src/routes/webhook.ts
+++ b/packages/server/src/routes/webhook.ts
@@ -7,7 +7,7 @@ import type { WebhookEventStore } from '../webhook-events.js';
 import type { WebhookQueue } from '../webhook-queue.js';
 import { handleAppleWebhook, processAppleNotification } from './webhook-apple.js';
 import type { AppleWebhookWork } from './webhook-apple.js';
-import { handleGoogleWebhook, processGoogleNotification } from './webhook-google.js';
+import { handleGoogleWebhook, processGoogleNotification, servesGoogle } from './webhook-google.js';
 import type { GoogleWebhookWork } from './webhook-google.js';
 
 /**
@@ -50,9 +50,23 @@ export function createWebhookRouter(
     handleAppleWebhook(req, res, config, store, purchaseStore, webhookEventStore, webhookQueue),
   );
 
-  router.post(ROUTES.WEBHOOK_GOOGLE, (req: Request, res: Response) =>
-    handleGoogleWebhook(req, res, config, store, purchaseStore, webhookEventStore, webhookQueue),
-  );
+  // Google's route is mounted only for deployments that actually serve Google
+  // Play. Unlike Apple's, it does not authenticate unconditionally — the Pub/Sub
+  // token is verified only when an app declares a `pushAudience` — and its
+  // voided-purchase branch needs no Google credentials to run: it cancels a
+  // subscription by `purchaseToken` or deletes a purchase row by `orderId`
+  // straight from the payload. An Apple-only deployment therefore exposed an
+  // unauthenticated endpoint that could revoke entitlement, for no benefit,
+  // since it has no Google purchases to receive notifications about.
+  //
+  // Apple's route stays unconditional: it verifies the `signedPayload` JWS
+  // against the bundled Apple roots on every request regardless of config, so it
+  // is not open in the same way.
+  if (servesGoogle(config)) {
+    router.post(ROUTES.WEBHOOK_GOOGLE, (req: Request, res: Response) =>
+      handleGoogleWebhook(req, res, config, store, purchaseStore, webhookEventStore, webhookQueue),
+    );
+  }
 
   return router;
 }


### PR DESCRIPTION
The first of the two follow-ups proposed in #131.

## What changed

`POST /onesub/webhook/google` was registered unconditionally. It is now registered
only when the config has a top-level `google` block, or a `google` block on an
`apps[]` entry.

## Why this route and not Apple's

The asymmetry is the whole justification, so it is now asserted by a test rather
than left to be inferred:

- **Apple's** webhook verifies the `signedPayload` JWS against the bundled Apple
  roots on **every** request, regardless of config. Not open.
- **Google's** verifies the Pub/Sub OIDC token **only when** an app declares a
  `pushAudience`. And its `voidedPurchaseNotification` branch needs no Google
  credentials at all: it cancels a subscription by `purchaseToken`, or deletes a
  one-time purchase row by `orderId`, straight from the payload.

So an Apple-only deployment exposed an unauthenticated endpoint that could **revoke
entitlement**, with no Google purchases for it to be about. One test now stores an
Apple non-consumable, posts a forged `voidedPurchaseNotification` naming its
`orderId`, and asserts 404 *and* that the row survives — the path is unreachable,
not merely unauthenticated.

## Consistency with the 0.21.2 warnings

Mounting and the startup warnings now share one `servesGoogle` predicate. If they
disagreed, a deployment would either be warned about a route it does not expose or
expose one nothing warned about — so the open-mode warning is now silent for a
deployment that does not serve Google.

## Two existing tests updated, not deleted

Both asserted the old premise:

- `error-codes.test.ts` probed the Google webhook through a shared config with no
  provider blocks — that config deliberately omits `google` so its
  `GOOGLE_CONFIG_MISSING` case works, so adding one there would have broken a
  different test. That describe now builds its own app.
- The open-mode warning test for an Apple-only deployment now asserts silence.

## Verification

722 tests (was 713). `build`, `type-check`, `size` (35.44/38 KB), `docs:check`,
`validate-unity-packages.ps1`, and the dashboard build pass. The OpenAPI parity test
passes unchanged — its fixture configures Google precisely so every conditional
router mounts.

Reverting the condition to an unconditional mount fails 4 of the new tests.

`e2e.yml` passed on this branch (run 30205767903). The Google job is the one that
matters: it configures `pushAudience`, so it confirms a real Google deployment still
mounts and still authenticates — real OIDC token 200, wrong audience 401, missing
`Authorization` 401.

## Release

`minor`, not `major`: the package is pre-1.0 and no deployment that serves Google
Play sees any change. `docs/MIGRATION.md` records the impact for hosts that do not —
and its preamble is corrected, since it claimed every minor release is drop-in.

The second follow-up from #131 (refusing to start without `pushAudience` in
production) is **not** included; that one does affect working Google deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)