### PR TITLE
feat(server): render each log call into one escaped string

### DIFF
--- a/.changeset/brave-logs-render.md
+++ b/.changeset/brave-logs-render.md
@@ -1,0 +1,32 @@
+---
+'@onesub/server': minor
+'@onesub/shared': patch
+---
+
+Render each log call into one escaped string, so a caller cannot forge a log line on
+any sink.
+
+`config.logger` now receives exactly one string per log: the message, contextual
+values as `key=value` pairs, and any stack trace as `    | ` continuation lines.
+
+The guarantee is that **no byte supplied by a caller can begin a line** — weaker
+than "the output has no newlines", and deliberately so. That framing is what lets a
+stack trace stay whole: attacker text may appear inside a record but never at the
+start of one, so a forged `[onesub] admin granted premium to mallory` line is
+impossible while `at ...` frames remain readable.
+
+Rendering happens in the server rather than being left to the sink because leaving
+it to the sink only works for some of them. `console` escapes strings inside a
+trailing object, but `pino` — which this package's own docs recommend — treats that
+object as a printf interpolation argument, and a JSON-serialising sink drops an
+`Error` to `{}` because its properties are non-enumerable, losing the error
+entirely.
+
+Field values are quoted when they contain anything outside `[A-Za-z0-9_.:/@+-]`,
+which is a control rather than cosmetics: an unquoted `userId` of
+`alice productId=hacked` would otherwise be parsed as two fields.
+
+Call sites still using printf-style arguments render sensibly, so the remaining
+migration proceeds file by file with no flag day. Fields are text inside the message
+for now, not typed JSON fields — a typed sink is a planned follow-up. See
+`docs/MIGRATION.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ verify contents against the source before quoting them.
 | SQL schema shipped to users | `packages/server/sql/schema.sql` (parity-tested against `stores/schema.ts`) |
 | OpenAPI spec | `packages/server/src/openapi.ts` (parity-tested against mounted routers) |
 | Webhook durability | `packages/server/src/webhook-queue.ts`, `webhook-events.ts` |
-| Outbound HTTP, caching, logging, tracing | `packages/server/src/http.ts`, `cache.ts`, `logger.ts`, `tracing.ts` |
+| Outbound HTTP, caching, logging, tracing | `packages/server/src/http.ts`, `cache.ts`, `logger.ts`, `log-format.ts`, `tracing.ts` |
 | Multi-app credential resolution | `packages/server/src/apps.ts` |
 | SDK provider (listeners, drain gate, purchase/restore entry points) | `packages/sdk/src/OneSubProvider.tsx` |
 | SDK pure purchase-flow logic (in-flight map, native error mapping, type resolution) | `packages/sdk/src/purchaseFlow.ts` |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -98,7 +98,7 @@ createOneSubMiddleware(config)
           └── GET    /onesub/metrics/*                            → active/started/expired counts
 ```
 
