### PR TITLE
test(server): run the Postgres stores against a real database in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,31 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+
+    # The Postgres stores are what production runs on, and until this service
+    # existed nothing executed their SQL: `schema.test.ts` compares the embedded
+    # DDL to sql/schema.sql as text, and every other suite uses the in-memory
+    # store. `postgres-store.test.ts` skips itself when DATABASE_URL is unset, so
+    # a local `npm test` without a database still passes — which means this
+    # service is the only thing that runs those tests. Removing it silently drops
+    # ~28 tests rather than failing.
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: onesub_test
+        ports:
+          - 5432:5432
+        # Without a health check the steps can start before the server accepts
+        # connections, which shows up as a flaky ECONNREFUSED rather than a
+        # failure anyone can read.
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
@@ -25,6 +50,8 @@ jobs:
         run: npm run build  # tsc per-workspace — fails on type errors
       - name: Test
         run: npm test
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/onesub_test
       - name: Validate Unity UPM boundaries
         shell: pwsh
         run: ./validate-unity-packages.ps1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,9 +282,25 @@ Reconstructing this from the workflows is slow, so it is stated once here. `.git
 
 1. `npm ci`
 2. `npm run build`  (this is the real type-error gate; CI never runs root `npm run type-check`)
-3. `npm test`
+3. `npm test`, with `DATABASE_URL` pointing at a `postgres:17-alpine` service container
 4. `pwsh ./validate-unity-packages.ps1`
 5. `npm run size -w @onesub/server`
+
+**The Postgres store tests only run in CI unless you give them a database.**
+`packages/server/src/__tests__/postgres-store.test.ts` skips itself when
+`DATABASE_URL` is unset, so a green local `npm test` says nothing about the SQL. To
+run them, point `DATABASE_URL` at a throwaway database — the tests `TRUNCATE` both
+onesub tables between cases, so do not aim it at anything you care about:
+
+```bash
+docker run -d --rm -p 5432:5432 -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=onesub_test postgres:17-alpine
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/onesub_test npm test -- packages/server/src/__tests__/postgres-store.test.ts
+```
+
+That file is the only thing that executes the Postgres SQL; `schema.test.ts`
+compares the embedded DDL to `sql/schema.sql` as text and proves nothing about
+whether either works. Any change under `packages/server/src/stores/postgres.ts`
+wants a run against a real database before it is trusted.
 
 Plus a **separate `dashboard` job** — `npm run build -w @onesub/shared` → `type-check` → `build` for
 `@onesub/dashboard`. CI can therefore be red for a dashboard break while the entire root build is
@@ -327,6 +343,7 @@ If a change needs real sandbox coverage, say so in the PR description and ask a 
    | `packages/server/src` | `npm run build -w @onesub/server`, `npm test`, `npm run size -w @onesub/server` |
    | A route or the OpenAPI spec | the above plus `npm test -- packages/server/src/__tests__/openapi.test.ts` |
    | A store or SQL schema | the above plus `npm test -- packages/server/src/__tests__/schema.test.ts` |
+   | `stores/postgres.ts` or `sql/schema.sql` | the above plus `postgres-store.test.ts` **with a real `DATABASE_URL`** — it skips silently without one |
    | `packages/dashboard` | the three dashboard commands under Commands |
    | `packages/unity*` | `pwsh ./validate-unity-packages.ps1` |
    | Any `.md` | `npm run docs:check` |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -35,6 +35,36 @@ behavior, and their message reads as a puzzle unless you know that:
 The schema test strips SQL comments, collapses whitespace, and does a normalized substring check — it
 also strips `\r` first, so a CRLF checkout does not break it.
 
+Note what the schema test does **not** prove: it compares two pieces of SQL to each other as text, so
+it fails when they drift apart but passes when both are wrong. Executing them is
+`postgres-store.test.ts` below.
+
+### Postgres store tests
+
+`packages/server/src/__tests__/postgres-store.test.ts` runs the real SQL against a real database. It
+is the only suite that does — everything else uses the in-memory store — and it **skips itself when
+`DATABASE_URL` is unset**, so a green `npm test` on a machine without a database says nothing about
+`stores/postgres.ts`.
+
+CI supplies a `postgres:17-alpine` service container, so these tests always run there. To run them
+locally, point `DATABASE_URL` at a throwaway database. The tests `TRUNCATE onesub_subscriptions,
+onesub_purchases` between cases, so do not aim it at anything you care about:
+
+```bash
+docker run -d --rm -p 5432:5432 \
+  -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=onesub_test \
+  postgres:17-alpine
+
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/onesub_test \
+  npm test -- packages/server/src/__tests__/postgres-store.test.ts
+```
+
+Beyond CRUD, it covers the things only a database can answer: that `initSchema()` is safe to re-run
+against an already-migrated database, that the shipped `sql/schema.sql` produces a schema the stores
+can actually drive, that the partial unique index really blocks a second non-consumable row for one
+user and product, and that `listFiltered` combines filters as AND while reporting the unpaged total
+next to a limited page.
+
 ## Build and Type Checks
 
 ```bash
