### PR TITLE
perf(server): push metrics aggregation into SQL

### DIFF
--- a/.changeset/sharp-metrics-group.md
+++ b/.changeset/sharp-metrics-group.md
@@ -1,0 +1,36 @@
+---
+'@onesub/server': minor
+---
+
+Push metrics aggregation into SQL instead of reducing every row in the process.
+
+Each `/onesub/metrics/*` request read the entire subscription or purchase table and
+reduced it on the event loop, where it competes with receipt validation. Caching
+(0.20.0) bounded how often that happened; it did not make the scan cheaper.
+
+`SubscriptionStore` and `PurchaseStore` gain optional aggregate methods —
+`aggregateActive`, `aggregateStarted`, `aggregateExpired`,
+`aggregateNonConsumable` — and the metrics routes use them when the store has one.
+The Postgres stores implement them as `GROUP BY`, so the work is bounded by
+products × platforms (× days when bucketing) rather than by row count.
+
+Optional, so nothing breaks: a store without them falls back to the previous
+`listAll()` plus in-memory reduction, which is the path the in-memory and Redis
+stores keep. Neither has server-side grouping to push into, so implementing there
+would be the same reduction behind a longer interface. Custom stores written before
+these methods existed keep working unchanged. `/onesub/metrics/active` takes each
+half independently, so a Postgres subscription store pairs fine with a custom
+purchase store.
+
+`metrics-aggregate.ts` remains the definition of what the numbers mean, and is now
+what the SQL is checked against: `postgres-store.test.ts` runs both paths over the
+same rows and asserts the results are identical — inclusive window bounds, the
+strictly-greater-than expiry boundary, status and type filters, and zero-filled
+UTC calendar-day buckets.
+
+One correctness note worth stating, because a green CI would not have caught it.
+`date_trunc` truncates in the database session's timezone, so the daily buckets are
+only correct because of an explicit `AT TIME ZONE 'UTC'` cast. A CI container
+running UTC cannot distinguish that from a missing cast — every other test passes
+either way — so one test forces a non-UTC session on its own connection and
+re-checks the equivalence there.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,6 +297,12 @@ docker run -d --rm -p 5432:5432 -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=one
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/onesub_test npm test -- packages/server/src/__tests__/postgres-store.test.ts
 ```
 
+**No Docker in this checkout?** Common in sandboxes: the daemon runs but your user is
+not in the `docker` group and `sudo` wants a password. PostgreSQL needs no root — it
+refuses to run as root — so a relocatable build unpacked outside the repo works
+instead. `docs/TESTING.md` → *Postgres store tests* has the commands. Do not add the
+Postgres binaries to this repo's dependencies to get them.
+
 That file is the only thing that executes the Postgres SQL; `schema.test.ts`
 compares the embedded DDL to `sql/schema.sql` as text and proves nothing about
 whether either works. Any change under `packages/server/src/stores/postgres.ts`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -131,6 +131,10 @@ interface SubscriptionStore {
   getAllByUserId(userId: string): Promise<SubscriptionInfo[]>;
   listAll(): Promise<SubscriptionInfo[]>;
   listFiltered(options: ListFilteredOptions): Promise<ListFilteredResult>;
+  // 0.23.0+, all optional — metrics aggregates
+  aggregateActive?(now: Date): Promise<ActiveSubscriptionAggregate>;
+  aggregateStarted?(query: MetricsRangeQuery): Promise<MetricsRangeAggregate>;
+  aggregateExpired?(query: MetricsRangeQuery): Promise<MetricsRangeAggregate>;
 }
 ```
 