-All runtime logging goes through `config.logger` (OneSubLogger interface; defaults to `console`). Providers and routes import `log` from the internal `logger.ts` singleton instead of calling `console.*` directly.
+All runtime logging goes through `config.logger` (OneSubLogger interface; defaults to `console`). Providers and routes import `log` from the internal `logger.ts` singleton instead of calling `console.*` directly. `logger.ts` renders each call through `log-format.ts` and hands the sink exactly one string: the message, contextual values as `key=value` pairs, and any stack as `    | ` continuation lines. That is what keeps a caller-supplied newline from starting a line on every sink and not just on `console`.
 
 All outbound HTTP calls (Apple Status/History APIs, Apple Consumption Response, Google
 subscriptionsv2, Google OAuth, Google ack/consume) go through `http.ts/fetchWithTimeout` —

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -47,7 +47,7 @@ explicitly. Without them, middleware uses in-memory stores even when `database.u
 | `metricsCacheTtlSeconds` | No | `30` | How long a `/onesub/metrics/*` aggregate may be reused; `0` disables |
 | `entitlements` | No | Entitlement routes not mounted | Maps stable entitlement IDs to product IDs |
 | `refundPolicy` | No | `immediate` | Subscription refund access policy |
-| `logger` | No | `console` | `{ info, warn, error }` server log sink |
+| `logger` | No | `console` | `{ info, warn, error }` server log sink; receives one pre-formatted string per log |
 | `webhookSecret` | No | No current Apple/Google enforcement | Legacy/reserved field; do not use it as webhook authentication |
 
 Apple uses signed JWS payloads. Google push authentication is configured with `pushAudience` and

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -4,6 +4,50 @@ Upgrade notes for releases of `@onesub/server` that need one. While the package 
 
 ---
 
+## `@onesub/server` 0.23.x → 0.24.0
+
+### Your log sink now receives one pre-formatted string
+
+`config.logger` previously got printf-style arguments — a message, then whatever
+values the call site passed, including raw `Error` objects. It now receives **exactly
+one string** per log: the message, contextual values as `key=value` pairs, and any
+stack trace as `    | `-prefixed continuation lines.
+
+```text
+before  logger.warn('[onesub/apple] Bundle ID mismatch:', 'com.evil', '!==', 'com.real')
+after   logger.warn('[onesub/apple] bundle id mismatch bundleId=com.evil expected=com.real')
+```
+
+**Why.** Values interpolated into a message could not be escaped without also
+escaping the message, and a caller-supplied newline in one of them could end the log
+line and forge the next — `userId` arrives in a request body, and bundle ids and
+purchase tokens are decoded out of submitted receipts and notifications. Passing
+values as a trailing object does not fix it either: `console` escapes strings inside
+objects, but `pino` treats the object as a printf argument, and a JSON sink drops an
+`Error` entirely because its properties are non-enumerable. Rendering in the server
+is the only place the guarantee holds for every sink.
+
+**Impact.** If you pass `console`, `pino`, `winston` or `bunyan`, nothing to do — the
+string arrives as the message. You are affected if you:
+
+- **Inspected arguments beyond the first.** There is only one now.
+- **Relied on receiving the raw `Error`** so your sink could serialise it. The stack
+  is now rendered into the string instead. It is still complete and still readable;
+  it is no longer an object.
+- **Parse onesub log lines.** Contextual values are `key=value` pairs, quoted when
+  they contain anything but `[A-Za-z0-9_.:/@+-]`. Logfmt parsers in Loki, Splunk,
+  Datadog and CloudWatch Insights extract them as fields.
+- **Join multi-line records.** Stack frames are continuation lines beginning with
+  four spaces and `| `. Shippers that already join `^\s` to the previous record need
+  no change.
+
+**Not the end state.** Fields are text inside the message, not typed JSON fields. A
+typed structured sink is a planned follow-up now that the call sites carry
+`(message, fields)`; this release is the step that makes the guarantee hold
+everywhere first.
+
+---
+
 ## `@onesub/server` 0.21.x → 0.22.0
 
 ### `POST /onesub/webhook/google` is mounted only when the config serves Google Play

--- a/packages/server/.size-limit.cjs
+++ b/packages/server/.size-limit.cjs
@@ -25,6 +25,12 @@
 // 2026-07-26: 34.17/34.55 KB after the metrics aggregation split and response
 // cache (`metrics-aggregate.ts`, `metrics-cache.ts`). Limit unchanged.
 //
+// 2026-07-27: raised 38 → 40 KB for `log-format.ts`, which renders a log call into
+// one escaped string so the anti-forgery guarantee holds on every sink rather than
+// only on `console`. Measured 37.45/37.78 KB — the formatter itself is +0.98 KB.
+// Raised rather than left at 0.22 KB of headroom, with the call-site migration
+// (104 sites, two further PRs) still to land and expected to move this again.
+//
 // 2026-07-26: 36.35/36.69 KB after the metrics SQL aggregation pushdown
 // (`aggregateViaSql` plus the optional store methods). Limit unchanged.
 //
@@ -38,13 +44,13 @@ module.exports = [
   {
     name: 'esm bundle (gzipped)',
     path: 'dist/index.js',
-    limit: '38 KB',
+    limit: '40 KB',
     gzip: true,
   },
   {
     name: 'cjs bundle (gzipped)',
     path: 'dist/index.cjs',
-    limit: '38 KB',
+    limit: '40 KB',
     gzip: true,
   },
 ];

--- a/packages/server/src/__tests__/log-format.test.ts
+++ b/packages/server/src/__tests__/log-format.test.ts
@@ -1,0 +1,209 @@
+/**
+ * formatLogArgs — the security properties of log rendering.
+ *
+ * These live here rather than in `logger.test.ts` because they are properties of a
+ * pure function from arguments to a string. `logger.ts` holds process-global state
+ * and needs `setLogger` juggling; nothing that carries a security claim should
+ * depend on that.
+ *
+ * The central claim is one property, asserted over a hostile matrix rather than
+ * case by case: **no byte supplied by a caller can begin a line.** Everything else
+ * here is either a corollary or a guard against the formatter throwing on input it
+ * will genuinely receive.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { formatLogArgs, LOG_CONTINUATION } from '../log-format.js';
+
+/** Written as escapes on purpose: a raw U+2028 is a line terminator in source too. */
+const LS = '\u2028';
+const PS = '\u2029';
+
+const CONTINUATION_PREFIX = LOG_CONTINUATION.slice(1); // without the leading \n
+
+/** The claim, as a function. Every case in the matrix is checked against this. */
+function everyLineIsOursOrTheFirst(output: string): boolean {
+  const [, ...rest] = output.split('\n');
+  return rest.every((line) => line.startsWith(CONTINUATION_PREFIX));
+}
+
+/** No terminator other than the ones we write ourselves may survive. */
+function hasNoStrayTerminator(output: string): boolean {
+  return !output.includes('\r') && !output.includes(LS) && !output.includes(PS);
+}
+
+function erroring(message: string): Error {
+  // A real Error, so it carries a real multi-line stack.
+  return new Error(message);
+}
+
+describe('the line invariant', () => {
+  const FORGERY = '[onesub] admin granted premium to mallory';
+
+  const hostile: Array<{ name: string; args: unknown[] }> = [
+    { name: 'newline in the message', args: [`userId: alice\n${FORGERY}`] },
+    { name: 'carriage return in the message', args: [`userId: alice\r${FORGERY}`] },
+    { name: 'CRLF in the message', args: [`userId: alice\r\n${FORGERY}`] },
+    { name: 'U+2028 in the message', args: [`userId: alice${LS}${FORGERY}`] },
+    { name: 'U+2029 in the message', args: [`userId: alice${PS}${FORGERY}`] },
+    { name: 'newline in a field value', args: ['lookup', { userId: `alice\n${FORGERY}` }] },
+    { name: 'newline in a field KEY', args: ['lookup', { [`a\n${FORGERY}`]: 'x' }] },
+    { name: 'newline in a nested object', args: ['lookup', { detail: { userId: `a\n${FORGERY}` } }] },
+    { name: 'newline in an array field', args: ['lookup', { skus: [`a\n${FORGERY}`] }] },
+    { name: 'error message with a newline', args: ['failed', { err: erroring(`boom\n${FORGERY}`) }] },
+    { name: 'error as a positional arg', args: ['failed:', erroring(`boom\n${FORGERY}`)] },
+    { name: 'error with a cause chain', args: ['failed', { err: new Error('outer', { cause: erroring(`inner\n${FORGERY}`) }) }] },
+    { name: 'aggregate error', args: ['failed', { err: new AggregateError([erroring(`a\n${FORGERY}`), erroring('b')], 'many') }] },
+    { name: 'thrown string', args: ['failed', { err: `boom\n${FORGERY}` }] },
+    { name: 'thrown object', args: ['failed', { err: { toString: () => `boom\n${FORGERY}` } }] },
+    { name: 'legacy varargs with a newline', args: ['prefix:', `a\n${FORGERY}`, 'suffix'] },
+    { name: 'a literal backslash-n, not a terminator', args: [`userId: alice\\n${FORGERY}`] },
+  ];
+
+  for (const { name, args } of hostile) {
+    it(`holds for ${name}`, () => {
+      const output = formatLogArgs(args);
+      expect(everyLineIsOursOrTheFirst(output)).toBe(true);
+      expect(hasNoStrayTerminator(output)).toBe(true);
+      // The attempt must still be legible — a guarantee that hid the attack would
+      // be worse than none, because nobody would know it happened.
+      expect(output).toContain('admin granted premium to mallory');
+    });
+  }
+
+  it('distinguishes a real terminator from a submitted backslash-n', () => {
+    // 0.23.1 shipped an escape that rendered these identically. If they collapse
+    // again, an operator cannot tell an escaped newline from two typed characters.
+    const fromReal = formatLogArgs(['x', { userId: 'alice\nFORGED' }]);
+    const fromLiteral = formatLogArgs(['x', { userId: 'alice\\nFORGED' }]);
+    expect(fromReal).not.toBe(fromLiteral);
+  });
+});
+
+describe('field quoting is a control, not formatting', () => {
+  /** Count `key=` occurrences outside quotes, the way a logfmt parser would. */
+  function bareKeyCount(output: string, key: string): number {
+    let count = 0;
+    let inQuote = false;
+    for (let i = 0; i < output.length; i++) {
+      const ch = output[i];
+      if (ch === '"' && output[i - 1] !== '\\') inQuote = !inQuote;
+      if (!inQuote && output.startsWith(`${key}=`, i)) count++;
+    }
+    return count;
+  }
+
+  it('a value containing key=value does not become a second field', () => {
+    // Unquoted, Loki / Splunk / CloudWatch Insights would parse two fields here.
+    const output = formatLogArgs(['lookup', { userId: 'alice productId=hacked' }]);
+    expect(bareKeyCount(output, 'productId')).toBe(0);
+    expect(bareKeyCount(output, 'userId')).toBe(1);
+  });
+
+  it('a quote inside a value cannot close the value early', () => {
+    const output = formatLogArgs(['lookup', { userId: 'a" productId=hacked "b' }]);
+    expect(bareKeyCount(output, 'productId')).toBe(0);
+  });
+
+  it('a backslash before a quote cannot escape the escaping', () => {
+    const output = formatLogArgs(['lookup', { userId: 'a\\" productId=hacked' }]);
+    expect(bareKeyCount(output, 'productId')).toBe(0);
+  });
+
+  it('leaves plain tokens unquoted so lines stay readable', () => {
+    const output = formatLogArgs(['lookup', { userId: 'alice', productId: 'pro_monthly' }]);
+    expect(output).toBe('lookup userId=alice productId=pro_monthly');
+  });
+});
+
+describe('errors keep their stack', () => {
+  it('renders frames as continuation lines, not as one flattened line', () => {
+    const output = formatLogArgs(['validation failed', { userId: 'alice', err: erroring('boom') }]);
+
+    expect(output).toContain('err=Error');
+    expect(output).toContain('err.msg=boom');
+    expect(output).toContain(`${LOG_CONTINUATION}at `);
+    // More than one frame, i.e. the stack was not truncated to a single line.
+    expect(output.split(LOG_CONTINUATION).length).toBeGreaterThan(2);
+  });
+
+  it('drops the header even when the error message spans lines', () => {
+    // The header is `Name: message`, which is multi-line when the message is. If it
+    // leaked into the frames the forged text would appear at a line start.
+    const output = formatLogArgs(['failed', { err: erroring('boom\n    at fake (evil.js:1:1)') }]);
+    const frames = output.split(LOG_CONTINUATION).slice(1);
+    expect(frames.every((f) => f.startsWith('at ') || f.startsWith('cause:') || f.startsWith('also:'))).toBe(true);
+  });
+
+  it('follows a cause chain but does not follow it forever', () => {
+    let err = erroring('root');
+    for (let i = 0; i < 10; i++) err = new Error(`wrap${i}`, { cause: err });
+    const output = formatLogArgs(['failed', { err }]);
+    // Bounded: a cause chain is reachable through provider error wrapping, so an
+    // unbounded walk is a way to turn one log call into a very large write.
+    expect(output.split('cause:').length - 1).toBeLessThanOrEqual(2);
+  });
+
+  it('handles a non-Error throw without a stack', () => {
+    expect(formatLogArgs(['failed', { err: 'just a string' }])).toContain('err.msg=');
+    expect(formatLogArgs(['failed', { err: 42 }])).toContain('err.msg=');
+    expect(formatLogArgs(['failed', { err: null }])).toContain('failed');
+  });
+});
+
+describe('never throws on input it will actually receive', () => {
+  const nasty: Array<{ name: string; value: unknown }> = [
+    { name: 'a circular object', value: (() => { const o: Record<string, unknown> = {}; o['self'] = o; return o; })() },
+    { name: 'a throwing getter', value: { get boom() { throw new Error('nope'); } } },
+    { name: 'a throwing toString', value: { toString() { throw new Error('nope'); } } },
+    { name: 'a symbol', value: Symbol('s') },
+    { name: 'a function', value: () => undefined },
+    { name: 'a bigint', value: 10n },
+    { name: 'a deeply nested object', value: { a: { b: { c: { d: { e: 1 } } } } } },
+  ];
+
+  for (const { name, value } of nasty) {
+    it(`survives ${name}`, () => {
+      expect(() => formatLogArgs(['x', { field: value }])).not.toThrow();
+      expect(() => formatLogArgs(['x', value])).not.toThrow();
+    });
+  }
+
+  it('omits undefined fields and renders null explicitly', () => {
+    const output = formatLogArgs(['x', { a: undefined, b: null, c: 0, d: false }]);
+    expect(output).not.toContain('a=');
+    expect(output).toContain('b=null');
+    expect(output).toContain('c=0');
+    expect(output).toContain('d=false');
+  });
+
+  it('handles no arguments and an empty fields object', () => {
+    expect(formatLogArgs([])).toBe('');
+    expect(formatLogArgs(['x', {}])).toBe('x');
+  });
+});
+
+describe('exact shape', () => {
+  // Three snapshots only, as executable documentation of the format. Any more and
+  // the suite becomes a formatting snapshot that blocks future adjustment.
+  it('message only', () => {
+    expect(formatLogArgs(['[onesub/apple] receipt rejected'])).toBe('[onesub/apple] receipt rejected');
+  });
+
+  it('message and fields', () => {
+    expect(formatLogArgs(['[onesub/validate] account binding mismatch', {
+      route: 'validate',
+      userId: 'alice',
+      originalTransactionId: '2000000123',
+    }])).toBe(
+      '[onesub/validate] account binding mismatch route=validate userId=alice originalTransactionId=2000000123',
+    );
+  });
+
+  it('legacy varargs still render sensibly during the migration', () => {
+    // Call sites move file by file; an un-migrated one must not produce garbage.
+    expect(formatLogArgs(['[onesub/apple] Bundle ID mismatch:', 'com.evil', '!==', 'com.real'])).toBe(
+      '[onesub/apple] Bundle ID mismatch: com.evil !== com.real',
+    );
+  });
+});