@@ -229,10 +259,15 @@ npm run build -w @onesub/dashboard
 npm run docs:check
 ```
 
-This is a superset of CI, not a mirror of it. CI's `ci.yml` job runs `npm ci` → `build` → `test` →
-the Unity validator → the size check; it never runs root `npm run type-check`, because `build` is the
-type gate. `docs:check` runs in its own path-filtered workflow, and CodeQL (`security-extended`) runs
-separately and can fail a PR.
+This is a superset of CI in one way and a subset in another. It is a superset because CI never runs
+root `npm run type-check` — `build` is the type gate. It is a **subset** because CI runs `npm test`
+with `DATABASE_URL` pointing at a Postgres service container, so the Postgres store tests run there
+and skip in the list above. Add a `DATABASE_URL` (see *Postgres store tests*) when your change touches
+`stores/postgres.ts` or `sql/schema.sql`.
+
+Otherwise CI's `ci.yml` job runs `npm ci` → `build` → `test` → the Unity validator → the size check.
+`docs:check` runs in its own path-filtered workflow, and CodeQL (`security-extended`) runs separately
+and can fail a PR.
 
 Use focused checks for package-local changes. Documentation-only changes normally need only
 `npm run docs:check` — `ci.yml` sets `paths-ignore: '**/*.md'`, so a Markdown-only PR runs no build

--- a/package-lock.json
+++ b/package-lock.json
@@ -7350,6 +7350,49 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -7358,6 +7401,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
@@ -7382,6 +7435,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
       }
     },
     "node_modules/picocolors": {
@@ -8524,6 +8587,16 @@
         "signal-exit": "^4.0.1"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
@@ -9562,11 +9635,11 @@
     },
     "packages/cli": {
       "name": "@onesub/cli",
-      "version": "0.1.29",
+      "version": "0.1.34",
       "license": "MIT",
       "dependencies": {
-        "@onesub/server": "0.19.0",
-        "@onesub/shared": "0.14.0",
+        "@onesub/server": "0.22.0",
+        "@onesub/shared": "0.15.0",
         "express": "^5.2.1"
       },
       "bin": {
@@ -9599,9 +9672,9 @@
     },
     "packages/dashboard": {
       "name": "@onesub/dashboard",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "dependencies": {
-        "@onesub/shared": "0.14.0",
+        "@onesub/shared": "0.15.0",
         "next": "^16.2.10",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -9639,12 +9712,12 @@
     },
     "packages/mcp-server": {
       "name": "@onesub/mcp-server",
-      "version": "0.4.9",
+      "version": "0.4.10",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "@onesub/providers": "*",
-        "@onesub/shared": "0.14.0",
+        "@onesub/shared": "0.15.0",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -9706,10 +9779,10 @@
     },
     "packages/sdk": {
       "name": "@jeonghwanko/onesub-sdk",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "license": "MIT",
       "dependencies": {
-        "@onesub/shared": "0.14.0"
+        "@onesub/shared": "0.15.0"
       },
       "devDependencies": {
         "@types/react": "^19.2.17",
@@ -9732,10 +9805,10 @@
     },
     "packages/server": {
       "name": "@onesub/server",
-      "version": "0.19.0",
+      "version": "0.22.0",
       "license": "MIT",
       "dependencies": {
-        "@onesub/shared": "0.14.0",
+        "@onesub/shared": "0.15.0",
         "jose": "^6.2.3",
         "zod": "^4.4.3"
       },
@@ -9747,6 +9820,7 @@
         "@types/pg": "^8.20.0",
         "express": "^5.2.1",
         "ioredis-mock": "^8.9.0",
+        "pg": "^8.22.0",
         "size-limit": "^12.1.0",
         "tsup": "^8.3.5",
         "typescript": "^5.7.0"
@@ -9795,7 +9869,7 @@
     },
     "packages/shared": {
       "name": "@onesub/shared",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.0"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -88,6 +88,7 @@
     "@types/pg": "^8.20.0",
     "express": "^5.2.1",
     "ioredis-mock": "^8.9.0",
+    "pg": "^8.22.0",
     "size-limit": "^12.1.0",
     "tsup": "^8.3.5",
     "typescript": "^5.7.0"

--- a/packages/server/src/__tests__/postgres-store.test.ts
+++ b/packages/server/src/__tests__/postgres-store.test.ts
@@ -1,0 +1,362 @@
+/**
+ * PostgresSubscriptionStore / PostgresPurchaseStore against a real database.
+ *
+ * Until now nothing executed this SQL. `schema.test.ts` compares the embedded DDL
+ * strings to `sql/schema.sql` as text, which catches the two drifting apart but
+ * says nothing about whether either one works, and every other suite runs on the
+ * in-memory store. So the store that production actually uses was the least
+ * verified code in the package — and two things shipped on the strength of
+ * reading it: `getPurchasesForProduct`, and the claim in ARCHITECTURE.md that the
+ * partial unique index is "the atomic guarantee" behind non-consumable dedup.
+ *
+ * Skipped unless `DATABASE_URL` is set, so a local `npm test` without a database
+ * still passes. CI provides one through a service container.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import type { PurchaseInfo, SubscriptionInfo } from '@onesub/shared';
+import { PostgresSubscriptionStore, PostgresPurchaseStore } from '../stores/postgres.js';
+
+const DATABASE_URL = process.env['DATABASE_URL'];
+const describePg = DATABASE_URL ? describe : describe.skip;
+
+function sub(overrides?: Partial<SubscriptionInfo>): SubscriptionInfo {
+  return {
+    userId: 'alice',
+    productId: 'pro_monthly',
+    platform: 'apple',
+    status: 'active',
+    expiresAt: '2099-01-01T00:00:00.000Z',
+    purchasedAt: '2026-04-01T00:00:00.000Z',
+    originalTransactionId: 'sub-1',
+    willRenew: true,
+    ...overrides,
+  };
+}
+
+function purchase(overrides?: Partial<PurchaseInfo>): PurchaseInfo {
+  return {
+    userId: 'alice',
+    productId: 'lifetime_pass',
+    platform: 'apple',
+    type: 'non_consumable',
+    transactionId: 'pur-1',
+    quantity: 1,
+    purchasedAt: '2026-04-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describePg('Postgres stores', () => {
+  let store: PostgresSubscriptionStore;
+  let purchaseStore: PostgresPurchaseStore;
+  // Raw client for truncation and for applying the shipped .sql by hand.
+  let pool: import('pg').Pool;
+
+  beforeAll(async () => {
+    const pg = await import('pg');
+    const Pool = pg.default?.Pool ?? (pg as unknown as { Pool: typeof import('pg').Pool }).Pool;
+    pool = new Pool({ connectionString: DATABASE_URL, max: 4 });
+
+    store = new PostgresSubscriptionStore(DATABASE_URL!);
+    purchaseStore = new PostgresPurchaseStore(DATABASE_URL!);
+    await store.initSchema();
+    await purchaseStore.initSchema();
+  });
+
+  afterAll(async () => {
+    await store.close();
+    await purchaseStore.close();
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await pool.query('TRUNCATE onesub_subscriptions, onesub_purchases');
+  });
+
+  // ── schema ───────────────────────────────────────────────────────────────
+
+  describe('schema', () => {
+    it('initSchema is safe to run repeatedly', async () => {
+      // Hosts are told to call it at every startup, so it has to be idempotent
+      // against an already-migrated database, not just an empty one.
+      await store.initSchema();
+      await store.initSchema();
+      await purchaseStore.initSchema();
+      await purchaseStore.initSchema();
+
+      await store.save(sub());
+      expect(await store.getByTransactionId('sub-1')).not.toBeNull();
+    });
+
+    it('the shipped sql/schema.sql produces a schema the stores can use', async () => {
+      // schema.test.ts proves this file matches the embedded DDL as text. That
+      // leaves open the possibility that both are wrong; applying it and then
+      // driving the stores through it does not.
+      const sqlPath = fileURLToPath(new URL('../../sql/schema.sql', import.meta.url));
+      const schemaSql = readFileSync(sqlPath, 'utf-8');
+
+      await pool.query('DROP TABLE IF EXISTS onesub_subscriptions, onesub_purchases');
+      await pool.query(schemaSql);
+
+      await store.save(sub());
+      await purchaseStore.savePurchase(purchase());
+      expect(await store.getByUserId('alice')).not.toBeNull();
+      expect(await purchaseStore.hasPurchased('alice', 'lifetime_pass')).toBe(true);
+    });
+  });
+
+  // ── the query shipped unverified in P4 ───────────────────────────────────
+
+  describe('PurchaseStore.getPurchasesForProduct', () => {
+    it('returns only the requested user + product', async () => {
+      await purchaseStore.savePurchase(purchase({ transactionId: 'c1', productId: 'coins', type: 'consumable' }));
+      await purchaseStore.savePurchase(purchase({ transactionId: 'c2', productId: 'coins', type: 'consumable' }));
+      await purchaseStore.savePurchase(purchase({ transactionId: 'l1', productId: 'lifetime_pass' }));
+      await purchaseStore.savePurchase(
+        purchase({ transactionId: 'c3', productId: 'coins', type: 'consumable', userId: 'bob' }),
+      );
+
+      const rows = await purchaseStore.getPurchasesForProduct('alice', 'coins');
+      expect(rows).toHaveLength(2);
+      expect(rows.every((p) => p.userId === 'alice' && p.productId === 'coins')).toBe(true);
+      expect(rows.map((p) => p.transactionId).sort()).toEqual(['c1', 'c2']);
+    });
+
+    it('orders most-recent-first, matching the interface contract', async () => {
+      await purchaseStore.savePurchase(
+        purchase({ transactionId: 'mid', productId: 'coins', type: 'consumable', purchasedAt: '2026-04-10T00:00:00.000Z' }),
+      );
+      await purchaseStore.savePurchase(
+        purchase({ transactionId: 'newest', productId: 'coins', type: 'consumable', purchasedAt: '2026-08-01T00:00:00.000Z' }),
+      );
+      await purchaseStore.savePurchase(
+        purchase({ transactionId: 'oldest', productId: 'coins', type: 'consumable', purchasedAt: '2026-01-01T00:00:00.000Z' }),
+      );
+
+      const rows = await purchaseStore.getPurchasesForProduct('alice', 'coins');
+      expect(rows.map((p) => p.transactionId)).toEqual(['newest', 'mid', 'oldest']);
+    });
+
+    it('returns an empty array for an unknown user or product', async () => {
+      await purchaseStore.savePurchase(purchase());
+      expect(await purchaseStore.getPurchasesForProduct('alice', 'nope')).toEqual([]);
+      expect(await purchaseStore.getPurchasesForProduct('nobody', 'lifetime_pass')).toEqual([]);
+    });
+
+    it('round-trips every field, not just the ones it filters on', async () => {
+      await purchaseStore.savePurchase(
+        purchase({ transactionId: 'g1', platform: 'google', type: 'consumable', productId: 'coins', quantity: 3 }),
+      );
+      const [row] = await purchaseStore.getPurchasesForProduct('alice', 'coins');
+      expect(row).toEqual({
+        transactionId: 'g1',
+        userId: 'alice',
+        productId: 'coins',
+        platform: 'google',
+        type: 'consumable',
+        quantity: 3,
+        purchasedAt: '2026-04-01T00:00:00.000Z',
+      });
+    });
+  });
+
+  // ── purchase ownership + the DB-level guarantee ──────────────────────────
+
+  describe('PurchaseStore.savePurchase', () => {
+    it('is idempotent for the same user and transactionId', async () => {
+      await purchaseStore.savePurchase(purchase());
+      await purchaseStore.savePurchase(purchase());
+      expect(await purchaseStore.getPurchasesByUserId('alice')).toHaveLength(1);
+    });
+
+    it('refuses a transactionId already owned by someone else', async () => {
+      await purchaseStore.savePurchase(purchase());
+      await expect(
+        purchaseStore.savePurchase(purchase({ userId: 'mallory' })),
+      ).rejects.toThrow(/TRANSACTION_BELONGS_TO_OTHER_USER/);
+      // The loser must not have acquired a row.
+      expect(await purchaseStore.getPurchasesByUserId('mallory')).toEqual([]);
+    });
+
+    it('lets a user hold many consumable rows for one product', async () => {
+      await purchaseStore.savePurchase(purchase({ transactionId: 'c1', productId: 'coins', type: 'consumable' }));
+      await purchaseStore.savePurchase(purchase({ transactionId: 'c2', productId: 'coins', type: 'consumable' }));
+      expect(await purchaseStore.getPurchasesForProduct('alice', 'coins')).toHaveLength(2);
+    });
+
+    it('the partial unique index blocks a second non-consumable row for the same user + product', async () => {
+      // ARCHITECTURE.md calls this "the atomic guarantee" behind non-consumable
+      // dedup, with the application-level check as a fast path. Nothing had
+      // exercised it. Note the rejection is the raw constraint violation, not a
+      // mapped ONESUB_ERROR_CODE — the route checks ownership first, so this
+      // fires only on a concurrent double-insert or a direct admin grant.
+      await purchaseStore.savePurchase(purchase({ transactionId: 'n1' }));
+      await expect(purchaseStore.savePurchase(purchase({ transactionId: 'n2' }))).rejects.toThrow();
+      expect(await purchaseStore.getPurchasesForProduct('alice', 'lifetime_pass')).toHaveLength(1);
+    });
+  });
+
+  describe('PurchaseStore mutations', () => {
+    it('deletePurchaseByTransactionId removes exactly one row', async () => {
+      await purchaseStore.savePurchase(purchase({ transactionId: 'c1', productId: 'coins', type: 'consumable' }));
+      await purchaseStore.savePurchase(purchase({ transactionId: 'c2', productId: 'coins', type: 'consumable' }));
+
+      expect(await purchaseStore.deletePurchaseByTransactionId('c1')).toBe(true);
+      expect(await purchaseStore.deletePurchaseByTransactionId('c1')).toBe(false);
+      // The sibling consumable survives — the reason this method exists.
+      expect(await purchaseStore.getPurchasesForProduct('alice', 'coins')).toHaveLength(1);
+    });
+
+    it('deletePurchases removes every row for the user + product', async () => {
+      await purchaseStore.savePurchase(purchase({ transactionId: 'c1', productId: 'coins', type: 'consumable' }));
+      await purchaseStore.savePurchase(purchase({ transactionId: 'c2', productId: 'coins', type: 'consumable' }));
+      await purchaseStore.savePurchase(purchase({ transactionId: 'l1', productId: 'lifetime_pass' }));
+
+      expect(await purchaseStore.deletePurchases('alice', 'coins')).toBe(2);
+      expect(await purchaseStore.getPurchasesForProduct('alice', 'coins')).toEqual([]);
+      expect(await purchaseStore.getPurchasesForProduct('alice', 'lifetime_pass')).toHaveLength(1);
+    });
+
+    it('reassignPurchase moves ownership and reports whether it found the row', async () => {
+      await purchaseStore.savePurchase(purchase());
+      expect(await purchaseStore.reassignPurchase('pur-1', 'bob')).toBe(true);
+      expect(await purchaseStore.hasPurchased('alice', 'lifetime_pass')).toBe(false);
+      expect(await purchaseStore.hasPurchased('bob', 'lifetime_pass')).toBe(true);
+      expect(await purchaseStore.reassignPurchase('missing', 'bob')).toBe(false);
+    });
+
+    it('hasPurchased answers per user and product', async () => {
+      await purchaseStore.savePurchase(purchase());
+      expect(await purchaseStore.hasPurchased('alice', 'lifetime_pass')).toBe(true);
+      expect(await purchaseStore.hasPurchased('alice', 'other')).toBe(false);
+      expect(await purchaseStore.hasPurchased('bob', 'lifetime_pass')).toBe(false);
+    });
+  });
+
+  // ── subscriptions ────────────────────────────────────────────────────────
+
+  describe('SubscriptionStore', () => {
+    it('save upserts on originalTransactionId rather than inserting again', async () => {
+      await store.save(sub({ status: 'active' }));
+      await store.save(sub({ status: 'canceled', willRenew: false }));
+
+      const all = await store.getAllByUserId('alice');
+      expect(all).toHaveLength(1);
+      expect(all[0]?.status).toBe('canceled');
+      expect(all[0]?.willRenew).toBe(false);
+    });
+
+    it('round-trips dates as ISO strings and optional columns as undefined', async () => {
+      await store.save(sub());
+      const fetched = await store.getByTransactionId('sub-1');
+      expect(fetched?.expiresAt).toBe('2099-01-01T00:00:00.000Z');
+      expect(fetched?.purchasedAt).toBe('2026-04-01T00:00:00.000Z');
+      expect(fetched?.linkedPurchaseToken).toBeUndefined();
+      expect(fetched?.autoResumeTime).toBeUndefined();
+    });
+
+    it('persists the optional columns when they are set', async () => {
+      await store.save(
+        sub({ linkedPurchaseToken: 'prev-token', autoResumeTime: '2026-09-01T00:00:00.000Z', status: 'paused' }),
+      );
+      const fetched = await store.getByTransactionId('sub-1');
+      expect(fetched?.linkedPurchaseToken).toBe('prev-token');
+      expect(fetched?.autoResumeTime).toBe('2026-09-01T00:00:00.000Z');
+    });
+
+    it('getByUserId returns the most recently updated record', async () => {
+      await store.save(sub({ originalTransactionId: 'old', productId: 'pro_monthly' }));
+      await store.save(sub({ originalTransactionId: 'new', productId: 'pro_yearly' }));
+
+      // updated_at is NOW() on write, so the second save is the most recent.
+      expect((await store.getByUserId('alice'))?.originalTransactionId).toBe('new');
+    });
+
+    it('getAllByUserId returns every record for the user and nobody else’s', async () => {
+      await store.save(sub({ originalTransactionId: 't1', productId: 'pro_monthly' }));
+      await store.save(sub({ originalTransactionId: 't2', productId: 'pro_yearly' }));
+      await store.save(sub({ originalTransactionId: 't3', userId: 'bob' }));
+
+      const all = await store.getAllByUserId('alice');
+      expect(all).toHaveLength(2);
+      expect(all.every((s) => s.userId === 'alice')).toBe(true);
+    });
+
+    it('rebinds a transaction to a new userId on re-validation', async () => {
+      await store.save(sub({ userId: 'alice' }));
+      await store.save(sub({ userId: 'bob' }));
+
+      expect(await store.getAllByUserId('alice')).toEqual([]);
+      expect(await store.getAllByUserId('bob')).toHaveLength(1);
+    });
+  });
+
+  describe('SubscriptionStore.listFiltered', () => {
+    beforeEach(async () => {
+      await store.save(sub({ originalTransactionId: 'a1', status: 'active', productId: 'pro_monthly', platform: 'apple' }));
+      await store.save(sub({ originalTransactionId: 'a2', status: 'expired', productId: 'pro_monthly', platform: 'apple' }));
+      await store.save(sub({ originalTransactionId: 'g1', status: 'active', productId: 'pro_yearly', platform: 'google', userId: 'bob' }));
+    });
+
+    it('returns everything with no filters', async () => {
+      const result = await store.listFiltered({});
+      expect(result.total).toBe(3);
+      expect(result.items).toHaveLength(3);
+      expect(result.limit).toBe(50);
+      expect(result.offset).toBe(0);
+    });
+
+    it('combines filters as AND', async () => {
+      expect((await store.listFiltered({ status: 'active' })).total).toBe(2);
+      expect((await store.listFiltered({ platform: 'apple' })).total).toBe(2);
+      expect((await store.listFiltered({ status: 'active', platform: 'apple' })).total).toBe(1);
+      expect((await store.listFiltered({ userId: 'bob', status: 'active' })).total).toBe(1);
+      expect((await store.listFiltered({ userId: 'bob', status: 'expired' })).total).toBe(0);
+    });
+
+    it('filters by productId', async () => {
+      expect((await store.listFiltered({ productId: 'pro_yearly' })).total).toBe(1);
+    });
+
+    it('reports the unpaged total alongside a limited page', async () => {
+      const page = await store.listFiltered({ limit: 2 });
+      expect(page.items).toHaveLength(2);
+      expect(page.total).toBe(3);
+    });
+
+    it('pages without repeating or dropping a row', async () => {
+      const first = await store.listFiltered({ limit: 2, offset: 0 });
+      const second = await store.listFiltered({ limit: 2, offset: 2 });
+      expect(second.items).toHaveLength(1);
+
+      const ids = [...first.items, ...second.items].map((s) => s.originalTransactionId);
+      expect(new Set(ids).size).toBe(3);
+    });
+
+    it('returns an empty page past the end, still with the true total', async () => {
+      const result = await store.listFiltered({ limit: 2, offset: 99 });
+      expect(result.items).toEqual([]);
+      expect(result.total).toBe(3);
+    });
+  });
+
+  describe('listAll', () => {
+    it('returns every row from both stores', async () => {
+      await store.save(sub({ originalTransactionId: 's1' }));
+      await store.save(sub({ originalTransactionId: 's2', userId: 'bob' }));
+      await purchaseStore.savePurchase(purchase({ transactionId: 'p1' }));
+      await purchaseStore.savePurchase(purchase({ transactionId: 'p2', userId: 'bob' }));
+
+      expect(await store.listAll()).toHaveLength(2);
+      expect(await purchaseStore.listAll()).toHaveLength(2);
+    });
+
+    it('returns an empty array on an empty table', async () => {
+      expect(await store.listAll()).toEqual([]);
+      expect(await purchaseStore.listAll()).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
The remaining risk from the #124 review, and the blocker behind two deferred items.

## The gap

The Postgres stores are what production runs on, and **nothing executed their SQL**:

- `schema.test.ts` compares the embedded DDL to `sql/schema.sql` **as text** — it
  catches the two drifting apart, and passes when both are wrong.
- Every other suite uses the in-memory store.

So the least-verified code in the package was the code most deployments depend on.
Two things shipped this week on the strength of reading it rather than running it:
`getPurchasesForProduct` (#126, 0.21.0), and the claim in ARCHITECTURE.md that the
partial unique index is "the atomic guarantee" behind non-consumable dedup.

## What this adds

`postgres-store.test.ts` — 28 tests — plus a `postgres:17-alpine` service container
on the `ci` job.

The suite **skips itself when `DATABASE_URL` is unset**, so a local `npm test`
without a database still passes. That also means the service container is the only
thing that runs it, and deleting the container would silently drop 28 tests instead
of failing. That trap is called out in the workflow comment, in `AGENTS.md`, and in
`docs/TESTING.md` — the latter two also document how to point a throwaway database
at it locally.

Beyond CRUD it covers what only a database can answer:

- `initSchema()` is safe to re-run against an already-migrated database — hosts are
  told to call it at every startup
- the shipped `sql/schema.sql`, applied by hand, produces a schema the stores can
  actually drive (closing the gap `schema.test.ts` leaves open)
- the partial unique index really blocks a second non-consumable row for one user and
  product — and the rejection is the raw constraint violation, not a mapped
  `ONESUB_ERROR_CODE`, which the test records rather than papers over
- `listFiltered` combines filters as AND, reports the unpaged total next to a limited
  page, and pages without repeating or dropping a row
- dates round-trip as ISO strings, with the optional columns coming back `undefined`
- `getPurchasesForProduct` — scoping, `purchased_at DESC` ordering, cross-user
  isolation, and full-row fidelity

## Dependency change

`pg` becomes a devDependency of `@onesub/server`. It remains an **optional peer** for
consumers, so nothing changes for them. The lockfile diff is `pg` plus its own five
dependencies (`pg-cloudflare`, `pg-connection-string`, `pg-pool`, `pgpass`,
`split2`), with no version changes to anything else and **no new advisories** — the 6
existing ones are all in `mcp-server` / `dashboard` dependencies.

`npm install` also synced the workspace version entries in the lockfile, which had
drifted from `package.json` because `changeset version` does not update the lockfile.
`npm ci` validates.

## What CI will verify that I could not

This checkout has no Postgres and no usable Docker daemon, so **I could not run these
tests locally** — the run on this PR is their first execution. That is the point: it
is the verification that was missing. If `getPurchasesForProduct`'s SQL is wrong,
this is where it surfaces.

Local gates pass: 722 passed / 28 skipped, `build`, `type-check`, `size` (35.44/38
KB), `docs:check`, `validate-unity-graph`, dashboard build.

## Unblocks

- The metrics SQL aggregation pushdown deferred from #124 (P2) — the remaining
  per-request full scan on `/onesub/metrics/*`.
- Any future change to `stores/postgres.ts`, which now has a way to be checked.

No changeset: tests, CI, docs, and a devDependency change nothing for consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)