@@ -147,8 +151,30 @@ interface PurchaseStore {
   reassignPurchase(transactionId: string, newUserId: string): Promise<boolean>;       // 0.6.1+
   deletePurchases(userId: string, productId: string): Promise<number>;                // 0.4.0+
   deletePurchaseByTransactionId(transactionId: string): Promise<boolean>;             // 0.8.0+
+  // 0.23.0+, all optional — metrics aggregates
+  aggregateNonConsumable?(): Promise<NonConsumablePurchaseAggregate>;
+  aggregateStarted?(query: MetricsRangeQuery): Promise<MetricsRangeAggregate>;
 }
 ```
+
+### Metrics aggregation
+
+The `aggregate*` methods are optional on both stores. `/onesub/metrics/*` uses a
+store's own aggregate when it has one and otherwise reads every row and reduces in
+process — the same answer at O(rows), on the event loop.
+
+`PostgresSubscriptionStore` / `PostgresPurchaseStore` implement them as `GROUP BY`,
+so the work is bounded by products × platforms (× days when bucketing) rather than by
+row count. The in-memory and Redis stores deliberately do not: neither has
+server-side grouping to push into, so an implementation there would be the same
+in-process reduction behind a longer interface.
+
+`packages/server/src/metrics-aggregate.ts` is the executable definition of what the
+numbers mean, for both paths. `postgres-store.test.ts` runs the SQL and the reducer
+over the same rows and asserts they agree — including UTC calendar-day bucket
+boundaries, which is why the SQL casts with `AT TIME ZONE 'UTC'` before
+`date_trunc`, and one test forces a non-UTC session so a UTC-only CI container
+cannot hide a missing cast.
 
 Both read methods return **most-recent-first** by `purchasedAt`. All three built-in
 stores agree on that; a custom store should too, since `/onesub/purchase/status`

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -59,6 +59,46 @@ DATABASE_URL=postgres://postgres:postgres@localhost:5432/onesub_test \
   npm test -- packages/server/src/__tests__/postgres-store.test.ts
 ```
 
+#### Without Docker (sandboxes, restricted CI runners, no root)
+
+Docker is unavailable in some environments — the daemon may be running while your
+user is not in the `docker` group, and `sudo` may need a password you do not have.
+PostgreSQL itself needs no root; it refuses to run as root. So fetch a relocatable
+build and run it as yourself. Keep it **outside the repo** so the root lockfile is
+untouched:
+
+```bash
+mkdir -p /tmp/onesub-pg && cd /tmp/onesub-pg && npm init -y >/dev/null
+npm install @embedded-postgres/linux-x64@17.10.0-beta.17   # match CI's major
+
+BIN=/tmp/onesub-pg/node_modules/@embedded-postgres/linux-x64/native/bin
+export LD_LIBRARY_PATH=/tmp/onesub-pg/node_modules/@embedded-postgres/linux-x64/native/lib
+
+$BIN/initdb -D /tmp/onesub-pg/data -U postgres --auth=trust
+# Port 55432 avoids colliding with a system Postgres; -k keeps the socket writable.
+$BIN/pg_ctl -D /tmp/onesub-pg/data -l /tmp/onesub-pg/log \
+  -o "-p 55432 -k /tmp/onesub-pg -c listen_addresses=127.0.0.1" start
+```
+
+The package ships the server but not `psql`, which these tests do not need — they
+connect through `pg` over TCP. Create the database with a one-liner and run:
+
+```bash
+cd /path/to/onesub
+node -e "const{Client}=require('pg');(async()=>{const c=new Client({host:'127.0.0.1',port:55432,user:'postgres',database:'postgres'});await c.connect();await c.query('CREATE DATABASE onesub_test');await c.end()})()"
+
+DATABASE_URL=postgres://postgres@127.0.0.1:55432/onesub_test npm test
+```
+
+Stop it with `$BIN/pg_ctl -D /tmp/onesub-pg/data stop`.
+
+**A non-UTC session timezone is a feature here.** `date_trunc` truncates in the
+session timezone, so the daily-bucket aggregation is only correct because of an
+explicit `AT TIME ZONE 'UTC'`. A UTC container cannot distinguish a correct
+implementation from one missing that cast. One test forces a hostile session
+timezone on its own connection so the check holds anywhere, but running the suite
+under a non-UTC local timezone exercises the rest of it that way too.
+
 Beyond CRUD, it covers the things only a database can answer: that `initSchema()` is safe to re-run
 against an already-migrated database, that the shipped `sql/schema.sql` produces a schema the stores
 can actually drive, that the partial unique index really blocks a second non-consumable row for one

--- a/packages/server/.size-limit.cjs
+++ b/packages/server/.size-limit.cjs
@@ -25,6 +25,9 @@
 // 2026-07-26: 34.17/34.55 KB after the metrics aggregation split and response
 // cache (`metrics-aggregate.ts`, `metrics-cache.ts`). Limit unchanged.
 //
+// 2026-07-26: 36.35/36.69 KB after the metrics SQL aggregation pushdown
+// (`aggregateViaSql` plus the optional store methods). Limit unchanged.
+//
 // 2026-07-26: raised 36 → 38 KB. Measured 35.12/35.47 KB after the
 // product-scoped purchase lookup, the `parseOrSend` consolidation (which cut
 // ~80 lines from the route handlers but adds a shared helper), and the Google

--- a/packages/server/src/__tests__/metrics.test.ts
+++ b/packages/server/src/__tests__/metrics.test.ts
@@ -14,6 +14,8 @@ import type {
 } from '@onesub/shared';
 import { SUBSCRIPTION_STATUS } from '@onesub/shared';
 import { createOneSubMiddleware, InMemorySubscriptionStore, InMemoryPurchaseStore } from '../index.js';
+import { aggregateActiveSubscriptions } from '../metrics-aggregate.js';
+import type { SubscriptionStore } from '../store.js';
 
 // ── helpers ─────────────────────────────────────────────────────────────────
 
@@ -628,6 +630,59 @@ describe('Metrics response caching', () => {
     await server.get('/onesub/metrics/active', AUTH);
 
     expect(reads()).toBe(3);
+  });
+
+  it('prefers a store’s own aggregate over reading every row', async () => {
+    // Responses are identical either way, so a call count is the only way to see
+    // which path ran. A store that can group server-side must not be asked for
+    // its whole table.
+    const store: InMemorySubscriptionStore & Pick<SubscriptionStore, 'aggregateActive'> =
+      new InMemorySubscriptionStore();
+    await store.save(sub({ userId: 'a', productId: 'pro_monthly', originalTransactionId: 't1' }));
+
+    // Stand in for a SQL implementation: answer from the records without the
+    // route ever calling listAll().
+    let aggregateCalls = 0;
+    store.aggregateActive = async (now: Date) => {
+      aggregateCalls++;
+      return aggregateActiveSubscriptions(await store.getAllByUserId('a'), now.getTime());
+    };
+
+    const purchaseStore = new InMemoryPurchaseStore();
+    const app = express();
+    app.use(
+      createOneSubMiddleware({
+        apple: { bundleId: 'com.example.app', skipJwsVerification: true },
+        database: { url: '' },
+        adminSecret: SECRET,
+        metricsCacheTtlSeconds: 0,
+        store,
+        purchaseStore,
+      }),
+    );
+    const server = spinUp(app);
+    const fullReads = countCalls(store, 'listAll');
+
+    const resp = await server.get<MetricsActiveResponse>('/onesub/metrics/active', AUTH);
+
+    expect(resp.status).toBe(200);
+    expect(resp.body.activeSubscriptions).toBe(1);
+    expect(aggregateCalls).toBe(1);
+    expect(fullReads()).toBe(0);
+  });
+
+  it('falls back to reading rows when the store has no aggregate', async () => {
+    // The in-memory store deliberately implements none of them — there is no
+    // server-side grouping to push into — so the route must still work.
+    const { store, server } = buildServer({ adminSecret: SECRET, metricsCacheTtlSeconds: 0 });
+    expect((store as SubscriptionStore).aggregateActive).toBeUndefined();
+    await store.save(sub({ userId: 'a', originalTransactionId: 't1' }));
+    const fullReads = countCalls(store, 'listAll');
+
+    const resp = await server.get<MetricsActiveResponse>('/onesub/metrics/active', AUTH);
+
+    expect(resp.body.activeSubscriptions).toBe(1);
+    expect(fullReads()).toBe(1);
   });
 
   it('with the TTL disabled, a newly saved record shows up immediately', async () => {

--- a/packages/server/src/__tests__/postgres-store.test.ts
+++ b/packages/server/src/__tests__/postgres-store.test.ts
@@ -18,6 +18,13 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import type { PurchaseInfo, SubscriptionInfo } from '@onesub/shared';
 import { PostgresSubscriptionStore, PostgresPurchaseStore } from '../stores/postgres.js';
+import {
+  aggregateActiveSubscriptions,
+  aggregateNonConsumablePurchases,
+  aggregateRange,
+  isEndedSubscription,
+  isNonConsumable,
+} from '../metrics-aggregate.js';
 
 const DATABASE_URL = process.env['DATABASE_URL'];
 const describePg = DATABASE_URL ? describe : describe.skip;
@@ -340,6 +347,211 @@ describePg('Postgres stores', () => {
       const result = await store.listFiltered({ limit: 2, offset: 99 });
       expect(result.items).toEqual([]);
       expect(result.total).toBe(3);
+    });
+  });
+
+  // ── metrics aggregation: SQL must equal the in-memory reducer ─────────────
+  //
+  // These are the point of the whole aggregation change. `metrics-aggregate.ts`
+  // is the definition of what a metrics response means; the SQL is an
+  // optimisation that has to produce byte-identical output. Rather than restate
+  // expected numbers, each test runs BOTH over the same rows and compares — so a
+  // timezone slip, an exclusive bound, or a missed zero-fill fails here instead
+  // of quietly changing what operators see.
+
+  describe('aggregateActive equals the in-memory reduction', () => {
+    const NOW = new Date('2026-06-15T12:00:00.000Z');
+
+    async function bothWays() {
+      const sql = await store.aggregateActive!(NOW);
+      const memory = aggregateActiveSubscriptions(await store.listAll(), NOW.getTime());
+      return { sql, memory };
+    }
+
+    it('agrees on an empty table', async () => {
+      const { sql, memory } = await bothWays();
+      expect(sql).toEqual(memory);
+      expect(sql.active).toBe(0);
+    });
+
+    it('agrees across statuses, products and platforms', async () => {
+      await store.save(sub({ originalTransactionId: 'a', status: 'active', expiresAt: '2026-07-01T00:00:00.000Z' }));
+      await store.save(sub({ originalTransactionId: 'b', status: 'grace_period', expiresAt: '2026-07-01T00:00:00.000Z', platform: 'google' }));
+      await store.save(sub({ originalTransactionId: 'c', status: 'grace_period', expiresAt: '2026-07-01T00:00:00.000Z', productId: 'pro_yearly' }));
+      // Excluded: right status, already expired.
+      await store.save(sub({ originalTransactionId: 'd', status: 'active', expiresAt: '2026-01-01T00:00:00.000Z' }));
+      // Excluded: on_hold / paused do not grant entitlement.
+      await store.save(sub({ originalTransactionId: 'e', status: 'on_hold', expiresAt: '2026-07-01T00:00:00.000Z' }));
+      await store.save(sub({ originalTransactionId: 'f', status: 'paused', expiresAt: '2026-07-01T00:00:00.000Z' }));
+
+      const { sql, memory } = await bothWays();
+      expect(sql).toEqual(memory);
+      expect(sql.active).toBe(3);
+      expect(sql.gracePeriod).toBe(2);
+    });
+
+    it('agrees on the expiry boundary, which is strictly greater-than', async () => {
+      // expires_at exactly == now must NOT count, matching isActiveSubscription.
+      await store.save(sub({ originalTransactionId: 'exact', status: 'active', expiresAt: NOW.toISOString() }));
+      const { sql, memory } = await bothWays();
+      expect(sql).toEqual(memory);
+      expect(sql.active).toBe(0);
+    });
+  });
+
+  describe('aggregateNonConsumable equals the in-memory reduction', () => {
+    it('counts non-consumables only, and agrees', async () => {
+      await purchaseStore.savePurchase(purchase({ transactionId: 'n1', productId: 'lifetime_pass' }));
+      await purchaseStore.savePurchase(purchase({ transactionId: 'n2', productId: 'remove_ads', platform: 'google' }));
+      await purchaseStore.savePurchase(purchase({ transactionId: 'c1', productId: 'coins', type: 'consumable' }));
+
+      const sql = await purchaseStore.aggregateNonConsumable!();
+      const memory = aggregateNonConsumablePurchases(await purchaseStore.listAll());
+      expect(sql).toEqual(memory);
+      expect(sql.total).toBe(2);
+      expect(sql.byProduct).toEqual({ lifetime_pass: 1, remove_ads: 1 });
+    });
+  });
+
+  describe('aggregateStarted / aggregateExpired equal the in-memory reduction', () => {
+    const from = new Date('2026-04-01T00:00:00.000Z');
+    const to = new Date('2026-04-30T23:59:59.999Z');
+
+    async function seedSpread() {
+      await store.save(sub({ originalTransactionId: 'before', purchasedAt: '2026-03-31T23:59:59.999Z' }));
+      await store.save(sub({ originalTransactionId: 'lower', purchasedAt: '2026-04-01T00:00:00.000Z' }));
+      await store.save(sub({ originalTransactionId: 'mid', purchasedAt: '2026-04-15T09:30:00.000Z', productId: 'pro_yearly' }));
+      await store.save(sub({ originalTransactionId: 'upper', purchasedAt: '2026-04-30T23:59:59.999Z', platform: 'google' }));
+      await store.save(sub({ originalTransactionId: 'after', purchasedAt: '2026-05-01T00:00:00.000Z' }));
+    }
+
+    it('agrees on inclusive window bounds without bucketing', async () => {
+      await seedSpread();
+      const sql = await store.aggregateStarted!({ from, to, groupBy: 'none' });
+      const memory = aggregateRange(await store.listAll(), {
+        fromMs: from.getTime(),
+        toMs: to.getTime(),
+        groupBy: 'none',
+        anchor: (s) => s.purchasedAt,
+      });
+      expect(sql).toEqual(memory);
+      expect(sql.total).toBe(3);
+      expect(sql.buckets).toBeUndefined();
+    });
+
+    it('agrees on zero-filled daily buckets', async () => {
+      await seedSpread();
+      const sql = await store.aggregateStarted!({ from, to, groupBy: 'day' });
+      const memory = aggregateRange(await store.listAll(), {
+        fromMs: from.getTime(),
+        toMs: to.getTime(),
+        groupBy: 'day',
+        anchor: (s) => s.purchasedAt,
+      });
+      expect(sql).toEqual(memory);
+      expect(sql.buckets).toHaveLength(30);
+      expect(sql.buckets!.reduce((n, b) => n + b.count, 0)).toBe(sql.total);
+    });
+
+    it('assigns a UTC day even when the offset would move it', async () => {
+      // 23:30 at UTC−05:00 is already the next UTC day. `date_trunc` truncates in
+      // the SESSION timezone, so without the explicit UTC cast the SQL would
+      // bucket this differently from `utcDateKey`.
+      await store.save(sub({ originalTransactionId: 'edge', purchasedAt: '2026-04-10T23:30:00-05:00' }));
+      const sql = await store.aggregateStarted!({ from, to, groupBy: 'day' });
+      const memory = aggregateRange(await store.listAll(), {
+        fromMs: from.getTime(),
+        toMs: to.getTime(),
+        groupBy: 'day',
+        anchor: (s) => s.purchasedAt,
+      });
+      expect(sql).toEqual(memory);
+      expect(sql.buckets!.find((b) => b.date === '2026-04-11')?.count).toBe(1);
+      expect(sql.buckets!.find((b) => b.date === '2026-04-10')?.count).toBe(0);
+    });
+
+    it('agrees on expired, which filters by status as well as window', async () => {
+      await store.save(sub({ originalTransactionId: 'exp', status: 'expired', expiresAt: '2026-04-10T00:00:00.000Z' }));
+      await store.save(sub({ originalTransactionId: 'can', status: 'canceled', expiresAt: '2026-04-20T00:00:00.000Z', productId: 'pro_yearly' }));
+      // Still active, expiry inside the window — must not count.
+      await store.save(sub({ originalTransactionId: 'act', status: 'active', expiresAt: '2026-04-25T00:00:00.000Z' }));
+      // Ended, expiry outside the window.
+      await store.save(sub({ originalTransactionId: 'old', status: 'expired', expiresAt: '2026-01-01T00:00:00.000Z' }));
+
+      const sql = await store.aggregateExpired!({ from, to, groupBy: 'day' });
+      const memory = aggregateRange(await store.listAll(), {
+        fromMs: from.getTime(),
+        toMs: to.getTime(),
+        groupBy: 'day',
+        anchor: (s) => s.expiresAt,
+        include: isEndedSubscription,
+      });
+      expect(sql).toEqual(memory);
+      expect(sql.total).toBe(2);
+    });
+
+    it('agrees on purchases started, which filters consumables out', async () => {
+      await purchaseStore.savePurchase(purchase({ transactionId: 'n1', purchasedAt: '2026-04-05T00:00:00.000Z' }));
+      await purchaseStore.savePurchase(purchase({ transactionId: 'c1', productId: 'coins', type: 'consumable', purchasedAt: '2026-04-06T00:00:00.000Z' }));
+      await purchaseStore.savePurchase(purchase({ transactionId: 'n2', productId: 'remove_ads', purchasedAt: '2026-05-10T00:00:00.000Z' }));
+
+      const sql = await purchaseStore.aggregateStarted!({ from, to, groupBy: 'day' });
+      const memory = aggregateRange(await purchaseStore.listAll(), {
+        fromMs: from.getTime(),
+        toMs: to.getTime(),
+        groupBy: 'day',
+        anchor: (p) => p.purchasedAt,
+        include: isNonConsumable,
+      });
+      expect(sql).toEqual(memory);
+      expect(sql.total).toBe(1);
+    });
+
+    it('agrees even when the database session is not in UTC', async () => {
+      // This is the test that has to exist rather than be assumed. `date_trunc`
+      // truncates in the SESSION timezone, so the aggregate is only correct
+      // because of an explicit `AT TIME ZONE 'UTC'`. A CI container running UTC
+      // cannot tell a correct implementation from one missing that cast — every
+      // other test here would pass either way. So this one forces a hostile
+      // session timezone and re-checks the equivalence.
+      const url = new URL(DATABASE_URL!);
+      url.searchParams.set('options', '-c timezone=America/New_York');
+      const skewed = new PostgresSubscriptionStore(url.toString());
+      try {
+        // 02:00 UTC is still the previous day in New York, so a session-local
+        // truncation would file this under 2026-04-09.
+        await store.save(sub({ originalTransactionId: 'tz', purchasedAt: '2026-04-10T02:00:00.000Z' }));
+
+        const sql = await skewed.aggregateStarted!({ from, to, groupBy: 'day' });
+        const memory = aggregateRange(await store.listAll(), {
+          fromMs: from.getTime(),
+          toMs: to.getTime(),
+          groupBy: 'day',
+          anchor: (s) => s.purchasedAt,
+        });
+
+        expect(sql).toEqual(memory);
+        expect(sql.buckets!.find((b) => b.date === '2026-04-10')?.count).toBe(1);
+        expect(sql.buckets!.find((b) => b.date === '2026-04-09')?.count).toBe(0);
+      } finally {
+        await skewed.close();
+      }
+    });
+
+    it('agrees when nothing falls in the window', async () => {
+      await store.save(sub({ originalTransactionId: 'far', purchasedAt: '2020-01-01T00:00:00.000Z' }));
+      const sql = await store.aggregateStarted!({ from, to, groupBy: 'day' });
+      const memory = aggregateRange(await store.listAll(), {
+        fromMs: from.getTime(),
+        toMs: to.getTime(),
+        groupBy: 'day',
+        anchor: (s) => s.purchasedAt,
+      });
+      expect(sql).toEqual(memory);
+      expect(sql.total).toBe(0);
+      expect(sql.byProduct).toEqual({});
+      // Still a full zero-filled series, so a chart renders flat rather than empty.
+      expect(sql.buckets).toHaveLength(30);
     });
   });
 

--- a/packages/server/src/metrics-aggregate.ts
+++ b/packages/server/src/metrics-aggregate.ts
@@ -6,6 +6,11 @@ import type {
   SubscriptionInfo,
 } from '@onesub/shared';
 import { PURCHASE_TYPE, SUBSCRIPTION_STATUS } from '@onesub/shared';
+import type {
+  ActiveSubscriptionAggregate,
+  MetricsRangeAggregate,
+  NonConsumablePurchaseAggregate,
+} from './store.js';
 
 /**
  * In-memory reduction of store records into the metrics responses.
@@ -30,14 +35,13 @@ interface Countable {
   platform: string;
 }
 
-/** The count-shaped part of a metrics response; the route adds `from`/`to`. */
-export interface RangeAggregate {
-  total: number;
-  byProduct: Record<string, number>;
-  byPlatform: Record<string, number>;
-  /** Present only when `groupBy: 'day'` was requested. */
-  buckets?: MetricsBucket[];
-}
+/**
+ * The count-shaped part of a metrics response; the route adds `from`/`to`.
+ *
+ * Aliased to the store contract rather than declared separately, so the SQL
+ * implementations and this reducer cannot drift into different shapes.
+ */
+export type RangeAggregate = MetricsRangeAggregate;
 
 export interface RangeAggregateOptions<T> {
   /** Inclusive window bounds, ms-since-epoch. */
@@ -162,35 +166,81 @@ export function aggregateActive(
   purchases: readonly PurchaseInfo[],
   nowMs: number,
 ): MetricsActiveResponse {
+  return composeActiveResponse(
+    aggregateActiveSubscriptions(subs, nowMs),
+    aggregateNonConsumablePurchases(purchases),
+  );
+}
+
+/**
+ * Subscription half of the active snapshot.
+ *
+ * Split from the purchase half so the metrics route can take each from its own
+ * store's SQL aggregate, or fall back to this, independently — a deployment can
+ * have a Postgres subscription store and a custom purchase store.
+ */
+export function aggregateActiveSubscriptions(
+  subs: readonly SubscriptionInfo[],
+  nowMs: number,
+): ActiveSubscriptionAggregate {
   const byProduct: Record<string, number> = {};
-  const byProductPurchases: Record<string, number> = {};
   const byPlatform: Record<string, number> = {};
-  let activeSubscriptions = 0;
-  let gracePeriodSubscriptions = 0;
-  let nonConsumablePurchases = 0;
+  let active = 0;
+  let gracePeriod = 0;
 
   for (const sub of subs) {
     if (!isActiveSubscription(sub, nowMs)) continue;
-    activeSubscriptions++;
-    if (sub.status === SUBSCRIPTION_STATUS.GRACE_PERIOD) gracePeriodSubscriptions++;
+    active++;
+    if (sub.status === SUBSCRIPTION_STATUS.GRACE_PERIOD) gracePeriod++;
     bump(byProduct, sub.productId);
     bump(byPlatform, sub.platform);
   }
 
+  return { active, gracePeriod, byProduct, byPlatform };
+}
+
+/** Purchase half of the active snapshot. */
+export function aggregateNonConsumablePurchases(
+  purchases: readonly PurchaseInfo[],
+): NonConsumablePurchaseAggregate {
+  const byProduct: Record<string, number> = {};
+  const byPlatform: Record<string, number> = {};
+  let total = 0;
+
   for (const purchase of purchases) {
     if (!isNonConsumable(purchase)) continue;
-    nonConsumablePurchases++;
-    bump(byProductPurchases, purchase.productId);
+    total++;
+    bump(byProduct, purchase.productId);
     bump(byPlatform, purchase.platform);
   }
 
+  return { total, byProduct, byPlatform };
+}
+
+/**
+ * Assemble the wire response from the two halves.
+ *
+ * `byProduct` stays subscriptions-only and `byProductPurchases`
+ * non-consumables-only, so a dashboard can show "subscription mix" and "lifetime
+ * mix" as separate panels. `byPlatform` deliberately spans both — it answers
+ * "where are my paying users", which is not a per-kind question.
+ */
+export function composeActiveResponse(
+  subs: ActiveSubscriptionAggregate,
+  purchases: NonConsumablePurchaseAggregate,
+): MetricsActiveResponse {
+  const byPlatform: Record<string, number> = { ...subs.byPlatform };
+  for (const [platform, count] of Object.entries(purchases.byPlatform)) {
+    byPlatform[platform] = (byPlatform[platform] ?? 0) + count;
+  }
+
   return {
-    total: activeSubscriptions + nonConsumablePurchases,
-    activeSubscriptions,
-    gracePeriodSubscriptions,
-    nonConsumablePurchases,
-    byProduct,
-    byProductPurchases,
+    total: subs.active + purchases.total,
+    activeSubscriptions: subs.active,
+    gracePeriodSubscriptions: subs.gracePeriod,
+    nonConsumablePurchases: purchases.total,
+    byProduct: subs.byProduct,
+    byProductPurchases: purchases.byProduct,
     byPlatform,
   };
 }

--- a/packages/server/src/routes/metrics.ts
+++ b/packages/server/src/routes/metrics.ts
@@ -10,13 +10,15 @@ import type {
   SubscriptionInfo,
 } from '@onesub/shared';
 import { ROUTES, ONESUB_ERROR_CODE } from '@onesub/shared';
-import type { PurchaseStore, SubscriptionStore } from '../store.js';
+import type { MetricsRangeQuery, PurchaseStore, SubscriptionStore } from '../store.js';
 import { log } from '../logger.js';
 import { sendError } from '../errors.js';
 import { secretsEqual } from './secret-compare.js';
 import {
-  aggregateActive,
+  aggregateActiveSubscriptions,
+  aggregateNonConsumablePurchases,
   aggregateRange,
+  composeActiveResponse,
   isEndedSubscription,
   isNonConsumable,
   type RangeAggregate,
@@ -36,12 +38,24 @@ export const DEFAULT_METRICS_CACHE_TTL_SECONDS = 30;
  * server doesn't currently track; deferred to a follow-up release that adds
  * `config.products: { 'pro_monthly': { price: 9.99, currency: 'USD' } }`.
  *
- * Aggregation strategy: reads every record via `store.listAll()` and reduces in
- * memory (see `metrics-aggregate.ts` for the reduction, which is where the
- * semantics are tested). That is one full read per computed response, so
- * responses are cached for `config.metricsCacheTtlSeconds` to bound how often
- * it happens — see `metrics-cache.ts`. Removing the per-response scan entirely
- * needs SQL-side aggregation, which is per-store work and still pending.
+ * Aggregation strategy, in order of preference:
+ *
+ *   1. The store's own aggregate (`aggregateActive`, `aggregateStarted`,
+ *      `aggregateExpired`, `aggregateNonConsumable`) when it has one. Postgres
+ *      answers with a `GROUP BY`, so the work is bounded by
+ *      products × platforms × days rather than by row count.
+ *   2. Otherwise `listAll()` plus the in-memory reduction in
+ *      `metrics-aggregate.ts` — the same answer at O(rows), on the event loop.
+ *      That is the path for the in-memory and Redis stores, which have no
+ *      server-side grouping to push into, and for custom stores that predate the
+ *      optional methods.
+ *
+ * `metrics-aggregate.ts` is the definition of what these numbers mean either
+ * way; `postgres-store.test.ts` runs both paths over the same rows and asserts
+ * they agree.
+ *
+ * Responses are additionally cached for `config.metricsCacheTtlSeconds`, which
+ * bounds how often either path runs at all — see `metrics-cache.ts`.
  */
 export function createMetricsRouter(
   config: OneSubServerConfig,
@@ -76,8 +90,18 @@ export function createMetricsRouter(
       const response = await metricsCache.resolve<MetricsActiveResponse>(
         ['active', metricsCache.quantizeToWindow(Date.now())],
         async () => {
-          const [subs, purchases] = await Promise.all([store.listAll(), purchaseStore.listAll()]);
-          return aggregateActive(subs, purchases, Date.now());
+          const now = new Date();
+          // Each half falls back independently — a deployment can pair a Postgres
+          // subscription store with a custom purchase store that has no aggregate.
+          const [subsAgg, purchasesAgg] = await Promise.all([
+            store.aggregateActive
+              ? store.aggregateActive(now)
+              : store.listAll().then((subs) => aggregateActiveSubscriptions(subs, now.getTime())),
+            purchaseStore.aggregateNonConsumable
+              ? purchaseStore.aggregateNonConsumable()
+              : purchaseStore.listAll().then(aggregateNonConsumablePurchases),
+          ]);
+          return composeActiveResponse(subsAgg, purchasesAgg);
         },
       );
       res.status(200).json(response);
@@ -132,6 +156,13 @@ export function createMetricsRouter(
    */
   function windowed<T extends { productId: string; platform: string }>(
     name: string,
+    /**
+     * The store's own SQL aggregate, when it has one. Absent — a custom store, or
+     * in-memory / Redis, where a `GROUP BY` does not exist — and the route reads
+     * every row and reduces via `load`/`anchor`/`include` instead. Same answer,
+     * O(rows) instead of O(products × platforms × days).
+     */
+    sqlAggregate: ((query: MetricsRangeQuery) => Promise<RangeAggregate>) | undefined,
     load: () => Promise<readonly T[]>,
     anchor: (record: T) => string,
     include?: (record: T) => boolean,
@@ -150,14 +181,22 @@ export function createMetricsRouter(
             metricsCache.quantizeToWindow(range.toMs),
             range.groupBy,
           ],
-          async () =>
-            aggregateRange(await load(), {
+          async () => {
+            if (sqlAggregate) {
+              return sqlAggregate({
+                from: new Date(range.fromMs),
+                to: new Date(range.toMs),
+                groupBy: range.groupBy,
+              });
+            }
+            return aggregateRange(await load(), {
               fromMs: range.fromMs,
               toMs: range.toMs,
               groupBy: range.groupBy,
               anchor,
               ...(include ? { include } : {}),
-            }),
+            });
+          },
         );
 
         const response: MetricsCountResponse = {
@@ -178,7 +217,12 @@ export function createMetricsRouter(
   // current status — this is a cohort-start count, not a live-state count.
   router.get(
     ROUTES.METRICS_STARTED,
-    windowed<SubscriptionInfo>('started', () => store.listAll(), (sub) => sub.purchasedAt),
+    windowed<SubscriptionInfo>(
+      'started',
+      store.aggregateStarted?.bind(store),
+      () => store.listAll(),
+      (sub) => sub.purchasedAt,
+    ),
   );
 
   // ── GET /onesub/metrics/expired?from=&to= ────────────────────────────────
@@ -189,6 +233,7 @@ export function createMetricsRouter(
     ROUTES.METRICS_EXPIRED,
     windowed<SubscriptionInfo>(
       'expired',
+      store.aggregateExpired?.bind(store),
       () => store.listAll(),
       (sub) => sub.expiresAt,
       isEndedSubscription,
@@ -207,6 +252,7 @@ export function createMetricsRouter(
     ROUTES.METRICS_PURCHASES_STARTED,
     windowed<PurchaseInfo>(
       'purchases-started',
+      purchaseStore.aggregateStarted?.bind(purchaseStore),
       () => purchaseStore.listAll(),
       (purchase) => purchase.purchasedAt,
       isNonConsumable,

--- a/packages/server/src/store.ts
+++ b/packages/server/src/store.ts
@@ -21,6 +21,61 @@ export interface ListFilteredResult {
   offset: number;
 }
 
+// ---------------------------------------------------------------------------
+// Metrics aggregates
+//
+// The `/onesub/metrics/*` routes need counts, not records. A store that can
+// compute them itself — `GROUP BY` in SQL — spares the process reading every
+// row and reducing it on the event loop. These methods are OPTIONAL: a store
+// without them falls back to `listAll()` plus the in-memory reduction in
+// `metrics-aggregate.ts`, which is the same answer at O(rows) cost.
+//
+// `metrics-aggregate.ts` is the executable definition of these shapes. Any
+// SQL implementation has to reproduce it exactly, including the UTC calendar-day
+// bucket boundaries and the inclusive window — which is what the equivalence
+// tests in `postgres-store.test.ts` assert, by running both and comparing.
+// ---------------------------------------------------------------------------
+
+/** One day of a daily series. `date` is a UTC `YYYY-MM-DD`. */
+export interface MetricsDayBucket {
+  date: string;
+  count: number;
+}
+
+/** Window to aggregate over. Both bounds are inclusive. */
+export interface MetricsRangeQuery {
+  from: Date;
+  to: Date;
+  /** `'day'` additionally fills a zero-filled bucket per UTC day in the window. */
+  groupBy: 'none' | 'day';
+}
+
+/** Counts for a windowed query. */
+export interface MetricsRangeAggregate {
+  total: number;
+  byProduct: Record<string, number>;
+  byPlatform: Record<string, number>;
+  /** Present only for `groupBy: 'day'`; zero-filled across the whole window. */
+  buckets?: MetricsDayBucket[];
+}
+
+/** Point-in-time counts for subscriptions that currently grant entitlement. */
+export interface ActiveSubscriptionAggregate {
+  /** status active|grace_period AND not yet expired. */
+  active: number;
+  /** The grace_period subset of `active` — the at-risk cohort. */
+  gracePeriod: number;
+  byProduct: Record<string, number>;
+  byPlatform: Record<string, number>;
+}
+
+/** Counts for non-consumable purchases (lifetime products). */
+export interface NonConsumablePurchaseAggregate {
+  total: number;
+  byProduct: Record<string, number>;
+  byPlatform: Record<string, number>;
+}
+
 /**
  * Pluggable subscription store interface.
  * Default is in-memory. Replace with a PostgreSQL/Redis implementation
@@ -62,6 +117,24 @@ export interface SubscriptionStore {
    * the in-memory store and `updated_at DESC` for Postgres/Redis.
    */
   getAllByUserId(userId: string): Promise<SubscriptionInfo[]>;
+  /**
+   * OPTIONAL. Counts of subscriptions currently granting entitlement, as of
+   * `now`. Equivalent to `aggregateActiveSubscriptions(await listAll(), now)`.
+   */
+  aggregateActive?(now: Date): Promise<ActiveSubscriptionAggregate>;
+  /**
+   * OPTIONAL. Subscriptions whose `purchasedAt` falls in the window, whatever
+   * their current status — a cohort-start count. Equivalent to
+   * `aggregateRange(await listAll(), { anchor: purchasedAt, ... })`.
+   */
+  aggregateStarted?(query: MetricsRangeQuery): Promise<MetricsRangeAggregate>;
+  /**
+   * OPTIONAL. Subscriptions that are currently expired or canceled AND whose
+   * `expiresAt` falls in the window. A still-active record does not count even
+   * if its expiry lands inside the window. Equivalent to
+   * `aggregateRange(await listAll(), { anchor: expiresAt, include: isEnded })`.
+   */
+  aggregateExpired?(query: MetricsRangeQuery): Promise<MetricsRangeAggregate>;
 }
 
 /**
@@ -198,6 +271,18 @@ export interface PurchaseStore {
    * Returns true if a row was updated, false if the transactionId was not found.
    */
   reassignPurchase(transactionId: string, newUserId: string): Promise<boolean>;
+  /**
+   * OPTIONAL. Counts of non-consumable purchases. Consumables are excluded —
+   * they grant a spent resource, not an ongoing right. Equivalent to
+   * `aggregateNonConsumablePurchases(await listAll())`.
+   */
+  aggregateNonConsumable?(): Promise<NonConsumablePurchaseAggregate>;
+  /**
+   * OPTIONAL. Non-consumable purchases whose `purchasedAt` falls in the window.
+   * Equivalent to
+   * `aggregateRange(await listAll(), { anchor: purchasedAt, include: isNonConsumable })`.
+   */
+  aggregateStarted?(query: MetricsRangeQuery): Promise<MetricsRangeAggregate>;
 }
 
 /**

--- a/packages/server/src/stores/postgres.ts
+++ b/packages/server/src/stores/postgres.ts
@@ -1,10 +1,17 @@
 import type { SubscriptionInfo, PurchaseInfo } from '@onesub/shared';
+import { PURCHASE_TYPE, SUBSCRIPTION_STATUS } from '@onesub/shared';
 import type {
   SubscriptionStore,
   PurchaseStore,
   ListFilteredOptions,
   ListFilteredResult,
+  ActiveSubscriptionAggregate,
+  MetricsRangeAggregate,
+  MetricsRangeQuery,
+  NonConsumablePurchaseAggregate,
 } from '../store.js';
+// Shared with the in-memory reduction so both paths agree on UTC day boundaries.
+import { emptyDailyBuckets } from '../metrics-aggregate.js';
 import { SUBSCRIPTIONS_SCHEMA_SQL, PURCHASES_SCHEMA_SQL } from './schema.js';
 import { log } from '../logger.js';
 
@@ -218,6 +225,56 @@ export class PostgresSubscriptionStore implements SubscriptionStore {
     };
   }
 
+  /**
+   * Counts of subscriptions currently granting entitlement.
+   *
+   * One `GROUP BY` instead of reading every row into the process. Grouping by
+   * status as well as product/platform is what lets the grace-period subset come
+   * out of the same query.
+   */
+  async aggregateActive(now: Date): Promise<ActiveSubscriptionAggregate> {
+    const pool = await this.getPool();
+    const result = await pool.query<{ product_id: string; platform: string; status: string; n: string }>(
+      `SELECT product_id, platform, status, COUNT(*)::text AS n
+         FROM onesub_subscriptions
+        WHERE status IN ($1, $2) AND expires_at > $3
+        GROUP BY product_id, platform, status`,
+      [SUBSCRIPTION_STATUS.ACTIVE, SUBSCRIPTION_STATUS.GRACE_PERIOD, now],
+    );
+
+    const byProduct: Record<string, number> = {};
+    const byPlatform: Record<string, number> = {};
+    let active = 0;
+    let gracePeriod = 0;
+    for (const row of result.rows) {
+      const n = parseInt(row.n, 10);
+      active += n;
+      if (row.status === SUBSCRIPTION_STATUS.GRACE_PERIOD) gracePeriod += n;
+      byProduct[row.product_id] = (byProduct[row.product_id] ?? 0) + n;
+      byPlatform[row.platform] = (byPlatform[row.platform] ?? 0) + n;
+    }
+    return { active, gracePeriod, byProduct, byPlatform };
+  }
+
+  /** Cohort-start counts: subscriptions whose `purchased_at` is in the window. */
+  async aggregateStarted(query: MetricsRangeQuery): Promise<MetricsRangeAggregate> {
+    const pool = await this.getPool();
+    return aggregateViaSql(pool, 'onesub_subscriptions', 'purchased_at', query);
+  }
+
+  /**
+   * Subscriptions that have ended AND whose `expires_at` is in the window. A
+   * still-active record does not count even if its expiry lands inside it — see
+   * `isEndedSubscription`, which this mirrors.
+   */
+  async aggregateExpired(query: MetricsRangeQuery): Promise<MetricsRangeAggregate> {
+    const pool = await this.getPool();
+    return aggregateViaSql(pool, 'onesub_subscriptions', 'expires_at', query, {
+      column: 'status',
+      values: [SUBSCRIPTION_STATUS.EXPIRED, SUBSCRIPTION_STATUS.CANCELED],
+    });
+  }
+
   /** Gracefully close the underlying connection pool. */
   async close(): Promise<void> {
     if (this.poolPromise) {
@@ -400,6 +457,38 @@ export class PostgresPurchaseStore implements PurchaseStore {
     return result.rows.map(rowToPurchaseInfo);
   }
 
+  /** Counts of non-consumable purchases. Consumables are excluded. */
+  async aggregateNonConsumable(): Promise<NonConsumablePurchaseAggregate> {
+    const pool = await this.getPool();
+    const result = await pool.query<{ product_id: string; platform: string; n: string }>(
+      `SELECT product_id, platform, COUNT(*)::text AS n
+         FROM onesub_purchases
+        WHERE type = $1
+        GROUP BY product_id, platform`,
+      [PURCHASE_TYPE.NON_CONSUMABLE],
+    );
+
+    const byProduct: Record<string, number> = {};
+    const byPlatform: Record<string, number> = {};
+    let total = 0;
+    for (const row of result.rows) {
+      const n = parseInt(row.n, 10);
+      total += n;
+      byProduct[row.product_id] = (byProduct[row.product_id] ?? 0) + n;
+      byPlatform[row.platform] = (byPlatform[row.platform] ?? 0) + n;
+    }
+    return { total, byProduct, byPlatform };
+  }
+
+  /** Non-consumable purchases whose `purchased_at` is in the window. */
+  async aggregateStarted(query: MetricsRangeQuery): Promise<MetricsRangeAggregate> {
+    const pool = await this.getPool();
+    return aggregateViaSql(pool, 'onesub_purchases', 'purchased_at', query, {
+      column: 'type',
+      values: [PURCHASE_TYPE.NON_CONSUMABLE],
+    });
+  }
+
   /** Gracefully close the underlying connection pool. */
   async close(): Promise<void> {
     if (this.poolPromise) {
@@ -408,6 +497,78 @@ export class PostgresPurchaseStore implements PurchaseStore {
       this.poolPromise = null;
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Metrics aggregation
+// ---------------------------------------------------------------------------
+
+/**
+ * Windowed count aggregation, pushed into SQL.
+ *
+ * Replaces "read every row, reduce on the event loop" with one `GROUP BY` whose
+ * result set is bounded by products × platforms (× days when bucketing), not by
+ * row count.
+ *
+ * `table`, `anchorColumn`, and `filter.column` are literals chosen by the caller
+ * — SQL cannot parameterise identifiers. Every *value* is parameterised.
+ *
+ * The output has to match `aggregateRange` in `metrics-aggregate.ts` exactly,
+ * including zero-filled buckets across the whole window, because
+ * `postgres-store.test.ts` runs both over the same data and compares.
+ */
+async function aggregateViaSql(
+  pool: import('pg').Pool,
+  table: string,
+  anchorColumn: string,
+  query: MetricsRangeQuery,
+  filter?: { column: string; values: readonly string[] },
+): Promise<MetricsRangeAggregate> {
+  const params: unknown[] = [query.from, query.to];
+  let filterClause = '';
+  if (filter) {
+    const placeholders = filter.values.map((_, i) => `$${params.length + i + 1}`).join(', ');
+    filterClause = `AND ${filter.column} IN (${placeholders})`;
+    params.push(...filter.values);
+  }
+
+  const bucketing = query.groupBy === 'day';
+  // `date_trunc` truncates in the SESSION timezone, so the cast to UTC is
+  // load-bearing: without it the same data buckets differently depending on the
+  // server's timezone, and stops matching `utcDateKey`.
+  const dayExpr = `to_char(date_trunc('day', ${anchorColumn} AT TIME ZONE 'UTC'), 'YYYY-MM-DD')`;
+
+  const result = await pool.query<{ product_id: string; platform: string; day?: string; n: string }>(
+    `SELECT product_id, platform,${bucketing ? ` ${dayExpr} AS day,` : ''}
+            COUNT(*)::text AS n
+       FROM ${table}
+      WHERE ${anchorColumn} >= $1 AND ${anchorColumn} <= $2 ${filterClause}
+      GROUP BY product_id, platform${bucketing ? ', day' : ''}`,
+    params,
+  );
+
+  const byProduct: Record<string, number> = {};
+  const byPlatform: Record<string, number> = {};
+  const perDay = new Map<string, number>();
+  let total = 0;
+
+  for (const row of result.rows) {
+    const n = parseInt(row.n, 10);
+    total += n;
+    byProduct[row.product_id] = (byProduct[row.product_id] ?? 0) + n;
+    byPlatform[row.platform] = (byPlatform[row.platform] ?? 0) + n;
+    if (bucketing && row.day) perDay.set(row.day, (perDay.get(row.day) ?? 0) + n);
+  }
+
+  if (!bucketing) return { total, byProduct, byPlatform };
+
+  // Zero-fill from the same helper the in-memory path uses, so the two agree on
+  // where a window starts and ends rather than each deciding for itself.
+  const buckets = emptyDailyBuckets(query.from.getTime(), query.to.getTime()).map((b) => ({
+    date: b.date,
+    count: perDay.get(b.date) ?? 0,
+  }));
+  return { total, byProduct, byPlatform, buckets };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
The last performance item from the #124 review — deferred there because the SQL
could not be verified, and unblocked by the Postgres coverage in #135.

## What changed

Each `/onesub/metrics/*` request read the **entire** subscription or purchase table
and reduced it on the event loop, competing with receipt validation. The cache in
#124 bounded how often that happened; it did not make the scan cheaper.

`SubscriptionStore` and `PurchaseStore` gain optional aggregate methods
(`aggregateActive`, `aggregateStarted`, `aggregateExpired`,
`aggregateNonConsumable`). The Postgres stores implement them as `GROUP BY`, so the
work is bounded by products × platforms (× days when bucketing) instead of by row
count.

**Optional, so nothing breaks.** A store without them falls back to the previous
`listAll()` + in-memory reduction — the path the in-memory and Redis stores keep,
since neither has server-side grouping to push into. Custom stores written before
these methods keep working. `/onesub/metrics/active` resolves each half
independently, so a Postgres subscription store pairs fine with a custom purchase
store.

## How it is verified

`metrics-aggregate.ts` was already the definition of what these numbers mean. It is
now what the SQL is **checked against** rather than a comment claiming it should be:
`postgres-store.test.ts` runs both paths over the same rows and asserts the results
are identical — inclusive window bounds, the strictly-greater-than expiry boundary,
status/type filters, and zero-filled UTC calendar-day buckets. `RangeAggregate` is
aliased to the store contract so the two shapes cannot drift.

Four mutations, run against a real database, confirm the tests bite:

| Mutation | Tests failed |
|---|---|
| Drop `product_id` from the scoped lookup | 3 |
| Make the window upper bound exclusive | 2 |
| Drop `expires_at >` from the active filter | 3 |
| Drop the `AT TIME ZONE 'UTC'` cast | 1 |

## The timezone finding

Worth calling out because **a green CI would not have caught it.** `date_trunc`
truncates in the database session's timezone, so the daily buckets are only correct
because of an explicit `AT TIME ZONE 'UTC'` cast. On a UTC runner, a missing cast
produces identical output — every other test passes either way.

This surfaced only because the local database session was `Asia/Seoul`, where the
mutation failed instantly. Demonstration:

```
New_York session, input 2026-04-11T02:00:00Z
  with    AT TIME ZONE 'UTC' → 2026-04-11   (correct)
  without                    → 2026-04-10   (off by a day)
```

There is now a test that forces a non-UTC session on its own connection, so the
check holds on a UTC runner too — verified by re-running the mutation with the
session pinned to UTC, where it still fails.

## Docs

- `docs/ARCHITECTURE.md` — the new optional methods, which stores implement them and
  why the others deliberately do not.
- `docs/TESTING.md` — a **rootless** way to get a local Postgres, for environments
  where the Docker daemon is running but the user is not in the `docker` group and
  `sudo` wants a password. That is how this change was verified. It stays outside the
  repo so the root lockfile is untouched, and the note explains why a non-UTC local
  timezone is a feature here.
- `AGENTS.md` — points at that section rather than repeating it.

## Verification

763 tests with a database (724 + 39 skipped without). `build`, `type-check`, `size`
(36.69/38 KB, measurement recorded), `docs:check`,
`validate-unity-packages.ps1`, dashboard build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)