--- a/packages/server/src/__tests__/logger.test.ts
+++ b/packages/server/src/__tests__/logger.test.ts
@@ -1,11 +1,18 @@
 /**
- * The process-wide logger, and specifically that a caller cannot forge log lines.
+ * The process-wide logger: routing, and the shape of what reaches the sink.
  *
- * Much of what this server logs is attacker-influenced — `userId` arrives in the
- * request body, and bundle ids, package names and receipt previews come out of
- * submitted receipts. A newline in any of those would let a caller end the current
- * line and write an entry of their own, and these logs are what support and fraud
- * decisions get read from.
+ * The escaping and rendering details moved to `log-format.test.ts`, which tests them
+ * as properties of a pure function over a hostile matrix rather than one case at a
+ * time. What is left here is what only this module can answer: that each level goes
+ * where it should, and that a sink receives **exactly one string argument**.
+ *
+ * That last one is the load-bearing assertion. It is the contract every documented
+ * sink depends on — `pino` treats a second argument as a printf interpolation
+ * parameter, not as structured fields, so anything "helpfully" passing fields
+ * alongside the message would silently degrade for the sink this package recommends
+ * for production. There is also then no shape for a JSON serialiser to drop: an
+ * `Error` passed as an object would serialise to `{}`, because its own properties
+ * are non-enumerable.
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -53,89 +60,79 @@ describe('routing', () => {
   });
 });
 
-describe('log-line forgery', () => {
-  it('escapes a newline in a user-controlled value', () => {
+describe('the sink always receives exactly one string', () => {
+  it('for a message on its own', () => {
     const { logger, calls } = recorder();
     setLogger(logger);
 
-    // What a malicious userId would try to do.
-    log.warn(`[onesub/status] userId: alice\n[onesub] admin granted premium to mallory`);
+    log.info('[onesub/apple] receipt rejected');
+
+    expect(calls[0]!.args).toEqual(['[onesub/apple] receipt rejected']);
+  });
+
+  it('for a message with fields', () => {
+    // Fields are rendered into that one string rather than passed alongside it.
+    // Passing them alongside works on `console`, whose util.inspect escapes strings
+    // inside objects — but not on `pino`, which would treat the object as a printf
+    // argument. Rendering here is what makes the guarantee hold on every sink.
+    const { logger, calls } = recorder();
+    setLogger(logger);
+
+    log.warn('account binding mismatch', { route: 'validate', userId: 'alice' });
+
+    expect(calls[0]!.args).toHaveLength(1);
+    expect(calls[0]!.args[0]).toBe('account binding mismatch route=validate userId=alice');
+  });
+
+  it('for a message with an Error', () => {
+    const { logger, calls } = recorder();
+    setLogger(logger);
+
+    log.error('validation failed', { userId: 'alice', err: new Error('boom') });
+
+    expect(calls[0]!.args).toHaveLength(1);
+    const line = calls[0]!.args[0] as string;
+    expect(typeof line).toBe('string');
+    expect(line).toContain('err=Error');
+    expect(line).toContain('err.msg=boom');
+    // The stack survives, as continuation lines rather than a flattened blob.
+    expect(line).toContain('\n    | at ');
+  });
+
+  it('for a legacy varargs call that has not been migrated yet', () => {
+    // Call sites move file by file, so an un-migrated one still has to render
+    // sensibly — that is what makes the migration incremental, not a flag day.
+    const { logger, calls } = recorder();
+    setLogger(logger);
+
+    log.warn('[onesub/apple] Bundle ID mismatch:', 'com.evil', '!==', 'com.real');
+
+    expect(calls[0]!.args).toEqual(['[onesub/apple] Bundle ID mismatch: com.evil !== com.real']);
+  });
+});
+
+describe('log-line forgery, end to end', () => {
+  it('a newline in a logged value cannot start a new line', () => {
+    // The matrix version of this lives in log-format.test.ts. This one proves the
+    // facade actually routes through the formatter, which no pure test can show.
+    const { logger, calls } = recorder();
+    setLogger(logger);
+
+    log.warn('user lookup', { userId: 'alice\n[onesub] admin granted premium to mallory' });
 
     const line = calls[0]!.args[0] as string;
-    expect(line).not.toContain('\n');
+    expect(line.split('\n')).toHaveLength(1);
     expect(line).toContain('\\n');
-    // The attempt is still legible — scrubbing must not hide that it happened.
+    // The attempt stays legible — a guarantee that hid it would be worse than none.
     expect(line).toContain('admin granted premium to mallory');
   });
 
-  it('escapes carriage returns and unicode line separators', () => {
-    const { logger, calls } = recorder();
-    setLogger(logger);
-
-    log.info('a\rb c d');
-
-    const line = calls[0]!.args[0] as string;
-    expect(line).toBe('a\\rb\\u2028c\\u2029d');
-  });
-
-  it('scrubs every string argument, not only the first', () => {
-    const { logger, calls } = recorder();
-    setLogger(logger);
-
-    log.error('prefix', 'mid\ndle', 'suffix\n');
-
-    expect(calls[0]!.args).toEqual(['prefix', 'mid\\ndle', 'suffix\\n']);
-  });
-
-  it('keeps a real newline distinguishable from a submitted backslash-n', () => {
-    // Escaping `\n` to `\` + `n` without escaping `\` first makes these two
-    // inputs render identically, and an operator reading the log then cannot
-    // tell an escaped terminator from two characters the caller typed — which
-    // is the forensic value the escaping exists to protect.
-    const { logger, calls } = recorder();
-    setLogger(logger);
-
-    log.warn('userId: alice\nFORGED');
-    log.warn('userId: alice\\nFORGED');
-
-    const [fromRealNewline, fromLiteral] = calls.map((c) => c.args[0] as string);
-    expect(fromRealNewline).toBe('userId: alice\\nFORGED');
-    expect(fromLiteral).toBe('userId: alice\\\\nFORGED');
-    expect(fromRealNewline).not.toBe(fromLiteral);
-  });
-
-  it('escapes a backslash before anything that produces one', () => {
-    const { logger, calls } = recorder();
-    setLogger(logger);
-
-    log.info('path C:\\tmp\\r');
-
-    // Neither the `\t` nor the `\r` here is a control character — they are
-    // literal pairs, and must not be mistaken for escaped ones.
-    expect(calls[0]!.args[0]).toBe('path C:\\\\tmp\\\\r');
-  });
-
-  it('leaves ordinary text untouched, including tabs', () => {
+  it('leaves ordinary text alone, including tabs', () => {
     const { logger, calls } = recorder();
     setLogger(logger);
 
     log.info('[onesub/apple] bundle\tid ok — 100% fine');
 
     expect(calls[0]!.args[0]).toBe('[onesub/apple] bundle\tid ok — 100% fine');
-  });
-
-  it('passes non-strings through unchanged', () => {
-    // Structured loggers serialise objects and Errors themselves; rewriting them
-    // here would corrupt what the operator asked to see.
-    const { logger, calls } = recorder();
-    setLogger(logger);
-    const err = new Error('boom');
-    const detail = { userId: 'alice\nnot-scrubbed-here', count: 2 };
-
-    log.error('failed:', err, detail, 42, null, undefined);
-
-    expect(calls[0]!.args[1]).toBe(err);
-    expect(calls[0]!.args[2]).toBe(detail);
-    expect(calls[0]!.args.slice(3)).toEqual([42, null, undefined]);
   });
 });

--- a/packages/server/src/log-format.ts
+++ b/packages/server/src/log-format.ts
@@ -1,0 +1,254 @@
+/**
+ * Renders a log call into exactly one string.
+ *
+ * Why this module exists, and why it is pure. `logger.ts` holds process-global
+ * state, so anything tested through it needs `setLogger` juggling to keep one test
+ * file from capturing another's output. Every security property below is a property
+ * of a function from arguments to a string, so it belongs somewhere with no state
+ * at all — see `log-format.test.ts`.
+ *
+ * ## The invariant
+ *
+ * **No byte supplied by a caller can begin a line.**
+ *
+ * That is the whole security claim, and it is weaker than "the output contains no
+ * newlines" on purpose. Demanding no newlines at all is what backed this server
+ * into a corner earlier: a stack trace is multi-line by nature and is the main
+ * reason to log an `Error`, so flattening it destroys the thing you wanted. Framing
+ * it as "attacker text may appear inside a record, never at the start of one" keeps
+ * the trace readable *and* makes forgery impossible.
+ *
+ * It holds mechanically: the message and every field value pass through `esc`,
+ * which leaves no line terminator behind, so the only newlines in the result are the
+ * ones this module writes itself as part of `LOG_CONTINUATION`. A forged
+ * `[onesub] admin granted premium to mallory` line cannot be produced.
+ *
+ * `LOG_CONTINUATION` begins with whitespace, which is what Fluent Bit, Loki and
+ * Docker multiline rules already use to join a line to the record above it. And
+ * grepping `[onesub/` still returns one hit per event, not one per stack frame.
+ *
+ * ## Output grammar
+ *
+ * ```text
+ * <message>[ <key>=<value>]*[<CONT><line>]*
+ * ```
+ *
+ * ## Field vocabulary
+ *
+ * Use these names and no synonyms — `userId`, not `user` or `uid`. The point of
+ * moving values out of the message is that an operator can filter on them, and that
+ * is lost the moment the same thing is called three things across 16 files:
+ *
+ *   route · provider · userId · appId · platform · productId · transactionId ·
+ *   originalTransactionId · purchaseToken · orderId · bundleId · packageName ·
+ *   notificationType · status · httpStatus · environment · err
+ *
+ * `err` is reserved: it always routes through the error renderer.
+ *
+ * Messages are static literals. Write `log.warn('bundle id mismatch', { bundleId,
+ * expected })`, never `` log.warn(`mismatch: ${a} !== ${b}`) `` — an interpolated
+ * value is a value that cannot be filtered on, and one that has to be escaped
+ * rather than simply carried.
+ */
+
+/**
+ * Prefix for every line after the first. Leading whitespace is deliberate: it is
+ * what existing log-shipper multiline rules key on.
+ */
+export const LOG_CONTINUATION = '\n    | ';
+
+/** Fields whose value is rendered bare, without quotes. */
+const BARE_VALUE = /^[\w.:/@+-]+$/;
+
+/** Any character that could end a line, including the two Unicode separators. */
+const LINE_TERMINATORS = /\r\n|\r|\n|\u2028|\u2029/;
+
+/** How far to follow `Error.cause`, and how many `AggregateError.errors` to render. */
+const MAX_CAUSE_DEPTH = 2;
+const MAX_AGGREGATE_ERRORS = 3;
+
+/**
+ * Escape everything that could break out of a line or out of a quoted value.
+ *
+ * Backslash goes FIRST and that ordering is the point. Escaping `\n` to `\` + `n`
+ * without escaping `\` first makes two different inputs render identically — a real
+ * terminator, and the two characters a caller typed — so an operator cannot tell
+ * which they are reading. That defect shipped in 0.23.1 and was fixed in 0.23.3;
+ * it is the same class as escaping a quote without escaping the escape character.
+ */
+function esc(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/\r/g, '\\r')
+    .replace(/\n/g, '\\n')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
+
+/**
+ * Render one field value in logfmt.
+ *
+ * The quoting is a security control, not formatting. An unquoted `userId` of
+ * `alice productId=hacked` would be parsed as two fields by Loki, Splunk and
+ * CloudWatch Insights — field injection rather than line injection, but the same
+ * shape of lie. Anything that is not a plain token gets quoted, and `"` inside a
+ * quoted value is escaped so it cannot close it early.
+ */
+function renderValue(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return 'null';
+
+  switch (typeof value) {
+    case 'number':
+    case 'boolean':
+      return String(value);
+    case 'bigint':
+      return `${value}n`;
+    case 'string':
+      return BARE_VALUE.test(value) ? value : `"${esc(value).replace(/"/g, '\\"')}"`;
+    case 'object':
+      // Depth 1 only, and inside a try/catch. Webhook payloads are attacker-shaped
+      // and arbitrarily deep; a recursive walk here would be both bundle weight and
+      // a CPU-DoS surface, and JSON.stringify already throws on cycles.
+      try {
+        return `"${esc(JSON.stringify(value) ?? 'null').replace(/"/g, '\\"')}"`;
+      } catch {
+        return '"[unserialisable]"';
+      }
+    default:
+      // symbol, function — String() is safe for both.
+      try {
+        return `"${esc(String(value)).replace(/"/g, '\\"')}"`;
+      } catch {
+        return '"[unrenderable]"';
+      }
+  }
+}
+
+/**
+ * `key=value` pairs for one object, skipping `undefined` and the reserved `err`.
+ *
+ * Keys are walked with `Object.keys` and read one at a time rather than through
+ * `Object.entries`, which evaluates every getter eagerly — one throwing getter would
+ * take down the whole log call, and `log` is a public export so the object is not
+ * always one this package built. Reading per key means a hostile property costs its
+ * own value and nothing else.
+ */
+function renderFields(fields: Record<string, unknown>): { pairs: string[]; err: unknown } {
+  const pairs: string[] = [];
+  let err: unknown;
+
+  for (const key of Object.keys(fields)) {
+    let value: unknown;
+    try {
+      value = fields[key];
+    } catch {
+      pairs.push(`${esc(key)}="[threw]"`);
+      continue;
+    }
+
+    if (key === 'err') {
+      err = value;
+      continue;
+    }
+    const rendered = renderValue(value);
+    if (rendered !== undefined) pairs.push(`${esc(key)}=${rendered}`);
+  }
+
+  return { pairs, err };
+}
+
+/**
+ * Stack frames as continuation lines, header removed.
+ *
+ * The header is dropped by finding the first `at ` frame rather than by skipping a
+ * fixed number of lines: when the error message itself contains newlines — which is
+ * exactly the forgery attempt — the header spans several lines, and counting would
+ * leak the rest of it into the frames.
+ */
+function renderStack(stack: string | undefined): string {
+  if (!stack) return '';
+  const lines = stack.split(LINE_TERMINATORS);
+  const firstFrame = lines.findIndex((line) => /^\s+at\s/.test(line));
+  const frames = firstFrame === -1 ? [] : lines.slice(firstFrame);
+  return frames.map((line) => LOG_CONTINUATION + esc(line.trim())).join('');
+}
+
+/**
+ * Render a thrown value: `err`/`err.msg` fields plus the stack as continuation
+ * lines, following `cause` and `AggregateError.errors` to a fixed depth.
+ *
+ * Bounded on purpose. A `cause` chain is attacker-reachable through provider error
+ * wrapping, and an unbounded walk is a way to turn one log call into a very large
+ * write.
+ */
+function renderError(value: unknown, depth = 0): { pairs: string[]; lines: string } {
+  if (!(value instanceof Error)) {
+    // `throw 'boom'`, `throw { code: 1 }` — no stack to render.
+    const rendered = renderValue(typeof value === 'string' ? value : String(value));
+    return { pairs: [`err.msg=${rendered ?? '"[unrenderable]"'}`], lines: '' };
+  }
+
+  const pairs = [`err=${renderValue(value.name) ?? 'Error'}`];
+  const message = renderValue(value.message);
+  if (message !== undefined) pairs.push(`err.msg=${message}`);
+
+  let lines = renderStack(value.stack);
+
+  if (depth < MAX_CAUSE_DEPTH && value.cause !== undefined && value.cause !== null) {
+    const cause = renderError(value.cause, depth + 1);
+    lines += LOG_CONTINUATION + `cause: ${cause.pairs.join(' ')}` + cause.lines;
+  }
+
+  if (value instanceof AggregateError && Array.isArray(value.errors)) {
+    for (const inner of value.errors.slice(0, MAX_AGGREGATE_ERRORS)) {
+      const rendered = renderError(inner, MAX_CAUSE_DEPTH);
+      lines += LOG_CONTINUATION + `also: ${rendered.pairs.join(' ')}`;
+    }
+  }
+
+  return { pairs, lines };
+}
+
+/**
+ * Render a whole log call into one string.
+ *
+ * Argument handling is generic rather than a fixed `(message, fields)` shape, and
+ * that is what makes the call-site migration incremental: a site still passing
+ * printf-style varargs renders sensibly, so files can move one PR at a time with no
+ * flag day. Strings join the message, plain objects contribute their entries as
+ * fields, `Error`s go through the error renderer wherever they appear.
+ */
+export function formatLogArgs(args: readonly unknown[]): string {
+  const words: string[] = [];
+  const pairs: string[] = [];
+  let errorLines = '';
+
+  for (const arg of args) {
+    if (typeof arg === 'string') {
+      words.push(esc(arg));
+      continue;
+    }
+    if (arg instanceof Error) {
+      const rendered = renderError(arg);
+      pairs.push(...rendered.pairs);
+      errorLines += rendered.lines;
+      continue;
+    }
+    if (arg !== null && typeof arg === 'object' && !Array.isArray(arg)) {
+      const { pairs: fieldPairs, err } = renderFields(arg as Record<string, unknown>);
+      pairs.push(...fieldPairs);
+      if (err !== undefined) {
+        const rendered = renderError(err);
+        pairs.push(...rendered.pairs);
+        errorLines += rendered.lines;
+      }
+      continue;
+    }
+    // Numbers, booleans, null, arrays, symbols from a legacy varargs call site.
+    const rendered = renderValue(arg);
+    if (rendered !== undefined) words.push(rendered);
+  }
+
+  return [words.join(' '), ...pairs].filter((part) => part !== '').join(' ') + errorLines;
+}

