### PR TITLE
test(sdk): render the provider; fix the fixable CodeQL alerts

### DIFF
--- a/.changeset/quiet-logs-escape.md
+++ b/.changeset/quiet-logs-escape.md
@@ -1,0 +1,19 @@
+---
+'@onesub/server': patch
+---
+
+Stop a caller from forging log lines.
+
+Much of what this server logs is attacker-influenced: `userId` arrives in the
+request body, and bundle ids, package names and receipt previews come out of
+submitted receipts. A newline in any of those let a caller end the current log line
+and write an entry of their own — a `userId` of `alice\n[onesub] admin granted
+premium to mallory` forges an audit record. These logs are what support and fraud
+decisions get read from.
+
+`log.info/warn/error` now escape `\r`, `\n`, U+2028 and U+2029 in top-level string
+arguments. Escaped rather than stripped, so the substitution stays visible instead
+of quietly merging two lines into one plausible-looking line. Tabs and other
+characters are untouched, and non-string arguments — objects, `Error`s — pass
+through unchanged, since a structured logger serialises those itself and rewriting
+them would corrupt what the operator asked to see.

--- a/.changeset/tidy-paywall-escape.md
+++ b/.changeset/tidy-paywall-escape.md
@@ -1,0 +1,13 @@
+---
+'@onesub/mcp-server': patch
+---
+
+Fix escaping in the generated paywall's feature list.
+
+`add-paywall` built the feature array by escaping `'` and nothing else, so a feature
+string containing a backslash escaped its own closing quote — breaking the generated
+component, or extending it with whatever followed. Feature names reach this from tool
+input, so the input that triggers it is not hypothetical.
+
+Now uses `JSON.stringify` per entry, which escapes quotes, backslashes and control
+characters correctly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,57 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
@@ -309,6 +360,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@changesets/apply-release-plan": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.1.1.tgz",
@@ -549,6 +613,146 @@
         "fs-extra": "^7.0.1",
         "human-id": "^4.1.1",
         "prettier": "^2.7.1"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1050,6 +1254,24 @@
       "peer": true,
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@hono/node-server": {
@@ -3909,6 +4131,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
@@ -4499,6 +4731,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -4627,6 +4873,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -4643,6 +4903,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -4804,6 +5071,19 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-stack-parser": {
@@ -5581,6 +5861,19 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -5823,6 +6116,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -6014,6 +6314,57 @@
       "integrity": "sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==",
       "license": "0BSD",
       "peer": true
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -6477,6 +6828,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "1.1.1",
@@ -7295,6 +7653,19 @@
         "quansync": "^0.2.7"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -7693,6 +8064,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -8248,6 +8629,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -8790,6 +9184,13 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
@@ -8955,6 +9356,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.9"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
@@ -8991,6 +9412,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tree-kill": {
@@ -9130,6 +9577,16 @@
       "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "8.3.0",
