### PR TITLE
fix(server): escape backslashes before line terminators when logging

### DIFF
--- a/.changeset/sharp-logs-backslash.md
+++ b/.changeset/sharp-logs-backslash.md
@@ -1,0 +1,16 @@
+---
+'@onesub/server': patch
+---
+
+Escape backslashes before line terminators when logging.
+
+The line-break escaping added in 0.23.1 rewrote `\n` to a backslash followed by
+`n` without first escaping backslashes, so two different inputs produced identical
+output: a real line terminator, and the two characters a caller typed. An operator
+reading the log could not tell which one they were looking at — which costs exactly
+the forensic value the escaping exists to provide, on values like `userId` that
+arrive straight from a request body.
+
+A real newline now renders as `\n` and a submitted backslash-n as `\\n`, so the two
+stay distinguishable. Log output changes only for strings that contain a backslash;
+messages this server composes do not.

--- a/packages/server/src/__tests__/logger.test.ts
+++ b/packages/server/src/__tests__/logger.test.ts
@@ -87,6 +87,34 @@ describe('log-line forgery', () => {
     expect(calls[0]!.args).toEqual(['prefix', 'mid\\ndle', 'suffix\\n']);
   });
 
+  it('keeps a real newline distinguishable from a submitted backslash-n', () => {
+    // Escaping `\n` to `\` + `n` without escaping `\` first makes these two
+    // inputs render identically, and an operator reading the log then cannot
+    // tell an escaped terminator from two characters the caller typed — which
+    // is the forensic value the escaping exists to protect.
+    const { logger, calls } = recorder();
+    setLogger(logger);
+
+    log.warn('userId: alice\nFORGED');
+    log.warn('userId: alice\\nFORGED');
+
+    const [fromRealNewline, fromLiteral] = calls.map((c) => c.args[0] as string);
+    expect(fromRealNewline).toBe('userId: alice\\nFORGED');
+    expect(fromLiteral).toBe('userId: alice\\\\nFORGED');
+    expect(fromRealNewline).not.toBe(fromLiteral);
+  });
+
+  it('escapes a backslash before anything that produces one', () => {
+    const { logger, calls } = recorder();
+    setLogger(logger);
+
+    log.info('path C:\\tmp\\r');
+
+    // Neither the `\t` nor the `\r` here is a control character — they are
+    // literal pairs, and must not be mistaken for escaped ones.
+    expect(calls[0]!.args[0]).toBe('path C:\\\\tmp\\\\r');
+  });
+
   it('leaves ordinary text untouched, including tabs', () => {
     const { logger, calls } = recorder();
     setLogger(logger);

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -33,12 +33,23 @@ export function setLogger(logger: OneSubLogger | undefined): void {
  * left alone.
  */
 function escapeLineBreaks(value: string): string {
+  // Backslash goes FIRST, and that ordering is the whole point of this function
+  // being written out rather than done in one pass. Escaping `\n` to `\` + `n`
+  // without escaping `\` first makes two different inputs produce identical
+  // output: a real line terminator, and the two characters a caller typed. An
+  // operator reading the log then cannot tell which one they are looking at,
+  // which costs exactly the forensic value the escaping exists to protect.
+  //
+  // With this ordering a real newline renders as `\n` and a submitted backslash-n
+  // renders as `\\n`, so the two stay distinguishable.
+  //
   // One literal replacement per character rather than a single regex with a
-  // callback. This was changed hoping CodeQL's js/log-injection sanitiser
-  // recognition would follow it; it did not, and the alert points at the spread in
-  // `log.*` rather than here. The form is kept because it reads more plainly, not
+  // callback. That form was adopted hoping CodeQL's js/log-injection sanitiser
+  // recognition would follow it; it did not, and the alert points at the spread
+  // in `log.*` rather than here. It is kept because it reads more plainly, not
   // because it satisfies an analyser.
   return value
+    .replace(/\\/g, '\\\\')
     .replace(/\r/g, '\\r')
     .replace(/\n/g, '\\n')
     .replace(/\u2028/g, '\\u2028')


### PR DESCRIPTION
Found while planning the structured-logging migration. Shipped separately so the
published version stops carrying the defect regardless of how that lands.

## The defect

The line-break escaping added in 0.23.1 rewrote `\n` to a backslash followed by `n`
**without escaping backslashes first**. So two different inputs produce identical
output:

```
input: 'alice' + REAL NEWLINE + 'FORGED'   → 'alice\nFORGED'
input: 'alice' + BACKSLASH + 'n' + 'FORGED' → 'alice\nFORGED'   ← same string
```

An operator reading the log cannot tell an escaped terminator from two characters
the caller typed. That costs exactly the forensic value the escaping exists to
provide, and it applies to values like `userId` that arrive straight from a request
body.

Backslash now goes first, so a real newline renders as `\n` and a submitted
backslash-n as `\\n`.

## Worth naming plainly

This is the **same defect class** as the `add-paywall` escaping fixed in 0.23.1 —
escaping one metacharacter without escaping the escape character — and I
reintroduced it in the logger in that same change. It is also the shape CodeQL
reports as `js/incomplete-sanitization`, which is what caught the `add-paywall`
instance; it did not fire here, so nothing external would have flagged it.

## Verification

792 tests (was 790). Two new tests pin the distinction; removing the backslash
replacement fails both, confirmed by mutation. `build`, `type-check`, `size`
(36.8/38 KB), `docs:check`, Unity validator, dashboard build all pass.

Output changes only for strings containing a backslash. Messages this server
composes do not, so in practice this affects submitted values only — which is the
point.

The function itself is replaced outright by the structured-logging work; this keeps
the current release correct in the meantime.