### PR TITLE
fix(server): rewrite log escaping in a form a taint analyser recognises

### DIFF
--- a/.changeset/plain-logger-form.md
+++ b/.changeset/plain-logger-form.md
@@ -1,0 +1,12 @@
+---
+'@onesub/server': patch
+---
+
+Rewrite the log line-break escaping so a taint analyser can see it.
+
+Behaviour is unchanged — the same four characters are escaped to the same output,
+and the tests are untouched. The single regex with a callback is now one literal
+replacement per character, because CodeQL's `js/log-injection` sanitiser
+recognition could not prove the line terminator was removed through the callback
+form, and an unrecognised sanitiser is indistinguishable from an absent one to
+anyone reading an alert list.

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -33,11 +33,16 @@ export function setLogger(logger: OneSubLogger | undefined): void {
  * left alone.
  */
 function escapeLineBreaks(value: string): string {
-  return value.replace(/[\r\n\u2028\u2029]/g, (ch) => {
-    if (ch === '\n') return '\\n';
-    if (ch === '\r') return '\\r';
-    return `\\u${ch.charCodeAt(0).toString(16).padStart(4, '0')}`;
-  });
+  // One literal replacement per character rather than a single regex with a
+  // callback. Same output, but a taint analyser can see that the line terminator
+  // is gone -- CodeQL's js/log-injection sanitiser recognition could not prove it
+  // through the callback form, and an unrecognised sanitiser is indistinguishable
+  // from an absent one to anyone reading the alert list.
+  return value
+    .replace(/\r/g, '\\r')
+    .replace(/\n/g, '\\n')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
 }
 
 /**


### PR DESCRIPTION
Follow-up to #138.

The line-break escaping added there is correct and `logger.test.ts` proves it — but
CodeQL kept reporting `js/log-injection` on `logger.ts` afterwards, with **new alert
numbers** (#24, #25), so it was re-deriving the finding rather than showing stale
results.

The cause is the shape, not the behaviour. A single regex with a replacement
callback gives sanitiser recognition nothing to prove, so the taint flow still looked
unsanitised. It is now one literal replacement per character:

```ts
value
  .replace(/\r/g, '\\r')
  .replace(/\n/g, '\\n')
  .replace(/ /g, '\\u2028')
  .replace(/ /g, '\\u2029');
```

Identical output, tests untouched, and a pattern an analyser can follow.

Worth the churn rather than dismissing: an unrecognised sanitiser is
indistinguishable from an absent one to whoever reads the alert list next, and
"dismissed, trust me, the code is fine" is the kind of note that makes a real finding
easy to skip later. The three alerts dismissed in #138 were dismissed because the
*mitigation* was wrong for the code, which is a different claim.

Verification: 790 tests, `build`, `type-check`, `size`, `docs:check` pass. Whether
this actually clears the alert is what this PR's CodeQL run answers — if it does not,
the honest resolution is a false-positive dismissal, and I will say so.