@@ -9448,6 +9905,19 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -9458,12 +9928,47 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -9542,6 +10047,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -9635,10 +10157,10 @@
     },
     "packages/cli": {
       "name": "@onesub/cli",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "license": "MIT",
       "dependencies": {
-        "@onesub/server": "0.22.0",
+        "@onesub/server": "0.23.0",
         "@onesub/shared": "0.15.0",
         "express": "^5.2.1"
       },
@@ -9786,6 +10308,9 @@
       },
       "devDependencies": {
         "@types/react": "^19.2.17",
+        "jsdom": "^29.1.1",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
         "typescript": "^5.7.0"
       },
       "peerDependencies": {
@@ -9805,7 +10330,7 @@
     },
     "packages/server": {
       "name": "@onesub/server",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "license": "MIT",
       "dependencies": {
         "@onesub/shared": "0.15.0",

--- a/packages/mcp-server/src/tools/add-paywall.ts
+++ b/packages/mcp-server/src/tools/add-paywall.ts
@@ -80,7 +80,10 @@ export function runAddPaywall(args: {
 }
 
 function featureData(features: string[]): string {
-  return features.map((f) => `  '${f.replace(/'/g, "\\'")}',`).join('\n');
+  // JSON.stringify rather than escaping quotes by hand: the previous version
+  // escaped `'` but not `\`, so a feature ending in a backslash escaped its own
+  // closing quote and broke — or extended — the generated source.
+  return features.map((f) => `  ${JSON.stringify(f)},`).join('\n');
 }
 
 function buildMinimalPaywall(opts: { title: string; features: string[]; price: string }): string {

--- a/packages/providers/src/__tests__/google.test.ts
+++ b/packages/providers/src/__tests__/google.test.ts
@@ -39,6 +39,20 @@ interface MockCall {
   body?: unknown;
 }
 
+/**
+ * Exact host match. `isGoogleTokenEndpoint(u)` would also accept
+ * `https://evil.test/?x=oauth2.googleapis.com`, which is the pattern CodeQL flags
+ * as `js/incomplete-url-substring-sanitization` — worth not teaching here even in
+ * a test double.
+ */
+function isGoogleTokenEndpoint(url: string): boolean {
+  try {
+    return new URL(url).hostname === 'oauth2.googleapis.com';
+  } catch {
+    return false;
+  }
+}
+
 function mockFetch(
   routes: Array<{ match: (url: string, method: string) => boolean; status?: number; body?: unknown }>,
   opts?: { tokens?: string[] },
@@ -48,7 +62,7 @@ function mockFetch(
   vi.stubGlobal('fetch', vi.fn(async (url: string | URL, init?: RequestInit) => {
     const u = String(url);
     const method = init?.method ?? 'GET';
-    if (u.includes('oauth2.googleapis.com')) {
+    if (isGoogleTokenEndpoint(u)) {
       const token = opts?.tokens?.[tokenCount] ?? `tok_${tokenCount}`;
       tokenCount += 1;
       calls.push({ url: u, method });
@@ -74,7 +88,7 @@ function mockFetchSequence(
   let i = 0;
   vi.stubGlobal('fetch', vi.fn(async (url: string | URL) => {
     const u = String(url);
-    if (u.includes('oauth2.googleapis.com')) {
+    if (isGoogleTokenEndpoint(u)) {
       const token = JSON.stringify({ access_token: 'tok_seq' });
       return { ok: true, status: 200, headers: new Headers(), text: async () => token, json: async () => JSON.parse(token) } as Response;
     }
@@ -135,7 +149,7 @@ describe('playRequest — 429 retry', () => {
     const assertions: string[] = [];
     vi.stubGlobal('fetch', vi.fn(async (url: string | URL, init?: RequestInit) => {
       const u = String(url);
-      if (u.includes('oauth2.googleapis.com')) {
+      if (isGoogleTokenEndpoint(u)) {
         tokenCalls += 1;
         assertions.push(new URLSearchParams(String(init?.body)).get('assertion') ?? '');
         if (tokenCalls === 1) {
@@ -175,7 +189,7 @@ describe('token cache isolation', () => {
     await listProducts({ packageName: 'com.a', serviceAccountKey: keyA });
     await listProducts({ packageName: 'com.b', serviceAccountKey: keyB });
 
-    const tokenFetches = calls.filter((c) => c.url.includes('oauth2.googleapis.com'));
+    const tokenFetches = calls.filter((c) => isGoogleTokenEndpoint(c.url));
     expect(tokenFetches).toHaveLength(2);
   });
 });

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -57,6 +57,9 @@
   },
   "devDependencies": {
     "@types/react": "^19.2.17",
+    "jsdom": "^29.1.1",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
     "typescript": "^5.7.0"
   }
 }

--- a/packages/sdk/src/__tests__/OneSubProvider.test.ts
+++ b/packages/sdk/src/__tests__/OneSubProvider.test.ts
@@ -1,0 +1,450 @@
+// @vitest-environment jsdom
+/**
+ * OneSubProvider — mount, context, and re-render behaviour.
+ *
+ * This package had no render test at all: `purchaseFlow.test.ts` covers the pure
+ * decision logic, which is exactly why that logic was split out, but nothing
+ * exercised the React half. So the provider's mount sequence, its context
+ * contract, and the `null`-vs-throw semantics that host apps depend on were
+ * verified only by reading them — and the referential-stability work in 0.10.4
+ * shipped that way too.
+ *
+ * `react-native-iap` is deliberately NOT installed here, which is a supported
+ * configuration rather than a gap: the provider must still import, render, and
+ * report a clear error from the purchase paths. It also keeps `react-native`
+ * itself out of the picture, since `getCurrentPlatform()` is only reached once an
+ * IAP adapter exists.
+ *
+ * Written with `createElement` rather than JSX so the file is a `.test.ts` and is
+ * picked up by the repository's existing Vitest include pattern.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, createElement, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { OneSubConfig, StatusResponse } from '@onesub/shared';
+import { ONESUB_ERROR_CODE } from '@onesub/shared';
+import { OneSubProvider, useOneSubContext, type OneSubContextValue } from '../OneSubProvider.js';
+import { OneSubError } from '../OneSubError.js';
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+// React refuses to let `act()` flush updates without this, and instead logs
+// "not configured to support act(...)" — which would otherwise be the only thing
+// the unmount test's console.error assertion ever caught.
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const SERVER = 'https://api.example.test';
+
+interface ServerState {
+  status: StatusResponse;
+  entitlements: Record<string, { active: boolean; source: string | null }>;
+  statusFails: boolean;
+}
+
+let server: ServerState;
+let container: HTMLDivElement;
+let root: Root;
+
+/** Records every context value this component was rendered with. */
+interface Probe {
+  renders: OneSubContextValue[];
+  latest: () => OneSubContextValue;
+  count: () => number;
+}
+
+function makeProbe(): { probe: Probe; element: ReactNode } {
+  const renders: OneSubContextValue[] = [];
+  function Consumer() {
+    const ctx = useOneSubContext();
+    renders.push(ctx);
+    return null;
+  }
+  return {
+    probe: {
+      renders,
+      latest: () => renders[renders.length - 1]!,
+      count: () => renders.length,
+    },
+    element: createElement(Consumer),
+  };
+}
+
+function baseConfig(overrides?: Partial<OneSubConfig>): OneSubConfig {
+  return { serverUrl: SERVER, productId: 'pro_monthly', ...overrides };
+}
+
+/** Mount the provider and flush the mount effects. */
+async function mount(config: OneSubConfig, userId = 'alice', children: ReactNode = null) {
+  await act(async () => {
+    // `children` is required on OneSubProviderProps, so it goes in the props
+    // object rather than as a positional argument.
+    root.render(createElement(OneSubProvider, { config, userId, children }));
+  });
+}
+
+/** Re-render with new props, flushing effects. */
+async function rerender(config: OneSubConfig, userId = 'alice', children: ReactNode = null) {
+  await act(async () => {
+    root.render(createElement(OneSubProvider, { config, userId, children }));
+  });
+}
+
+beforeEach(() => {
+  server = {
+    status: { active: false, subscription: null },
+    entitlements: {},
+    statusFails: false,
+  };
+
+  vi.stubGlobal('fetch', async (input: string | URL) => {
+    const url = String(input);
+    if (url.includes('/onesub/status')) {
+      if (server.statusFails) throw new Error('network down');
+      return new Response(JSON.stringify(server.status), { status: 200 });
+    }
+    if (url.includes('/onesub/entitlements')) {
+      return new Response(JSON.stringify({ entitlements: server.entitlements }), { status: 200 });
+    }
+    return new Response('{}', { status: 404 });
+  });
+
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+
+describe('mount', () => {
+  it('renders its children', async () => {
+    await mount(baseConfig(), 'alice', createElement('span', { id: 'child' }, 'hello'));
+    expect(container.querySelector('#child')?.textContent).toBe('hello');
+  });
+
+  it('adopts the subscription state the server reports', async () => {
+    server.status = {
+      active: true,
+      subscription: {
+        userId: 'alice',
+        productId: 'pro_monthly',
+        platform: 'apple',
+        status: 'active',
+        expiresAt: '2099-01-01T00:00:00.000Z',
+        purchasedAt: '2026-01-01T00:00:00.000Z',
+        originalTransactionId: 'tx-1',
+        willRenew: true,
+      },
+    };
+    const { probe, element } = makeProbe();
+    await mount(baseConfig(), 'alice', element);
+
+    expect(probe.latest().isActive).toBe(true);
+    expect(probe.latest().subscription?.originalTransactionId).toBe('tx-1');
+    expect(probe.latest().isLoading).toBe(false);
+  });
+
+  it('loads the entitlements map', async () => {
+    server.entitlements = { premium: { active: true, source: 'subscription' } };
+    const { probe, element } = makeProbe();
+    await mount(baseConfig(), 'alice', element);
+
+    expect(probe.latest().entitlements.premium?.active).toBe(true);
+    expect(probe.latest().hasEntitlement('premium')).toBe(true);
+    expect(probe.latest().hasEntitlement('nope')).toBe(false);
+  });
+
+  it('survives a status request that fails, reporting not-active', async () => {
+    // A host must still get a usable provider when the server is unreachable —
+    // the alternative is an unhandled rejection at app launch.
+    server.statusFails = true;
+    const { probe, element } = makeProbe();
+    await mount(baseConfig(), 'alice', element);
+
+    expect(probe.latest().isActive).toBe(false);
+    expect(probe.latest().subscription).toBeNull();
+    expect(probe.latest().isLoading).toBe(false);
+  });
+
+  it('exposes the whole documented context surface', async () => {
+    const { probe, element } = makeProbe();
+    await mount(baseConfig(), 'alice', element);
+
+    const ctx = probe.latest();
+    for (const key of [
+      'subscribe',
+      'subscribeWithResult',
+      'restore',
+      'purchaseProduct',
+      'restoreProduct',
+      'refreshEntitlements',
+      'hasEntitlement',
+    ] as const) {
+      expect(typeof ctx[key]).toBe('function');
+    }
+    expect(ctx.isBusy).toBe(false);
+  });
+});
+
+describe('useOneSub outside a provider', () => {
+  it('throws NOT_IN_PROVIDER rather than returning undefined', async () => {
+    const { element } = makeProbe();
+    let caught: unknown;
+    // React logs the error boundary miss; swallow it to keep output readable.
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await act(async () => {
+        root.render(element);
+      });
+    } catch (err) {
+      caught = err;
+    } finally {
+      spy.mockRestore();
+    }
+    expect(caught).toBeInstanceOf(OneSubError);
+    expect((caught as OneSubError).code).toBe(ONESUB_ERROR_CODE.NOT_IN_PROVIDER);
+  });
+});
+
+describe('context identity (0.10.4 memoization)', () => {
+  it('does not hand consumers a new context on a parent re-render', async () => {
+    // The regression this guards: the value object was rebuilt every render and
+    // the callbacks depended on the whole `config` object, so a host passing an
+    // inline literal re-rendered every useOneSub() consumer on any parent render.
+    const { probe, element } = makeProbe();
+    await mount(baseConfig(), 'alice', element);
+    const before = probe.count();
+    const identity = probe.latest();
+
+    // A fresh config object each time, exactly as `config={{ ... }}` produces.
+    await rerender(baseConfig(), 'alice', element);
+    await rerender(baseConfig(), 'alice', element);
+    await rerender(baseConfig(), 'alice', element);
+
+    expect(probe.latest()).toBe(identity);
+    // Re-renders of the consumer itself are React's business; what must not
+    // happen is the context value changing identity.
+    expect(probe.renders.slice(before).every((c) => c === identity)).toBe(true);
+  });
+
+  it('keeps the purchase callbacks referentially stable across those renders', async () => {
+    const { probe, element } = makeProbe();
+    await mount(baseConfig(), 'alice', element);
+    const first = probe.latest();
+
+    await rerender(baseConfig(), 'alice', element);
+
+    expect(probe.latest().subscribe).toBe(first.subscribe);
+    expect(probe.latest().purchaseProduct).toBe(first.purchaseProduct);
+    expect(probe.latest().restoreProduct).toBe(first.restoreProduct);
+    expect(probe.latest().restore).toBe(first.restore);
+    expect(probe.latest().refreshEntitlements).toBe(first.refreshEntitlements);
+  });
+
+  it('DOES give a new context when the state it carries changes', async () => {
+    // Stability must not be achieved by freezing: a state change has to
+    // propagate, or consumers would never see a purchase land.
+    server.entitlements = {};
+    const { probe, element } = makeProbe();
+    await mount(baseConfig(), 'alice', element);
+    const before = probe.latest();
+
+    server.entitlements = { premium: { active: true, source: 'subscription' } };
+    await act(async () => {
+      await before.refreshEntitlements();
+    });
+
+    expect(probe.latest()).not.toBe(before);
+    expect(probe.latest().entitlements.premium?.active).toBe(true);
+  });
+});
+
+describe('config read through a ref (0.10.4 staleness fix)', () => {
+  it('a callback sees a config field changed after mount', async () => {
+    // The latent bug: the mount effect re-runs only on serverUrl/userId, so a
+    // callback that closed over `config` kept the value from mount. Here the
+    // productId changes without either of those changing, and mockMode's
+    // synthetic subscription reports which productId the callback actually used.
+    const { probe, element } = makeProbe();
+    await mount(baseConfig({ mockMode: true, productId: 'first' }), 'alice', element);
+
+    await rerender(baseConfig({ mockMode: true, productId: 'second' }), 'alice', element);
+
+    await act(async () => {
+      await probe.latest().subscribe();
+    });
+
+    expect(probe.latest().subscription?.productId).toBe('second');
+  });
+
+  it('uses the platform-specific product id when one is given', async () => {
+    const { probe, element } = makeProbe();
+    await mount(
+      baseConfig({ mockMode: true, productId: 'generic', appleProductId: 'apple_only' }),
+      'alice',
+      element,
+    );
+
+    await act(async () => {
+      await probe.latest().subscribe();
+    });
+
+    expect(probe.latest().subscription?.productId).toBe('apple_only');
+  });
+});
+
+describe('without react-native-iap installed', () => {
+  it('subscribe rejects with RN_IAP_NOT_INSTALLED', async () => {
+    const { probe, element } = makeProbe();
+    await mount(baseConfig(), 'alice', element);
+
+    await expect(probe.latest().subscribe()).rejects.toMatchObject({
+      code: ONESUB_ERROR_CODE.RN_IAP_NOT_INSTALLED,
+    });
+  });
+
+  it('purchaseProduct and restoreProduct reject the same way', async () => {
+    const { probe, element } = makeProbe();
+    await mount(baseConfig(), 'alice', element);
+
+    await expect(probe.latest().purchaseProduct('coins', 'consumable')).rejects.toMatchObject({
+      code: ONESUB_ERROR_CODE.RN_IAP_NOT_INSTALLED,
+    });
+    await expect(
+      probe.latest().restoreProduct('lifetime', 'non_consumable'),
+    ).rejects.toMatchObject({ code: ONESUB_ERROR_CODE.RN_IAP_NOT_INSTALLED });
+  });
+
+  it('releases the busy lock after a rejection, so the next attempt is not blocked', async () => {
+    // If the failure path left isBusy set, every later call would return null
+    // and look like a silent cancel.
+    const { probe, element } = makeProbe();
+    await mount(baseConfig(), 'alice', element);
+
+    await expect(probe.latest().subscribe()).rejects.toThrow();
+    expect(probe.latest().isBusy).toBe(false);
+    await expect(probe.latest().subscribe()).rejects.toThrow();
+  });
+});
+
+describe('mockMode', () => {
+  it('reports an active subscription without contacting a store', async () => {
+    const { probe, element } = makeProbe();
+    await mount(baseConfig({ mockMode: true }), 'alice', element);
+
+    await act(async () => {
+      await probe.latest().subscribe();
+    });
+
+    expect(probe.latest().isActive).toBe(true);
+  });
+
+  it('returns a synthetic purchase from purchaseProduct', async () => {
+    const { probe, element } = makeProbe();
+    await mount(baseConfig({ mockMode: true }), 'alice', element);
+
+    let result: Awaited<ReturnType<OneSubContextValue['purchaseProduct']>> = null;
+    await act(async () => {
+      result = await probe.latest().purchaseProduct('coins_100', 'consumable');
+    });
+
+    expect(result).toMatchObject({
+      userId: 'alice',
+      productId: 'coins_100',
+      type: 'consumable',
+      quantity: 1,
+    });
+  });
+
+  it('warns once that mock mode is on', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await mount(baseConfig({ mockMode: true }), 'alice');
+    expect(warn.mock.calls.flat().join(' ')).toMatch(/mockMode is enabled/);
+  });
+});
+
+describe('unmount', () => {
+  it('stops applying server state that arrives late', async () => {
+    // The mount effect guards every setState with `cancelled`; without it React
+    // warns and, worse, the provider would resurrect state after teardown.
+    let release!: (value: Response) => void;
+    vi.stubGlobal('fetch', (input: string | URL) => {
+      if (String(input).includes('/onesub/status')) {
+        return new Promise<Response>((resolve) => {
+          release = resolve;
+        });
+      }
+      return Promise.resolve(new Response(JSON.stringify({ entitlements: {} }), { status: 200 }));
+    });
+
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await act(async () => {
+      root.render(
+        createElement(OneSubProvider, { config: baseConfig(), userId: 'alice', children: null }),
+      );
+    });
+    await act(async () => {
+      root.unmount();
+    });
+
+    // The in-flight status request resolves only now, after teardown.
+    await act(async () => {
+      release(new Response(JSON.stringify({ active: true, subscription: null }), { status: 200 }));
+    });
+
+    expect(errors).not.toHaveBeenCalled();
+    // Re-create a root so afterEach's unmount stays valid.
+    root = createRoot(container);
+    errors.mockRestore();
+  });
+});
+
+describe('re-mount on identity change', () => {
+  it('re-reads status when userId changes', async () => {
+    const calls: string[] = [];
+    vi.stubGlobal('fetch', async (input: string | URL) => {
+      const url = String(input);
+      if (url.includes('/onesub/status')) {
+        calls.push(url);
+        return new Response(JSON.stringify({ active: false, subscription: null }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ entitlements: {} }), { status: 200 });
+    });
+
+    await mount(baseConfig(), 'alice');
+    await rerender(baseConfig(), 'bob');
+
+    expect(calls.some((u) => u.includes('alice'))).toBe(true);
+    expect(calls.some((u) => u.includes('bob'))).toBe(true);
+  });
+
+  it('does not re-read status for an unrelated config change', async () => {
+    // The mount effect depends on serverUrl/userId only, on purpose — re-running
+    // it re-opens the IAP connection and replays queued transactions.
+    let statusCalls = 0;
+    vi.stubGlobal('fetch', async (input: string | URL) => {
+      const url = String(input);
+      if (url.includes('/onesub/status')) {
+        statusCalls++;
+        return new Response(JSON.stringify({ active: false, subscription: null }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ entitlements: {} }), { status: 200 });
+    });
+
+    await mount(baseConfig({ debug: false }), 'alice');
+    await rerender(baseConfig({ debug: true }), 'alice');
+
+    expect(statusCalls).toBe(1);
+  });
+});

--- a/packages/server/src/__tests__/logger.test.ts
+++ b/packages/server/src/__tests__/logger.test.ts
@@ -1,0 +1,113 @@
+/**
+ * The process-wide logger, and specifically that a caller cannot forge log lines.
+ *
+ * Much of what this server logs is attacker-influenced — `userId` arrives in the
+ * request body, and bundle ids, package names and receipt previews come out of
+ * submitted receipts. A newline in any of those would let a caller end the current
+ * line and write an entry of their own, and these logs are what support and fraud
+ * decisions get read from.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { OneSubLogger } from '@onesub/shared';
+import { log, setLogger } from '../logger.js';
+
+/** Captures the exact argument list each level received. */
+function recorder() {
+  const calls: { level: string; args: unknown[] }[] = [];
+  const logger: OneSubLogger = {
+    info: (...args: unknown[]) => calls.push({ level: 'info', args }),
+    warn: (...args: unknown[]) => calls.push({ level: 'warn', args }),
+    error: (...args: unknown[]) => calls.push({ level: 'error', args }),
+  };
+  return { logger, calls };
+}
+
+afterEach(() => {
+  // The logger is module-level state; hand it back to console so one test cannot
+  // silently capture another file's output.
+  setLogger(console);
+  vi.restoreAllMocks();
+});
+
+describe('routing', () => {
+  it('sends each level to the configured logger', () => {
+    const { logger, calls } = recorder();
+    setLogger(logger);
+
+    log.info('i');
+    log.warn('w');
+    log.error('e');
+
+    expect(calls.map((c) => c.level)).toEqual(['info', 'warn', 'error']);
+  });
+
+  it('ignores an undefined logger rather than losing output', () => {
+    const { logger, calls } = recorder();
+    setLogger(logger);
+    setLogger(undefined);
+
+    log.info('still here');
+
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe('log-line forgery', () => {
+  it('escapes a newline in a user-controlled value', () => {
+    const { logger, calls } = recorder();
+    setLogger(logger);
+
+    // What a malicious userId would try to do.
+    log.warn(`[onesub/status] userId: alice\n[onesub] admin granted premium to mallory`);
+
+    const line = calls[0]!.args[0] as string;
+    expect(line).not.toContain('\n');
+    expect(line).toContain('\\n');
+    // The attempt is still legible — scrubbing must not hide that it happened.
+    expect(line).toContain('admin granted premium to mallory');
+  });
+
+  it('escapes carriage returns and unicode line separators', () => {
+    const { logger, calls } = recorder();
+    setLogger(logger);
+
+    log.info('a\rb c d');
+
+    const line = calls[0]!.args[0] as string;
+    expect(line).toBe('a\\rb\\u2028c\\u2029d');
+  });
+
+  it('scrubs every string argument, not only the first', () => {
+    const { logger, calls } = recorder();
+    setLogger(logger);
+
+    log.error('prefix', 'mid\ndle', 'suffix\n');
+
+    expect(calls[0]!.args).toEqual(['prefix', 'mid\\ndle', 'suffix\\n']);
+  });
+
+  it('leaves ordinary text untouched, including tabs', () => {
+    const { logger, calls } = recorder();
+    setLogger(logger);
+
+    log.info('[onesub/apple] bundle\tid ok — 100% fine');
+
+    expect(calls[0]!.args[0]).toBe('[onesub/apple] bundle\tid ok — 100% fine');
+  });
+
+  it('passes non-strings through unchanged', () => {
+    // Structured loggers serialise objects and Errors themselves; rewriting them
+    // here would corrupt what the operator asked to see.
+    const { logger, calls } = recorder();
+    setLogger(logger);
+    const err = new Error('boom');
+    const detail = { userId: 'alice\nnot-scrubbed-here', count: 2 };
+
+    log.error('failed:', err, detail, 42, null, undefined);
+
+    expect(calls[0]!.args[1]).toBe(err);
+    expect(calls[0]!.args[2]).toBe(detail);
+    expect(calls[0]!.args.slice(3)).toEqual([42, null, undefined]);
+  });
+});

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -16,8 +16,42 @@ export function setLogger(logger: OneSubLogger | undefined): void {
   if (logger) current = logger;
 }
 
+/**
+ * Neutralise line breaks in a logged string.
+ *
+ * Much of what this server logs is attacker-influenced: `userId` comes off the
+ * request body, and bundle ids, package names and receipt previews come out of
+ * submitted receipts. A newline in any of those lets a caller close the current
+ * log line and write a whole entry of their own — so a `userId` of
+ * `alice\n[onesub] admin granted premium to mallory` forges an audit record.
+ * These logs are what support and fraud decisions are read from, so the forgery
+ * matters more than the noise.
+ *
+ * Escaped rather than stripped: the substitution has to be visible, or scrubbing
+ * would quietly merge two lines into one plausible-looking line. Only the
+ * characters that can end a log line are touched; tabs and everything else are
+ * left alone.
+ */
+function escapeLineBreaks(value: string): string {
+  return value.replace(/[\r\n\u2028\u2029]/g, (ch) => {
+    if (ch === '\n') return '\\n';
+    if (ch === '\r') return '\\r';
+    return `\\u${ch.charCodeAt(0).toString(16).padStart(4, '0')}`;
+  });
+}
+
+/**
+ * Applied to top-level string arguments only. Objects and `Error`s are passed
+ * through untouched — a structured logger serialises those itself, and rewriting
+ * them here would corrupt data the operator asked for. The line-forgery vector is
+ * the message string, which is what this covers.
+ */
+function scrub(args: unknown[]): unknown[] {
+  return args.map((arg) => (typeof arg === 'string' ? escapeLineBreaks(arg) : arg));
+}
+
 export const log: OneSubLogger = {
-  info: (...args) => current.info(...args),
-  warn: (...args) => current.warn(...args),
-  error: (...args) => current.error(...args),
+  info: (...args) => current.info(...scrub(args)),
+  warn: (...args) => current.warn(...scrub(args)),
+  error: (...args) => current.error(...scrub(args)),
 };


### PR DESCRIPTION
The last two items from the #124 review thread: the SDK's missing render tests, and
the CodeQL alerts standing open on master.

## 1. `test(sdk): render the provider`

This package had no render test. `purchaseFlow.test.ts` covers the pure decision
logic — which is exactly why that logic was split out — but nothing exercised the
React half. The referential-stability work in #124 (0.10.4) shipped that way, and was
the last change in this repo with no executable evidence behind it.

Twenty tests: mounting and rendering children, adopting server-reported subscription
state, loading the entitlements map, surviving an unreachable server without an
unhandled rejection, the full context surface, and `useOneSub` outside a provider
throwing `NOT_IN_PROVIDER`.

They also pin the 0.10.4 properties, which is what makes them worth having rather
than merely present:

| Mutation | Result |
|---|---|
| Remove the `useMemo` around the context value | identity test fails |
| Read `config` directly instead of through the ref | staleness test fails |
| Put `config` back in a callback's dep array | identity + callback-stability fail |

`react-native-iap` is deliberately absent — a supported configuration, not a
shortcut. The provider must still import, render, and report
`RN_IAP_NOT_INSTALLED`, and one test asserts the busy lock is released afterwards,
since a stuck lock would make every later call look like a silent cancel. It also
keeps `react-native` out of the picture entirely, because `getCurrentPlatform()` is
only reached once an IAP adapter exists.

Adds `react`, `react-dom`, `jsdom` as devDependencies of this workspace. React was
already resolvable through the dashboard's tree; depending on that by accident would
have made these tests break for an unrelated reason. No new advisories. Written with
`createElement` rather than JSX so the file is a `.test.ts` and the Vitest include
pattern needs no change.

## 2. `fix:` the CodeQL alerts

Ten were open on master. **Seven are fixed in code** rather than dismissed:

- **`js/log-injection`** (×2, `server/src/logger.ts`) — the real one. Much of what
  this server logs is attacker-influenced: `userId` from the request body, bundle
  ids and receipt previews from submitted receipts. A newline let a caller end the
  current line and write their own entry — `alice\n[onesub] admin granted premium to
  mallory` forges an audit record, and these logs are what support and fraud
  decisions are read from. `log.*` now escapes `\r`, `\n`, U+2028, U+2029 in
  top-level strings. **Escaped, not stripped**, so the substitution stays visible
  instead of merging two lines into one plausible-looking line. Non-strings pass
  through: a structured logger serialises objects and `Error`s itself.
- **`js/incomplete-sanitization`** (`mcp-server/.../add-paywall.ts`) — the feature
  array escaped `'` and nothing else, so a backslash escaped its own closing quote,
  breaking the generated component or extending it with whatever followed. Now
  `JSON.stringify` per entry.
- **`js/incomplete-url-substring-sanitization`** (×4, `providers` test) — the fetch
  double matched `u.includes('oauth2.googleapis.com')`, which also accepts
  `https://evil.test/?x=oauth2.googleapis.com`. Now an exact hostname comparison.
  Only a test double, but not a pattern worth teaching.

**Three are dismissed**, with the reasoning recorded on each alert:

- `js/missing-rate-limiting` on the Google webhook — *won't fix*. Applying it would
  be harmful: a 429 is not a success, Apple and Google retry on finite budgets, and
  a shed notification can permanently lose a state transition. The route already
  authenticates cryptographically and a signed token is not brute-forceable, so a
  quota adds no security. Already documented in `docs/DEPLOYMENT.md`. This is the
  alert that turned #133's check red — it predates this session (created
  2026-07-03) and only attached to that PR because the diff touched the file.
- `js/clear-text-logging` in the Google e2e script — *false positive*. The logged
  value is the response to a request sent deliberately **without** an Authorization
  header, from a locally-spawned server that never echoes headers, printed only on
  failure.
- `js/insecure-randomness` in the k6 benchmark — *false positive*. It picks a
  synthetic `bench-user-N` id. Randomness is what the benchmark wants; a fixed
  sequence would make access patterns cache-friendly and change what it measures.

`logger.test.ts` is new: the logger had no test, so nothing would have caught a
regression in either the routing or the escaping.

## Verification

**790 tests** (was 763). Each commit checked out individually — `build`, `test`,
`type-check`, `size`, `docs:check` pass at both. `size` 36.84/38 KB. Unity validator
and dashboard build pass.

Changesets: `@onesub/server` patch (log escaping), `@onesub/mcp-server` patch
(generated-string escaping). The SDK change is tests plus devDependencies, so it
needs none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)