--- a/packages/server/src/log-format.ts
+++ b/packages/server/src/log-format.ts
@@ -86,6 +86,26 @@ function esc(value: string): string {
 }
 
 /**
+ * Escape a value that will sit inside double quotes.
+ *
+ * One chain, backslash first, quote second. It was previously `esc(v)` followed by a
+ * separate `.replace(/"/g, ...)` at three call sites — correct, because `esc` doubles
+ * backslashes before the quote pass runs, but wrong in two other ways: the same rule
+ * lived in three places, and splitting the escape across two functions leaves a taint
+ * analyser unable to see that the metacharacter is handled (CodeQL reported
+ * `js/incomplete-sanitization` on each of the three).
+ */
+function escQuoted(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\r/g, '\\r')
+    .replace(/\n/g, '\\n')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
+
+/**
  * Render one field value in logfmt.
  *
  * The quoting is a security control, not formatting. An unquoted `userId` of
@@ -105,20 +125,20 @@ function renderValue(value: unknown): string | undefined {
     case 'bigint':
       return `${value}n`;
     case 'string':
-      return BARE_VALUE.test(value) ? value : `"${esc(value).replace(/"/g, '\\"')}"`;
+      return BARE_VALUE.test(value) ? value : `"${escQuoted(value)}"`;
     case 'object':
       // Depth 1 only, and inside a try/catch. Webhook payloads are attacker-shaped
       // and arbitrarily deep; a recursive walk here would be both bundle weight and
       // a CPU-DoS surface, and JSON.stringify already throws on cycles.
       try {
-        return `"${esc(JSON.stringify(value) ?? 'null').replace(/"/g, '\\"')}"`;
+        return `"${escQuoted(JSON.stringify(value) ?? 'null')}"`;
       } catch {
         return '"[unserialisable]"';
       }
     default:
       // symbol, function — String() is safe for both.
       try {
-        return `"${esc(String(value)).replace(/"/g, '\\"')}"`;
+        return `"${escQuoted(String(value))}"`;
       } catch {
         return '"[unrenderable]"';
       }

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -1,4 +1,5 @@
 import type { OneSubLogger } from '@onesub/shared';
+import { formatLogArgs } from './log-format.js';
 
 /**
  * Process-wide logger used by @onesub/server's providers and routes.
@@ -8,6 +9,25 @@ import type { OneSubLogger } from '@onesub/shared';
  * import `log` from this module instead of calling `console.*` directly so
  * operators can redirect logs (pino / winston / bunyan) with a single config
  * setting.
+ *
+ * **The sink always receives exactly one string argument.** Rendering happens here,
+ * in `log-format.ts`, rather than being left to whatever the host configured — and
+ * that is the load-bearing decision, not an implementation detail:
+ *
+ *   - It is what makes the anti-forgery guarantee hold on every sink. Passing values
+ *     as a trailing object works on `console`, because `util.inspect` escapes
+ *     strings inside objects — but `pino`, which this package's own docs recommend,
+ *     treats a trailing object as a printf interpolation argument. Leaving the
+ *     escaping to the sink means it only happens for some of them.
+ *   - It fixes a bug nobody would have noticed until it mattered: `Error` properties
+ *     are non-enumerable, so a JSON-serialising sink turns `{ err }` into `{}` and
+ *     loses the error entirely.
+ *
+ * The cost is that structured fields arrive as `key=value` text inside the message
+ * rather than as typed JSON fields. That is a deferral, not the end state — a typed
+ * `structuredLogger` sink is a cheap follow-on now that the call sites carry
+ * `(message, fields)`. It is also already better than what a pino host got before,
+ * which was printf varargs flattened into the message with no field names at all.
  */
 
 let current: OneSubLogger = console;
