### PR TITLE
feat(server): give Apple and Google log lines named fields

### DIFF
--- a/.changeset/plain-doors-migrate.md
+++ b/.changeset/plain-doors-migrate.md
@@ -1,0 +1,24 @@
+---
+'@onesub/server': minor
+---
+
+Move Apple and Google provider log values out of the message and into named
+`key=value` fields.
+
+The 49 `log.*` call sites in `providers/apple.ts` and `providers/google.ts` now pass
+a static message plus a fields object, so `productId`, `originalTransactionId`,
+`httpStatus`, `bundleId` and friends can be filtered on instead of being spelled
+into a sentence. Rejections that previously identified nothing — "Purchase was
+revoked/refunded", "No transactionId in consumable transaction" — now name the
+product and transaction they refused. Error paths pass the `Error` itself rather
+than `err.message`, so the stack survives as continuation lines.
+
+Log *text* changes for these two providers; the `[onesub/apple]` and
+`[onesub/google]` prefixes do not. See `docs/MIGRATION.md` for the before/after and
+the two reworded messages. Routes, stores and webhook handlers still interpolate and
+follow separately.
+
+Adds a source-scanning test that holds every `log.*` call site in the package to the
+field vocabulary declared in `log-format.ts`, because per-site assertions do not
+scale to ~100 sites — a rename of `productId` to `product` at one un-asserted site
+passed the whole suite before it existed.

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -4,6 +4,52 @@ Upgrade notes for releases of `@onesub/server` that need one. While the package 
 
 ---
 
+## `@onesub/server` 0.24.0 → 0.25.0
+
+### Apple and Google log lines carry `key=value` fields
+
+0.24.0 made every log arrive as one escaped string. This release changes what is
+*in* that string for the Apple and Google providers: the message is now a fixed
+literal and the values that used to be interpolated into it are named fields.
+
+```text
+before  [onesub/apple] Bundle ID mismatch: com.evil !== com.real
+after   [onesub/apple] Bundle ID mismatch bundleId=com.evil expected=com.real
+
+before  [onesub/google] Product receipt too old (>72h)
+after   [onesub/google] Product receipt too old productId=coins_50 orderId=GPA.1234 maxAgeHours=72 purchaseDate=2026-01-02T03:04:05.000Z
+```
+
+**Why.** A value spelled into a sentence cannot be filtered on, so "show me every
+rejection for `productId=coins_50`" was not answerable. It also cannot be redacted,
+which matters because these lines carry receipt content.
+
+**Impact.** Only if you match on log *text*. Alerts and saved searches that pin the
+old wording need updating; the change is mechanical:
+
+- Trailing colons are gone from messages that had a value after them
+  (`Bundle ID mismatch:` → `Bundle ID mismatch`).
+- Values interpolated into the message are now fields. `(>72h)` became
+  `maxAgeHours=72`; `Status API error 503: <body>` became
+  `Status API error httpStatus=503 originalTransactionId=… responseBody="<body>"`.
+- One message was reworded because the number in it became a field:
+  `Transaction History pagination hit the 50-page cap` is now
+  `Transaction History pagination hit the page cap` with `maxPages=50`.
+- Rejections that previously identified nothing now carry `productId` and, where
+  known, `transactionId` / `orderId`.
+
+The `[onesub/apple]` and `[onesub/google]` prefixes are unchanged, so anything
+grepping those still matches. Routes, stores and the webhook handlers are not part
+of this release and still interpolate; they follow in a later one.
+
+**Still not redacted.** Upstream error bodies are logged under `responseBody`, and a
+Google Play error body can echo the request URL, which contains a `purchaseToken` —
+a value that is enough to cancel a subscription. Naming the field is what makes
+redacting it possible; this release does not redact it. Treat these logs as
+credential-bearing.
+
+---
+
 ## `@onesub/server` 0.23.x → 0.24.0
 
 ### Your log sink now receives one pre-formatted string
@@ -15,8 +61,11 @@ stack trace as `    | `-prefixed continuation lines.
 
 ```text
 before  logger.warn('[onesub/apple] Bundle ID mismatch:', 'com.evil', '!==', 'com.real')
-after   logger.warn('[onesub/apple] bundle id mismatch bundleId=com.evil expected=com.real')
+after   logger.warn('[onesub/apple] Bundle ID mismatch: com.evil !== com.real')
 ```
+
+The message text itself is unchanged in 0.24.0 — only the argument count is. Call
+sites moved to `key=value` fields in 0.25.0; see the entry below.
 
 **Why.** Values interpolated into a message could not be escaped without also
 escaping the message, and a caller-supplied newline in one of them could end the log

--- a/packages/server/src/__tests__/field-vocabulary.test.ts
+++ b/packages/server/src/__tests__/field-vocabulary.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Holds every `log.*` call site in the package to the field vocabulary declared in
+ * `log-format.ts`.
+ *
+ * Why a source-scanning test rather than more per-call-site assertions. The value of
+ * moving data out of the message is that an operator can filter on `productId` — and
+ * that value is destroyed by one file calling it `product`, silently, on a path no
+ * test happens to exercise. That is not hypothetical: while building
+ * `provider-log-fields.test.ts` a mutation renaming `productId` to `product` at the
+ * "No orderId in product purchase" site **passed all 13 of its tests**, because that
+ * site is not one of the ones asserted. Covering ~100 sites individually to close
+ * that gap is not maintainable; checking the vocabulary once, over all of them, is.
+ *
+ * The vocabulary lives in `log-format.ts`'s module doc and is parsed out of it here,
+ * so there is exactly one list. A doc comment is an odd place for an enforced
+ * contract, but the alternative — an exported `const` array — would ship a
+ * test-only value in the bundle that `npm run size` gates.
+ *
+ * What this test cannot do: it does not know whether a field is *correctly named*
+ * for its value, only that the name is one of the sanctioned ones. `bundleId:
+ * tx.productId` passes here. Per-site assertions in `provider-log-fields.test.ts`
+ * cover that for the paths that matter.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const SRC = dirname(dirname(fileURLToPath(import.meta.url)));
+
+/** Every .ts file under packages/server/src, excluding tests. */
+function sourceFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === '__tests__' || entry === 'node_modules') continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) sourceFiles(full, out);
+    else if (entry.endsWith('.ts')) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * The argument text of every `log.<level>( ... )` call, with string literals blanked.
+ *
+ * Blanking rather than removing keeps offsets stable and, more importantly, stops a
+ * message like `'state:'` from being mistaken for a field key.
+ */
+function logCallArgs(src: string): string[] {
+  const calls: string[] = [];
+  const re = /\blog\.(?:info|warn|error)\(/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = re.exec(src)) !== null) {
+    let i = match.index + match[0].length;
+    const start = i;
+    let depth = 1;
+    let text = '';
+
+    while (i < src.length && depth > 0) {
+      const ch = src[i]!;
+      if (ch === "'" || ch === '"' || ch === '`') {
+        // Skip the literal, emitting spaces so a quoted `foo:` cannot read as a key.
+        const quote = ch;
+        text += ' ';
+        i++;
+        while (i < src.length && src[i] !== quote) {
+          if (src[i] === '\\') {
+            text += ' ';
+            i++;
+          }
+          text += ' ';
+          i++;
+        }
+        text += ' ';
+        i++;
+        continue;
+      }
+      if (ch === '(') depth++;
+      else if (ch === ')') depth--;
+      if (depth > 0) text += ch;
+      i++;
+    }
+
+    if (start < src.length) calls.push(text);
+  }
+
+  return calls;
+}
+
+/**
+ * Field keys used in one log call — `{ a: expr, b }` yields `a` and `b`.
+ *
+ * A regex cannot do this: `{ product: productId }` matches `productId` as a
+ * shorthand key just as readily as `product`, which made the first version of this
+ * test report both. So it walks the object at brace depth 1, reading an identifier
+ * as a key and then, if a `:` follows, skipping the value expression entirely.
+ *
+ * Still not an AST — nested objects and arrays are skipped as opaque values rather
+ * than descended into, because a nested field is not something an operator filters
+ * on anyway.
+ */
+function fieldKeys(callText: string): string[] {
+  const open = callText.indexOf('{');
+  if (open === -1) return [];
+
+  const keys: string[] = [];
+  let i = open + 1;
+  let depth = 1;
+
+  while (i < callText.length && depth > 0) {
+    const ch = callText[i]!;
+
+    if (/\s|,/.test(ch)) {
+      i++;
+      continue;
+    }
+    if (ch === '}') break;
+
+    // An identifier in key position.
+    const ident = /^[A-Za-z_$][\w$]*/.exec(callText.slice(i));
+    if (!ident) {
+      i++;
+      continue;
+    }
+    const name = ident[0];
+    let j = i + name.length;
+    while (j < callText.length && /\s/.test(callText[j]!)) j++;
+
+    if (callText[j] === ':') {
+      // `name: <expr>` — record the key, then skip the value to the next comma at
+      // this depth (or the closing brace).
+      keys.push(name);
+      j++;
+      while (j < callText.length) {
+        const v = callText[j]!;
+        if (v === '{' || v === '[') depth++;
+        else if (v === ']') depth--;
+        else if (v === '}') {
+          if (depth === 1) break;
+          depth--;
+        } else if (v === ',' && depth === 1) break;
+        j++;
+      }
+      i = j;
+      continue;
+    }
+
+    // Shorthand `{ name }` or `{ name, ... }`.
+    if (callText[j] === ',' || callText[j] === '}' || j >= callText.length) keys.push(name);
+    i = j;
+  }
+
+  return keys;
+}
+
+/** Parse the enforced list out of `log-format.ts`'s module doc. */
+function vocabulary(): Set<string> {
+  const src = readFileSync(join(SRC, 'log-format.ts'), 'utf8');
+  const block = /FIELD VOCABULARY START([\s\S]*?)FIELD VOCABULARY END/.exec(src);
+  if (!block) throw new Error('log-format.ts no longer declares a FIELD VOCABULARY block');
+  return new Set(block[1]!.match(/[A-Za-z_$][\w$]*/g) ?? []);
+}
+
+describe('log field vocabulary', () => {
+  const allowed = vocabulary();
+
+  it('is declared in log-format.ts and non-trivial', () => {
+    // A parse that silently produced {} would make every assertion below vacuous.
+    expect(allowed.size).toBeGreaterThan(10);
+    expect(allowed.has('productId')).toBe(true);
+    expect(allowed.has('err')).toBe(true);
+  });
+
+  it('covers every field name used at every log call site', () => {
+    const offenders: string[] = [];
+
+    for (const file of sourceFiles(SRC)) {
+      const src = readFileSync(file, 'utf8');
+      for (const call of logCallArgs(src)) {
+        for (const key of fieldKeys(call)) {
+          if (!allowed.has(key)) offenders.push(`${file.slice(SRC.length + 1)}: ${key}`);
+        }
+      }
+    }
+
+    // Listing them is the point — the message has to say which name to fix.
+    expect(offenders).toEqual([]);
+  });
+
+  it('actually finds the call sites it claims to check', () => {
+    // Without this, a regex that matched nothing would report a clean sweep.
+    const apple = readFileSync(join(SRC, 'providers', 'apple.ts'), 'utf8');
+    const calls = logCallArgs(apple);
+    const keys = calls.flatMap(fieldKeys);
+
+    expect(calls.length).toBeGreaterThan(20);
+    expect(keys).toContain('bundleId');
+    expect(keys).toContain('originalTransactionId');
+    expect(keys).toContain('err');
+  });
+
+  it('does not mistake text inside a message for a field name', () => {
+    // The pre-migration style was `log.warn('... state:', value)`. If the scanner
+    // read inside string literals, `state` would look like a field key.
+    const keys = logCallArgs(`log.warn('[onesub/x] Purchase not completed, state:', v);`).flatMap(fieldKeys);
+
+    expect(keys).toEqual([]);
+  });
+
+  it('rejects a synonym, which is the drift it exists to catch', () => {
+    const keys = logCallArgs(`log.warn('msg', { product: productId });`).flatMap(fieldKeys);
+
+    expect(keys).toEqual(['product']);
+    expect(allowed.has('product')).toBe(false);
+  });
+});