@@ -16,70 +36,8 @@ export function setLogger(logger: OneSubLogger | undefined): void {
   if (logger) current = logger;
 }
 
-/**
- * Neutralise line breaks in a logged string.
- *
- * Much of what this server logs is attacker-influenced: `userId` comes off the
- * request body, and bundle ids, package names and receipt previews come out of
- * submitted receipts. A newline in any of those lets a caller close the current
- * log line and write a whole entry of their own — so a `userId` of
- * `alice\n[onesub] admin granted premium to mallory` forges an audit record.
- * These logs are what support and fraud decisions are read from, so the forgery
- * matters more than the noise.
- *
- * Escaped rather than stripped: the substitution has to be visible, or scrubbing
- * would quietly merge two lines into one plausible-looking line. Only the
- * characters that can end a log line are touched; tabs and everything else are
- * left alone.
- */
-function escapeLineBreaks(value: string): string {
-  // Backslash goes FIRST, and that ordering is the whole point of this function
-  // being written out rather than done in one pass. Escaping `\n` to `\` + `n`
-  // without escaping `\` first makes two different inputs produce identical
-  // output: a real line terminator, and the two characters a caller typed. An
-  // operator reading the log then cannot tell which one they are looking at,
-  // which costs exactly the forensic value the escaping exists to protect.
-  //
-  // With this ordering a real newline renders as `\n` and a submitted backslash-n
-  // renders as `\\n`, so the two stay distinguishable.
-  //
-  // One literal replacement per character rather than a single regex with a
-  // callback. That form was adopted hoping CodeQL's js/log-injection sanitiser
-  // recognition would follow it; it did not, and the alert points at the spread
-  // in `log.*` rather than here. It is kept because it reads more plainly, not
-  // because it satisfies an analyser.
-  return value
-    .replace(/\\/g, '\\\\')
-    .replace(/\r/g, '\\r')
-    .replace(/\n/g, '\\n')
-    .replace(/\u2028/g, '\\u2028')
-    .replace(/\u2029/g, '\\u2029');
-}
-
-/**
- * Applied to top-level string arguments only. Objects and `Error`s pass through
- * untouched, which is a real and deliberate gap rather than an oversight: an
- * `Error` reaching `log.error('...:', err)` can carry attacker-influenced text in
- * its message, so a newline there can still break a line.
- *
- * It is left that way because the alternative is worse. A stack trace is multi-line
- * by nature and is the main reason to log an `Error` at all; escaping its newlines
- * would turn every trace into one unreadable line, and escaping only `message`
- * achieves nothing because `stack` repeats it. Recursively rewriting strings inside
- * objects would likewise corrupt structured fields an operator asked to see.
- *
- * So the guarantee is scoped: message strings this server composes cannot be used
- * to forge a line. Reading a trace still requires distinguishing it from
- * surrounding entries by context, as it always has. CodeQL reports this gap on the
- * spread in `log.*` and is correct to; the alert is dismissed as won't-fix with
- * this reasoning, not as a false positive.
- */
-function scrub(args: unknown[]): unknown[] {
-  return args.map((arg) => (typeof arg === 'string' ? escapeLineBreaks(arg) : arg));
-}
-
 export const log: OneSubLogger = {
-  info: (...args) => current.info(...scrub(args)),
-  warn: (...args) => current.warn(...scrub(args)),
-  error: (...args) => current.error(...scrub(args)),
+  info: (...args) => current.info(formatLogArgs(args)),
+  warn: (...args) => current.warn(formatLogArgs(args)),
+  error: (...args) => current.error(formatLogArgs(args)),
 };

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -180,9 +180,20 @@ export interface GoogleNotificationPayload {
 }
 
 /**
- * Structured logger interface — compatible with the common shape of
- * `pino`, `winston`, `bunyan`, and `console`. Pass your own implementation
- * via `OneSubServerConfig.logger` to redirect onesub's runtime logs.
+ * Log sink — compatible with the common shape of `pino`, `winston`, `bunyan`, and
+ * `console`. Pass your own implementation via `OneSubServerConfig.logger` to
+ * redirect onesub's runtime logs.
+ *
+ * `@onesub/server` calls this with **exactly one string argument** per log, so a
+ * `pino` or `winston` host receives it as `msg` with nothing to interpolate.
+ * Contextual values arrive inside that string as `key=value` pairs, which logfmt
+ * parsers (Loki, Splunk, Datadog, CloudWatch Insights) extract as fields. The
+ * server renders them itself rather than passing an object, because a trailing
+ * object is only escaped by some sinks and is dropped entirely by a JSON
+ * serialiser when it holds an `Error`.
+ *
+ * The React Native SDK uses the same type but still calls it printf-style, with
+ * `'[onesub]'` as the first argument.
  *
  * Default: `console` (when `logger` is omitted).
  */