--- a/packages/server/src/__tests__/provider-log-fields.test.ts
+++ b/packages/server/src/__tests__/provider-log-fields.test.ts
@@ -1,0 +1,316 @@
+/**
+ * What the Apple and Google providers actually put on a log line.
+ *
+ * These paths had **no log assertions at all** before this file, which is worth
+ * stating plainly: the 49 call sites in `providers/apple.ts` and
+ * `providers/google.ts` could have been migrated to `(message, fields)` — or
+ * broken — and the whole suite would have stayed green either way. So this file
+ * is not belt-and-braces on top of `log-format.test.ts`; it is the only thing
+ * that holds the providers to the contract.
+ *
+ * It tests through the real provider functions rather than through
+ * `formatLogArgs`, because the two failure modes that matter are call-site
+ * failures a pure formatter test cannot see:
+ *
+ *   1. **A value left in the message.** `formatLogArgs` escapes whatever it is
+ *      given; it cannot know that `bundleId` should have been a field. Only an
+ *      assertion on the rendered line catches an interpolated value.
+ *   2. **A field named differently in two places.** The point of moving values
+ *      out of the message is that an operator can filter on `productId`. That is
+ *      lost the moment one file calls it `product` — and nothing but an exact
+ *      assertion notices.
+ *
+ * Hence exact-line assertions, not `toContain`. A substring match would pass on
+ * `productId=x` *and* on a message that happened to mention it.
+ */
+
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { generateKeyPairSync } from 'crypto';
+import type { OneSubLogger } from '@onesub/shared';
+import { setLogger } from '../logger.js';
+import { LOG_CONTINUATION } from '../log-format.js';
+import { validateAppleConsumableReceipt, validateAppleReceipt } from '../providers/apple.js';
+import { validateGoogleProductReceipt, validateGoogleReceipt } from '../providers/google.js';
+import { urlHost } from './test-utils.js';
+
+/** Collects rendered lines. The facade hands the sink exactly one string. */
+function capture() {
+  const lines: string[] = [];
+  const logger: OneSubLogger = {
+    info: (...args: unknown[]) => lines.push(args[0] as string),
+    warn: (...args: unknown[]) => lines.push(args[0] as string),
+    error: (...args: unknown[]) => lines.push(args[0] as string),
+  };
+  setLogger(logger);
+  return lines;
+}
+
+afterEach(() => {
+  setLogger(console);
+  vi.restoreAllMocks();
+});
+
+/**
+ * The invariant from `log-format.ts`, re-checked on real provider output: no byte
+ * a caller supplied may begin a line. Continuation lines are ours, so they are
+ * allowed — anything else starting a line means a value escaped its field.
+ */
+function noForgedLine(rendered: string): boolean {
+  const cont = LOG_CONTINUATION.slice(1); // drop the leading \n
+  return rendered
+    .split('\n')
+    .slice(1)
+    .every((line) => line.startsWith(cont));
+}
+
+/** A hostile value that tries to close its field and open a new record. */
+const FORGED = 'com.evil\n[onesub/apple] entitlement granted to mallory';
+
+function makeJws(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'ES256' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.fakesig`;
+}
+
+const APPLE_CONFIG = { bundleId: 'com.example.app', skipJwsVerification: true as const };
+
+let testPrivateKey: string;
+
+beforeAll(() => {
+  // getAccessToken() signs a real assertion, so the key has to be real. 2048-bit
+  // is CodeQL's minimum; generated once per suite.
+  const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  testPrivateKey = privateKey.export({ type: 'pkcs8', format: 'pem' }) as string;
+});
+
+/** A usable Play config. The email varies because the token cache is keyed on it. */
+function googleConfig(seed: string) {
+  return {
+    packageName: 'com.example.app',
+    serviceAccountKey: JSON.stringify({
+      client_email: `${seed}@test.iam.gserviceaccount.com`,
+      private_key: testPrivateKey,
+      token_uri: 'https://oauth2.googleapis.com/token',
+    }),
+  };
+}
+
+function applePayload(overrides?: Record<string, unknown>): Record<string, unknown> {
+  return {
+    bundleId: 'com.example.app',
+    type: 'Consumable',
+    productId: 'credits_100',
+    transactionId: 'txn_001',
+    originalTransactionId: 'orig_001',
+    purchaseDate: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('apple: rejections carry the identifier an operator would filter on', () => {
+  it('bundle ID mismatch names both sides', async () => {
+    const lines = capture();
+
+    await validateAppleConsumableReceipt(makeJws(applePayload({ bundleId: 'com.other' })), APPLE_CONFIG);
+
+    expect(lines).toEqual([
+      '[onesub/apple] Bundle ID mismatch bundleId=com.other expected=com.example.app',
+    ]);
+  });
+
+  it('product ID mismatch names both sides', async () => {
+    const lines = capture();
+
+    await validateAppleConsumableReceipt(makeJws(applePayload()), APPLE_CONFIG, 'credits_500');
+
+    expect(lines).toEqual([
+      '[onesub/apple] Product ID mismatch productId=credits_100 expected=credits_500',
+    ]);
+  });
+
+  it('a revoked purchase is attributable', async () => {
+    // Without productId/transactionId this line said only "Purchase was
+    // revoked/refunded" — true, and useless: an operator could not tell whose.
+    const lines = capture();
+
+    await validateAppleConsumableReceipt(
+      makeJws(applePayload({ revocationDate: Date.now() })),
+      APPLE_CONFIG,
+    );
+
+    expect(lines).toEqual([
+      '[onesub/apple] Purchase was revoked/refunded productId=credits_100 transactionId=txn_001',
+    ]);
+  });
+
+  it('a too-old receipt reports the window it missed and by how far', async () => {
+    const purchaseDate = Date.UTC(2020, 0, 2, 3, 4, 5);
+    const lines = capture();
+
+    await validateAppleConsumableReceipt(makeJws(applePayload({ purchaseDate })), APPLE_CONFIG);
+
+    // The threshold is a field, so `maxAgeHours=72` is filterable rather than
+    // being spelled into the sentence as `(>72h)`.
+    expect(lines).toEqual([
+      '[onesub/apple] Consumable receipt too old productId=credits_100 maxAgeHours=72 ' +
+        'purchaseDate=2020-01-02T03:04:05.000Z',
+    ]);
+  });
+
+  it('a missing transactionId still names the product', async () => {
+    const lines = capture();
+    const payload = applePayload();
+    delete payload['transactionId'];
+    delete payload['originalTransactionId'];
+
+    await validateAppleConsumableReceipt(makeJws(payload), APPLE_CONFIG);
+
+    expect(lines).toEqual(['[onesub/apple] No transactionId in consumable transaction productId=credits_100']);
+  });
+});
+
+describe('apple: attacker-supplied values cannot leave their field', () => {
+  it('a forged bundleId is quoted and escaped', async () => {
+    // bundleId is read out of the JWS. `peekAppleBundleId` in apps.ts reads it
+    // from an *unverified* one, so treating it as hostile is not hypothetical.
+    const lines = capture();
+
+    await validateAppleReceipt(makeJws({ ...applePayload(), bundleId: FORGED, expiresDate: Date.now() }), APPLE_CONFIG);
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toBe(
+      '[onesub/apple] Bundle ID mismatch ' +
+        'bundleId="com.evil\\n[onesub/apple] entitlement granted to mallory" ' +
+        'expected=com.example.app',
+    );
+    expect(noForgedLine(lines[0]!)).toBe(true);
+  });
+
+  it('an undecodable receipt reports a preview without becoming a second record', async () => {
+    // The whole receipt is attacker-supplied here, and the preview is the one
+    // field that deliberately carries raw request bytes.
+    const lines = capture();
+
+    const receipt = `${FORGED} not-a-jws`;
+
+    await validateAppleReceipt(receipt, APPLE_CONFIG);
+
+    expect(lines).toHaveLength(1);
+    const [rendered] = lines as [string];
+    expect(noForgedLine(rendered)).toBe(true);
+    expect(rendered.startsWith('[onesub/apple] Failed to decode receipt as JWS receiptPreview="com.evil\\n')).toBe(true);
+    // Length and part count are separate fields, not prose inside the preview.
+    // Derived from the input rather than hardcoded: a literal would silently stop
+    // describing the receipt if FORGED were ever edited.
+    expect(rendered).toContain(` receiptLength=${receipt.length} jwsParts=${receipt.split('.').length} `);
+    // Passing `err` rather than `err.message` is what keeps the stack — the
+    // previous call site threw it away.
+    expect(rendered).toContain(' err=');
+    expect(rendered).toContain(`${LOG_CONTINUATION}at `);
+  });
+});
+
+describe('google: rejections carry productId, and never the purchaseToken', () => {
+  function mockPlayFetch(purchase: Record<string, unknown>) {
+    vi.spyOn(global, 'fetch').mockImplementation(async (url) => {
+      const host = urlHost(url);
+      if (host === 'oauth2.googleapis.com') {
+        return { ok: true, json: async () => ({ access_token: 't', expires_in: 3600 }), text: async () => '' } as Response;
+      }
+      if (host === 'androidpublisher.googleapis.com') {
+        return { ok: true, json: async () => purchase, text: async () => JSON.stringify(purchase) } as Response;
+      }
+      throw new Error(`[test] Unexpected fetch URL: ${String(url)}`);
+    });
+  }
+
+  it('a misconfiguration names the product that was refused', async () => {
+    const lines = capture();
+
+    await validateGoogleProductReceipt('token_abc', 'coins_50', { packageName: 'com.example.app' });
+
+    expect(lines).toEqual([
+      '[onesub/google] No serviceAccountKey — cannot validate product receipt productId=coins_50',
+    ]);
+  });
+
+  it('an uncompleted purchase reports state and orderId', async () => {
+    mockPlayFetch({ purchaseState: 2, orderId: 'GPA.1234', purchaseTimeMillis: String(Date.now()) });
+    const lines = capture();
+
+    await validateGoogleProductReceipt('token_abc', 'coins_50', googleConfig('uncompleted'));
+
+    expect(lines).toEqual([
+      '[onesub/google] Purchase not completed productId=coins_50 purchaseState=2 orderId=GPA.1234',
+    ]);
+  });
+
+  it('a replayed consumable is attributable to an order', async () => {
+    mockPlayFetch({
+      purchaseState: 0,
+      consumptionState: 1,
+      orderId: 'GPA.1234',
+      purchaseTimeMillis: String(Date.now()),
+    });
+    const lines = capture();
+
+    await validateGoogleProductReceipt('token_abc', 'coins_50', googleConfig('replay'), 'consumable');
+
+    expect(lines).toEqual([
+      '[onesub/google] Consumable already consumed — possible replay attack productId=coins_50 orderId=GPA.1234',
+    ]);
+  });
+
+  it('does not log the purchaseToken, which can cancel a subscription', async () => {
+    // These call sites have `purchaseToken` in scope, so "tidying values into
+    // fields" could have swept it in. By webhook-google.ts's own warning a
+    // purchaseToken is enough to cancel a subscription; a value that grants a
+    // capability does not belong in a log line that was not carrying it before.
+    const lines = capture();
+
+    await validateGoogleProductReceipt('SECRET_CAPABILITY_TOKEN', 'coins_50', {
+      packageName: 'com.example.app',
+    });
+
+    expect(lines.join('\n')).not.toContain('SECRET_CAPABILITY_TOKEN');
+  });
+
+  it('a hostile productId is quoted rather than starting a record', async () => {
+    // productId comes straight off the request body.
+    const lines = capture();
+
+    await validateGoogleReceipt('token_abc', FORGED, { packageName: 'com.example.app' });
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toBe(
+      '[onesub/google] No serviceAccountKey provided — cannot call Play API ' +
+        'productId="com.evil\\n[onesub/apple] entitlement granted to mallory"',
+    );
+    expect(noForgedLine(lines[0]!)).toBe(true);
+  });
+
+  it('renders the available lineItem products as one field, not a joined sentence', async () => {
+    vi.spyOn(global, 'fetch').mockImplementation(async (url) => {
+      const host = urlHost(url);
+      if (host === 'oauth2.googleapis.com') {
+        return { ok: true, json: async () => ({ access_token: 't', expires_in: 3600 }), text: async () => '' } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          subscriptionState: 'SUBSCRIPTION_STATE_ACTIVE',
+          lineItems: [{ productId: 'monthly' }, { productId: 'yearly' }],
+        }),
+        text: async () => '',
+      } as Response;
+    });
+    const lines = capture();
+
+    await validateGoogleReceipt('token_abc', 'weekly', googleConfig('lineitems'));
+
+    expect(lines).toEqual([
+      '[onesub/google] productId not found in subscription lineItems ' +
+        'productId=weekly availableProductIds="[\\"monthly\\",\\"yearly\\"]"',
+    ]);
+  });
+});

--- a/packages/server/src/log-format.ts
+++ b/packages/server/src/log-format.ts
@@ -37,11 +37,23 @@
  *
  * Use these names and no synonyms — `userId`, not `user` or `uid`. The point of
  * moving values out of the message is that an operator can filter on them, and that
- * is lost the moment the same thing is called three things across 16 files:
+ * is lost the moment the same thing is called three things across 16 files.
  *
- *   route · provider · userId · appId · platform · productId · transactionId ·
- *   originalTransactionId · purchaseToken · orderId · bundleId · packageName ·
- *   notificationType · status · httpStatus · environment · err
+ * This list is **mechanically enforced**: `field-vocabulary.test.ts` parses the
+ * block below and fails if any `log.*` call site in the package uses a name that is
+ * not in it. So the list is the contract, not a suggestion — adding a field means
+ * adding it here first. That check exists because per-call-site tests do not scale
+ * to ~100 sites: a mutation renaming `productId` to `product` at one un-asserted
+ * site passed the entire suite before it was added.
+ *
+ * FIELD VOCABULARY START
+ *   route provider userId appId platform productId transactionId
+ *   originalTransactionId purchaseToken orderId bundleId packageName
+ *   notificationType status httpStatus environment err
+ *   expected type subscriptionState purchaseState maxAgeHours purchaseDate
+ *   receiptPreview receiptLength jwsParts looksLikeJws responseBody
+ *   availableProductIds maxPages pageCount outcome
+ * FIELD VOCABULARY END
  *
  * `err` is reserved: it always routes through the error renderer.
  *

--- a/packages/server/src/providers/apple.ts
+++ b/packages/server/src/providers/apple.ts
@@ -279,11 +279,12 @@ export async function validateAppleReceipt(
   } catch (err) {
     const preview = receipt.slice(0, 60);
     const parts = receipt.split('.').length;
-    log.warn(
-      '[onesub/apple] Failed to decode receipt as JWS:',
-      (err as Error)?.message ?? err,
-      `| preview: "${preview}..." (len=${receipt.length}, parts=${parts})`,
-    );
+    log.warn('[onesub/apple] Failed to decode receipt as JWS', {
+      receiptPreview: preview,
+      receiptLength: receipt.length,
+      jwsParts: parts,
+      err,
+    });
     return null;
   }
 
@@ -293,7 +294,7 @@ export async function validateAppleReceipt(
 
   // Validate bundle ID — missing or mismatched both rejected
   if (!tx.bundleId || tx.bundleId !== config.bundleId) {
-    log.warn('[onesub/apple] Bundle ID mismatch:', tx.bundleId, '!==', config.bundleId);
+    log.warn('[onesub/apple] Bundle ID mismatch', { bundleId: tx.bundleId, expected: config.bundleId });
     return null;
   }
 
@@ -305,7 +306,7 @@ export async function validateAppleReceipt(
     tx.environment !== 'Production' &&
     process.env['ONESUB_ALLOW_SANDBOX'] !== 'true'
   ) {
-    log.warn('[onesub/apple] Sandbox receipt rejected in production:', tx.environment);
+    log.warn('[onesub/apple] Sandbox receipt rejected in production', { environment: tx.environment });
     return null;
   }
 
@@ -379,23 +380,25 @@ export async function validateAppleConsumableReceipt(
     const preview = signedTransaction.slice(0, 60);
     const parts = signedTransaction.split('.').length;
     const looksLikeJws = parts === 3;
-    log.warn(
-      '[onesub/apple] Failed to decode consumable JWS:',
-      (err as Error)?.message ?? err,
-      `| receipt preview: "${preview}..." (len=${signedTransaction.length}, parts=${parts}, looksLikeJws=${looksLikeJws})`,
-    );
+    log.warn('[onesub/apple] Failed to decode consumable JWS', {
+      receiptPreview: preview,
+      receiptLength: signedTransaction.length,
+      jwsParts: parts,
+      looksLikeJws,
+      err,
+    });
     return null;
   }
 
   // bundleId must be present and match
   if (!tx.bundleId || tx.bundleId !== config.bundleId) {
-    log.warn('[onesub/apple] Bundle ID mismatch:', tx.bundleId, '!==', config.bundleId);
+    log.warn('[onesub/apple] Bundle ID mismatch', { bundleId: tx.bundleId, expected: config.bundleId });
     return null;
   }
 
   // Must be a one-time purchase type (not a subscription)
   if (tx.type !== 'Consumable' && tx.type !== 'Non-Consumable') {
-    log.warn('[onesub/apple] Invalid purchase type for product validation:', tx.type);
+    log.warn('[onesub/apple] Invalid purchase type for product validation', { type: tx.type });
     return null;
   }
 
@@ -407,7 +410,7 @@ export async function validateAppleConsumableReceipt(
     tx.environment !== 'Production' &&
     process.env['ONESUB_ALLOW_SANDBOX'] !== 'true'
   ) {
-    log.warn('[onesub/apple] Sandbox receipt rejected in production:', tx.environment);
+    log.warn('[onesub/apple] Sandbox receipt rejected in production', { environment: tx.environment });
     return null;
   }
 
@@ -417,13 +420,16 @@ export async function validateAppleConsumableReceipt(
   }
 
   if (expectedProductId && tx.productId !== expectedProductId) {
-    log.warn('[onesub/apple] Product ID mismatch:', tx.productId, '!==', expectedProductId);
+    log.warn('[onesub/apple] Product ID mismatch', { productId: tx.productId, expected: expectedProductId });
     return null;
   }
 
   // Reject refunded purchases
   if (tx.revocationDate) {
-    log.warn('[onesub/apple] Purchase was revoked/refunded');
+    log.warn('[onesub/apple] Purchase was revoked/refunded', {
+      productId: tx.productId,
+      transactionId: tx.transactionId,
+    });
     return null;
   }
 
@@ -432,7 +438,11 @@ export async function validateAppleConsumableReceipt(
   // receipts on purpose (migrations from another IAP backend, e2e tests).
   const maxAgeMs = (config.productReceiptMaxAgeHours ?? 72) * 60 * 60 * 1000;
   if (tx.purchaseDate && Date.now() - tx.purchaseDate > maxAgeMs) {
-    log.warn(`[onesub/apple] Consumable receipt too old (>${config.productReceiptMaxAgeHours ?? 72}h)`);
+    log.warn('[onesub/apple] Consumable receipt too old', {
+      productId: tx.productId,
+      maxAgeHours: config.productReceiptMaxAgeHours ?? 72,
+      purchaseDate: new Date(tx.purchaseDate).toISOString(),
+    });
     return null;
   }
 
@@ -441,7 +451,7 @@ export async function validateAppleConsumableReceipt(
   // as the deduplication key for consumables.
   const transactionId = tx.transactionId ?? tx.originalTransactionId;
   if (!transactionId) {
-    log.warn('[onesub/apple] No transactionId in consumable transaction');
+    log.warn('[onesub/apple] No transactionId in consumable transaction', { productId: tx.productId });
     return null;
   }
 
@@ -637,7 +647,7 @@ export async function sendAppleConsumptionResponse(
   try {
     jwt = await makeAppleApiJwt(config);
   } catch (err) {
-    log.warn('[onesub/apple] Cannot send consumption response — JWT mint failed:', err);
+    log.warn('[onesub/apple] Cannot send consumption response — JWT mint failed', { transactionId, err });
     return;
   }
 
@@ -657,10 +667,14 @@ export async function sendAppleConsumptionResponse(
     });
     if (!resp.ok) {
       const text = await resp.text();
-      log.warn(`[onesub/apple] Consumption response API error ${resp.status}: ${text}`);
+      log.warn('[onesub/apple] Consumption response API error', {
+        httpStatus: resp.status,
+        transactionId,
+        responseBody: text,
+      });
     }
   } catch (err) {
-    log.warn('[onesub/apple] Consumption response network error:', err);
+    log.warn('[onesub/apple] Consumption response network error', { transactionId, err });
   }
 }
 
@@ -737,7 +751,10 @@ export async function fetchAppleSubscriptionStatus(
   try {
     jwt = await makeAppleApiJwt(config);
   } catch (err) {
-    log.warn('[onesub/apple] Cannot fetch subscription status — JWT mint failed:', err);
+    log.warn('[onesub/apple] Cannot fetch subscription status — JWT mint failed', {
+      originalTransactionId,
+      err,
+    });
     return null;
   }
 
@@ -753,12 +770,16 @@ export async function fetchAppleSubscriptionStatus(
     });
     if (!resp.ok) {
       const text = await resp.text();
-      log.warn(`[onesub/apple] Status API error ${resp.status}: ${text}`);
+      log.warn('[onesub/apple] Status API error', {
+        httpStatus: resp.status,
+        originalTransactionId,
+        responseBody: text,
+      });
       return null;
     }
     body = (await resp.json()) as AppleSubscriptionStatusResponse;
   } catch (err) {
-    log.warn('[onesub/apple] Status API network error:', err);
+    log.warn('[onesub/apple] Status API network error', { originalTransactionId, err });
     return null;
   }
 
@@ -769,7 +790,7 @@ export async function fetchAppleSubscriptionStatus(
     .find((t) => t.originalTransactionId === originalTransactionId);
 
   if (!entry || entry.status == null || !entry.signedTransactionInfo) {
-    log.warn('[onesub/apple] Status API returned no matching transaction for', originalTransactionId);
+    log.warn('[onesub/apple] Status API returned no matching transaction', { originalTransactionId });
     return null;
   }
 
@@ -777,7 +798,10 @@ export async function fetchAppleSubscriptionStatus(
   try {
     tx = await decodeJws<AppleTransactionPayload>(entry.signedTransactionInfo, config.skipJwsVerification);
   } catch (err) {
-    log.warn('[onesub/apple] Failed to decode signedTransactionInfo from Status API:', err);
+    log.warn('[onesub/apple] Failed to decode signedTransactionInfo from Status API', {
+      originalTransactionId,
+      err,
+    });
     return null;
   }
 
@@ -791,7 +815,10 @@ export async function fetchAppleSubscriptionStatus(
   }
 
   if (!tx.productId || !tx.expiresDate) {
-    log.warn('[onesub/apple] Status API transaction missing productId or expiresDate');
+    log.warn('[onesub/apple] Status API transaction missing productId or expiresDate', {
+      originalTransactionId,
+      productId: tx.productId,
+    });
     return null;
   }
 
@@ -866,7 +893,10 @@ export async function fetchAppleTransactionHistory(
   try {
     jwt = await makeAppleApiJwt(config);
   } catch (err) {
-    log.warn('[onesub/apple] Cannot fetch transaction history — JWT mint failed:', err);
+    log.warn('[onesub/apple] Cannot fetch transaction history — JWT mint failed', {
+      originalTransactionId,
+      err,
+    });
     return null;
   }
 
@@ -889,12 +919,16 @@ export async function fetchAppleTransactionHistory(
       });
       if (!resp.ok) {
         const text = await resp.text();
-        log.warn(`[onesub/apple] Transaction History API error ${resp.status}: ${text}`);
+        log.warn('[onesub/apple] Transaction History API error', {
+          httpStatus: resp.status,
+          originalTransactionId,
+          responseBody: text,
+        });
         return null;
       }
       page = (await resp.json()) as AppleTransactionHistoryResponse;
     } catch (err) {
-      log.warn('[onesub/apple] Transaction History API network error:', err);
+      log.warn('[onesub/apple] Transaction History API network error', { originalTransactionId, err });
       return null;
     }
 
@@ -925,13 +959,15 @@ export async function fetchAppleTransactionHistory(
     if (!page.revision || page.revision === revision) {
       log.warn(
         '[onesub/apple] Transaction History API returned hasMore without a new revision cursor — stopping pagination (partial history returned)',
+        { originalTransactionId, pageCount },
       );
       break;
     }
     if (pageCount >= MAX_HISTORY_PAGES) {
-      log.warn(
-        `[onesub/apple] Transaction History pagination hit the ${MAX_HISTORY_PAGES}-page cap — stopping (partial history returned)`,
-      );
+      log.warn('[onesub/apple] Transaction History pagination hit the page cap — stopping (partial history returned)', {
+        originalTransactionId,
+        maxPages: MAX_HISTORY_PAGES,
+      });
       break;
     }
     revision = page.revision;

--- a/packages/server/src/providers/google.ts
+++ b/packages/server/src/providers/google.ts
@@ -350,7 +350,7 @@ export async function acknowledgeGoogleSubscription(
   try {
     accessToken = await getCachedAccessToken(config.serviceAccountKey);
   } catch (err) {
-    log.warn('[onesub/google] Could not get access token for subscription ack:', err);
+    log.warn('[onesub/google] Could not get access token for subscription ack', { productId, err });
     return;
   }
 
@@ -368,10 +368,14 @@ export async function acknowledgeGoogleSubscription(
 
     if (!resp.ok) {
       const body = await resp.text();
-      log.warn(`[onesub/google] Subscription acknowledge API error ${resp.status}: ${body} — auto-refund risk`);
+      log.warn('[onesub/google] Subscription acknowledge API error — auto-refund risk', {
+        httpStatus: resp.status,
+        productId,
+        responseBody: body,
+      });
     }
   } catch (err) {
-    log.warn('[onesub/google] Subscription acknowledge network error — auto-refund risk:', err);
+    log.warn('[onesub/google] Subscription acknowledge network error — auto-refund risk', { productId, err });
   }
 }
 
@@ -394,7 +398,7 @@ export async function acknowledgeGoogleProduct(
   try {
     accessToken = await getCachedAccessToken(config.serviceAccountKey);
   } catch (err) {
-    log.warn('[onesub/google] Could not get access token for product ack:', err);
+    log.warn('[onesub/google] Could not get access token for product ack', { productId, err });
     return;
   }
 
@@ -412,10 +416,14 @@ export async function acknowledgeGoogleProduct(
 
     if (!resp.ok) {
       const body = await resp.text();
-      log.warn(`[onesub/google] Product acknowledge API error ${resp.status}: ${body} — auto-refund risk`);
+      log.warn('[onesub/google] Product acknowledge API error — auto-refund risk', {
+        httpStatus: resp.status,
+        productId,
+        responseBody: body,
+      });
     }
   } catch (err) {
-    log.warn('[onesub/google] Product acknowledge network error — auto-refund risk:', err);
+    log.warn('[onesub/google] Product acknowledge network error — auto-refund risk', { productId, err });
   }
 }
 
@@ -439,7 +447,7 @@ export async function consumeGoogleProductReceipt(
   try {
     accessToken = await getCachedAccessToken(config.serviceAccountKey);
   } catch (err) {
-    log.warn('[onesub/google] Could not get access token for consume:', err);
+    log.warn('[onesub/google] Could not get access token for consume', { productId, err });
     return;
   }
 
@@ -456,10 +464,14 @@ export async function consumeGoogleProductReceipt(
 
     if (!resp.ok) {
       const body = await resp.text();
-      log.warn(`[onesub/google] Consume API error ${resp.status}: ${body} — auto-refund risk`);
+      log.warn('[onesub/google] Consume API error — auto-refund risk', {
+        httpStatus: resp.status,
+        productId,
+        responseBody: body,
+      });
     }
   } catch (err) {
-    log.warn('[onesub/google] Consume network error — auto-refund risk:', err);
+    log.warn('[onesub/google] Consume network error — auto-refund risk', { productId, err });
   }
 }
 
@@ -511,11 +523,11 @@ export async function validateGoogleReceipt(
 ): Promise<SubscriptionInfo | null> {
   if (config.mockMode) return mockValidateGoogleSubscription(receipt, productId);
   if (!config.serviceAccountKey) {
-    log.warn('[onesub/google] No serviceAccountKey provided — cannot call Play API');
+    log.warn('[onesub/google] No serviceAccountKey provided — cannot call Play API', { productId });
     return null;
   }
   if (!config.packageName) {
-    log.warn('[onesub/google] No packageName provided — cannot call Play API');
+    log.warn('[onesub/google] No packageName provided — cannot call Play API', { productId });
     return null;
   }
 
@@ -524,16 +536,20 @@ export async function validateGoogleReceipt(
     const token = await getCachedAccessToken(config.serviceAccountKey);
     purchase = await fetchSubscriptionPurchaseV2(config.packageName, receipt, token);
   } catch (err) {
-    log.error('[onesub/google] Receipt validation failed:', err);
+    log.error('[onesub/google] Receipt validation failed', {
+      productId,
+      packageName: config.packageName,
+      err,
+    });
     return null;
   }
 
   const status = deriveStatusV2(purchase.subscriptionState);
   if (!status) {
-    log.warn(
-      '[onesub/google] Unrecognised or pending subscriptionState — rejecting:',
-      purchase.subscriptionState,
-    );
+    log.warn('[onesub/google] Unrecognised or pending subscriptionState — rejecting', {
+      productId,
+      subscriptionState: purchase.subscriptionState,
+    });
     return null;
   }
 
@@ -542,12 +558,10 @@ export async function validateGoogleReceipt(
   // the caller for the productId they explicitly asked about.
   const lineItem = purchase.lineItems?.find((item) => item.productId === productId);
   if (!lineItem) {
-    log.warn(
-      '[onesub/google] productId not found in subscription lineItems:',
+    log.warn('[onesub/google] productId not found in subscription lineItems', {
       productId,
-      'available:',
-      purchase.lineItems?.map((i) => i.productId).join(', ') ?? '(none)',
-    );
+      availableProductIds: purchase.lineItems?.map((i) => i.productId) ?? [],
+    });
     return null;
   }
 
@@ -621,11 +635,11 @@ export async function validateGoogleProductReceipt(
 ): Promise<GoogleProductResult | null> {
   if (config.mockMode) return mockValidateGoogleProduct(purchaseToken, productId);
   if (!config.serviceAccountKey) {
-    log.warn('[onesub/google] No serviceAccountKey — cannot validate product receipt');
+    log.warn('[onesub/google] No serviceAccountKey — cannot validate product receipt', { productId });
     return null;
   }
   if (!config.packageName) {
-    log.warn('[onesub/google] No packageName — cannot validate product receipt');
+    log.warn('[onesub/google] No packageName — cannot validate product receipt', { productId });
     return null;
   }
 
@@ -634,20 +648,32 @@ export async function validateGoogleProductReceipt(
     const token = await getCachedAccessToken(config.serviceAccountKey);
     purchase = await fetchProductPurchase(config.packageName, productId, purchaseToken, token);
   } catch (err) {
-    log.error('[onesub/google] Product receipt validation failed:', err);
+    log.error('[onesub/google] Product receipt validation failed', {
+      productId,
+      packageName: config.packageName,
+      type,
+      err,
+    });
     return null;
   }
 
   // purchaseState 0 = completed (1 = canceled, 2 = pending)
   if (purchase.purchaseState !== 0) {
-    log.warn('[onesub/google] Purchase not completed, state:', purchase.purchaseState);
+    log.warn('[onesub/google] Purchase not completed', {
+      productId,
+      purchaseState: purchase.purchaseState,
+      orderId: purchase.orderId,
+    });
     return null;
   }
 
   // For consumables: consumptionState 1 means already consumed by a previous request.
   // This is the primary replay-attack signal for consumables on Android.
   if (type === 'consumable' && purchase.consumptionState === 1) {
-    log.warn('[onesub/google] Consumable already consumed — possible replay attack');
+    log.warn('[onesub/google] Consumable already consumed — possible replay attack', {
+      productId,
+      orderId: purchase.orderId,
+    });
     return null;
   }
 
@@ -657,13 +683,18 @@ export async function validateGoogleProductReceipt(
     const purchaseTime = parseInt(purchase.purchaseTimeMillis, 10);
     const maxAgeMs = (config.productReceiptMaxAgeHours ?? 72) * 60 * 60 * 1000;
     if (Date.now() - purchaseTime > maxAgeMs) {
-      log.warn(`[onesub/google] Product receipt too old (>${config.productReceiptMaxAgeHours ?? 72}h)`);
+      log.warn('[onesub/google] Product receipt too old', {
+        productId,
+        orderId: purchase.orderId,
+        maxAgeHours: config.productReceiptMaxAgeHours ?? 72,
+        purchaseDate: new Date(purchaseTime).toISOString(),
+      });
       return null;
     }
   }
 
   if (!purchase.orderId) {
-    log.warn('[onesub/google] No orderId in product purchase');
+    log.warn('[onesub/google] No orderId in product purchase', { productId });
     return null;
   }
 
@@ -781,7 +812,11 @@ export function decodeGoogleOneTimeProductNotification(
   if (!notification.oneTimeProductNotification) return null;
   const { notificationType, purchaseToken, sku } = notification.oneTimeProductNotification;
   if (notificationType !== 1 && notificationType !== 2) {
-    log.warn('[onesub/google] Unknown oneTimeProductNotification type:', notificationType);
+    log.warn('[onesub/google] Unknown oneTimeProductNotification type', {
+      notificationType,
+      productId: sku,
+      packageName: notification.packageName,
+    });
     return null;
   }
   return { notificationType, purchaseToken, sku, packageName: notification.packageName };


### PR DESCRIPTION
PR 2 of the structured-logging migration. 0.24.0 made every log arrive as one escaped string; this moves the Apple and Google call sites onto it, so values become filterable instead of being spelled into a sentence.

**49 sites** — `providers/apple.ts` (27), `providers/google.ts` (22). `providers/mock.ts` was already field-form.

## What changed beyond the mechanical move

- **Error paths pass `err`, not `err.message`.** The formatter renders the stack as `    | ` continuation lines, so the old sites were discarding it for nothing.
- **Rejections that identified nothing now name what they refused.** `Purchase was revoked/refunded` was true and useless — an operator could not tell whose. It now carries `productId` and `transactionId`.
- **`purchaseToken` is deliberately *not* added** to the Google acknowledge/consume sites, even though it is in scope there. By `webhook-google.ts`'s own warning a `purchaseToken` is enough to cancel a subscription; "tidying values into fields" is not a reason to start logging a capability. A test pins that it stays out.

## A gap this found in its own test strategy

Mutation-testing the new per-site assertions, one mutation **survived**: renaming `productId` → `product` at the `No orderId in product purchase` site passed all 13 tests, because that site is not one of the asserted ones. The test file's own doc comment claimed such a rename would be caught. It would not have been.

Covering ~100 sites individually is not maintainable, so `field-vocabulary.test.ts` scans the source of **all 106 call sites across 16 files** — including the routes and stores not yet migrated — and fails when a field name is not in the vocabulary declared in `log-format.ts`. The vocabulary is parsed out of that module's doc so there is one list, not two. It catches the surviving mutation and names the offending file and key.

That test cannot tell whether a name is *right* for its value (`bundleId: tx.productId` passes); the per-site assertions cover that for the paths that matter.

## Verification

| Check | Result |
|---|---|
| `npm test` (with `DATABASE_URL`) | **847 passed** (842 → 847; +13 provider, +5 vocabulary) |
| `npm run build` | pass |
| `npm run type-check` | 0 errors |
| `npm run size -w @onesub/server` | 37.63 / 37.97 KB vs 40 KB |
| `npm run docs:check` | pass |
| Each of the 3 commits, independently | build + full suite green |

**Mutation-tested**, baseline committed first — an earlier round used `git checkout --` against an uncommitted tree and silently reverted the migration, so the "failures" it reported were meaningless. Redone: reverting a value into the message, renaming `productId`→`product`, `transactionId`→`txId`, `responseBody`→`body`, adding `purchaseToken`, and swapping `err` back to `.message` are each caught.

**Real server, `mockMode` off**, hostile input through the actual HTTP path:

```text
[onesub/apple] Failed to decode receipt as JWS receiptPreview="com.evil\n[onesub] admin granted premium to mallory" receiptLength=50 jwsParts=2 err=TypeError err.msg="Invalid Token or Protected Header formatting"
    | at decodeProtectedHeader (…/jose/dist/webapi/util/decode_protected_header.js:32:15)
    | at decodeJws (…/packages/server/dist/index.js:583:18)

[onesub/google] No serviceAccountKey provided — cannot call Play API productId="pro\n[onesub] entitlement granted"
```

Every example in the `MIGRATION.md` entry was generated by running the formatter, not written by hand — the first draft claimed a 20-page history cap that is actually 50.

## Two things this does not fix

- **`responseBody` is logged in full and unredacted.** A Play error body can echo the request URL, which carries a `purchaseToken`. Naming the field is what makes redaction possible; this PR does not redact, and `MIGRATION.md` says so. Truncation was left out on purpose — dropping log content is a behaviour change that does not belong in a mechanical migration.
- **`apps.ts:120` is the most attacker-reachable log site in the package** and is still interpolated. Found while verifying on the real server: `peekAppleBundleId` reads `bundleId` from an *unverified* JWS, and it lands in the message of `No app configured for bundleId: …`. The formatter escapes it, so there is no forgery — but it is not filterable. PR 3 territory.

## Also corrects a published doc

The 0.24.0 `MIGRATION.md` entry's "after" example showed the field form. But 0.24.0 only changed the argument count — the provider sites still interpolated, so what it actually emitted was `Bundle ID mismatch: com.evil !== com.real`. The example was describing *this* release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)