@@ -363,9 +374,12 @@ export interface OneSubServerConfig {
    */
   metricsCacheTtlSeconds?: number;
   /**
-   * Structured logger to receive onesub's runtime logs. If omitted, logs go
-   * to `console.info/warn/error`. Any object that implements `OneSubLogger`
+   * Log sink for onesub's runtime logs. If omitted, logs go to
+   * `console.info/warn/error`. Any object that implements `OneSubLogger`
    * (`pino`, `winston`, `bunyan`, `console`) works.
+   *
+   * Receives one pre-formatted string per log, with contextual values as
+   * `key=value` pairs inside it — see `OneSubLogger`.
    */
   logger?: OneSubLogger;
   /**


### PR DESCRIPTION
PR 1 of the structured-logging work. The whole anti-forgery fix ships in this one;
the following PRs migrate call sites to `(message, fields)` so values become
queryable.

## What changed

`config.logger` now receives **exactly one string** per log: the message, contextual
values as `key=value`, and any stack as `    | ` continuation lines.

```
[onesub/validate] account binding mismatch route=validate userId="alice\nFORGED"
validation failed userId=alice err=Error err.msg=boom
    | at validateAppleReceipt (/app/providers/apple.js:283:11)
    | at handleValidate (/app/routes/validate.js:64:5)
```

## The reframing that unlocked it

`logger.ts` previously carried a comment concluding that a stack trace could not be
made safe, because escaping its newlines "would turn every trace into one unreadable
line". That is true only if the goal is *no newlines*.

The goal is actually **no byte supplied by a caller may begin a line.** Under that
framing the stack survives whole — attacker text can sit inside a record but never
start one — and forgery is still impossible. The invariant holds mechanically: the
message and every field pass through `esc`, so the only newlines in the output are
the ones the formatter writes itself.

## Why render here instead of handing the sink an object

Both verified rather than assumed:

| | `console` | JSON sink |
|---|---|---|
| `{ err: someError }` | stack renders with **real newlines** → still forgeable | **`{"err":{}}`** — the error vanishes, `Error` properties are non-enumerable |

And `pino`, which this package's own docs recommend in five places, treats a
trailing object as a printf interpolation argument rather than as fields. Leaving
escaping to the sink means it happens for some sinks and not others.

## Field quoting is a control

Values are quoted unless they match `[A-Za-z0-9_.:/@+-]`. An unquoted `userId` of
`alice productId=hacked` would be parsed as **two fields** by Loki, Splunk and
CloudWatch Insights — field injection rather than line injection, same shape of lie.
Tested by counting keys outside quotes the way a parser would.

## Incremental by construction

Argument handling is generic, not a fixed `(message, fields)` shape, so the 104
un-migrated printf-style call sites render sensibly today. No flag day, no
compatibility flag — files move one PR at a time.

## Tests

Two tests in `logger.test.ts` described the **retired** contract and were replaced
rather than quietly edited — `scrubs every string argument` and `passes non-strings
through unchanged`, both about positional varargs.

`log-format.test.ts` is new: 38 tests, centred on one property checked against a
hostile matrix of 17 inputs (CR, LF, CRLF, U+2028, U+2029, forged error messages,
cause chains, aggregate errors, thrown non-Errors, field *keys*, nested objects,
arrays, a literal backslash-n).

Writing them found a real hole: `Object.entries` evaluates getters eagerly, so one
throwing getter took down the entire log call. Fields are now read one key at a time
and a hostile property costs only its own value.

## Verified in the real server

Not only in tests. With `mockMode` off, a receipt whose first 60 characters carry a
newline and a forged `[onesub] admin granted premium to mallory` line produces:

```
[onesub/apple] Failed to decode receipt as JWS: Invalid Token or Protected Header
formatting | preview: "alice\n[onesub] admin granted premium to mallory\nmore..."
(len=52, parts=1)
```

One record. Forgery escaped inside it. Attempt still legible — a guarantee that hid
the attack would be worse than none. That call site is one of the un-migrated
three-argument ones, so it also demonstrates the incremental property.

An earlier attempt at this check via `onesub dev` logged nothing at all and proved
nothing; it is recorded here because "the test passed" and "the test ran" are
different claims.

## Honest notes

- **Fields are text inside the message, not typed JSON fields.** A typed sink is the
  planned follow-up now that call sites will carry `(message, fields)`. Still a
  strict improvement on what a pino host got before, which was printf varargs
  flattened with no field names at all.
- **No claim about the CodeQL alert.** Two previous attempts to satisfy
  `js/log-injection` by reshaping code did not work. If this PR's run clears it, the
  dismissal gets closed in a follow-up; if not, that is reported as-is.

## Verification

829 tests (was 792). `build`, `type-check`, `size` (37.78/40 KB — ceiling raised from
38 with the measurement recorded, formatter is +0.98 KB), `docs:check`, Unity
validator, dashboard build all pass.

Docs updated where this makes them wrong: `OneSubLogger` and `config.logger` doc
comments, `docs/CONFIGURATION.md`, `docs/ARCHITECTURE.md`, `AGENTS.md` source map,
plus a `docs/MIGRATION.md` entry — the sink's argument shape changes, which is not
drop-in for anyone inspecting beyond the first argument.

Changesets: `@onesub/server` minor, `@onesub/shared` patch (doc comments only).