### PR TITLE
feat(server): give routes, stores and webhooks named log fields

### DIFF
--- a/.changeset/lucky-lamps-report.md
+++ b/.changeset/lucky-lamps-report.md
@@ -1,0 +1,23 @@
+---
+'@onesub/server': minor
+---
+
+Finish the structured-logging migration: routes, the app registry, webhook
+handlers, the BullMQ queue and the Postgres pool now log `key=value` fields.
+
+**`userId` becomes filterable for the first time.** It arrives in a request body, so
+it exists only in the route layer — the provider migration in 0.25.0 could not
+deliver it. Error paths now carry the request they were serving (`userId`,
+`productId`, `platform`, `notificationUUID`, `messageId`) instead of a bare stack,
+and every `catch` passes the `Error` itself so the stack survives as continuation
+lines.
+
+Three prefixes changed because the value in them became a field:
+`[onesub/metrics/<name>]` → `[onesub/metrics] route=<name>`, `[onesub/mock/<tag>]` →
+`[onesub/mock] provider=<tag>`, and `[onesub] <label> pool error` → `[onesub]
+Postgres pool error store=<label>`. Every other prefix is unchanged. See
+`docs/MIGRATION.md`.
+
+`purchaseToken` and `orderId` are still logged in full on the Google webhook paths
+that already logged them, now under those field names — naming them is what makes a
+redaction pass expressible, which this release does not do.

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -4,6 +4,51 @@ Upgrade notes for releases of `@onesub/server` that need one. While the package 
 
 ---
 
+## `@onesub/server` 0.25.x → 0.26.0
+
+### The remaining log lines carry `key=value` fields
+
+0.25.0 did this for the Apple and Google providers. This release finishes it: the
+routes, the app registry, the webhook handlers, the BullMQ queue and the Postgres
+pool. **`userId` becomes filterable for the first time** — it arrives in a request
+body, so it exists in the routes and never in the provider layer.
+
+```text
+before  [onesub/validate] account binding mismatch for 2000000123: receipt token does not match userId alice
+after   [onesub/validate] account binding mismatch — receipt token does not match userId originalTransactionId=2000000123 userId=alice
+
+before  [onesub/purchase] reassigned transaction t_9 from alice to bob
+after   [onesub/purchase] reassigned transaction to a new user transactionId=t_9 fromUserId=alice userId=bob
+
+before  [onesub] Multi-app mode: main, eu | default: main
+after   [onesub] Multi-app mode appIds="[\"main\",\"eu\"]" defaultAppId=main
+```
+
+**Impact.** Only if you match on log *text*. Beyond the fields themselves, three
+prefixes changed, because the value in them is now a field:
+
+| before | after |
+|---|---|
+| `[onesub/metrics/started] error:` | `[onesub/metrics] error route=started` |
+| `[onesub/mock/apple] receipt rejected` | `[onesub/mock] receipt rejected provider=apple` |
+| `[onesub] PostgresSubscriptionStore pool error (idle client):` | `[onesub] Postgres pool error (idle client) store=PostgresSubscriptionStore` |
+
+Everything else keeps its prefix, so `[onesub/validate]`, `[onesub/webhook/apple]`,
+`[onesub/webhook/google]` and `[onesub/admin/…]` greps still match. Trailing colons
+are gone from messages that had a value after them.
+
+**Errors.** Every `catch` now passes the `Error` itself, so the stack arrives as
+`    | ` continuation lines instead of being flattened — and error lines carry the
+request context they were missing (`userId`, `productId`, `platform`,
+`notificationUUID`, `messageId`).
+
+**`purchaseToken` and `orderId` are still logged in full**, under those field names,
+on the Google webhook paths that already logged them — they are the lookup keys an
+operator needs. Naming them is what makes a redaction pass expressible; this release
+does not redact. Treat these logs as credential-bearing.
+
+---
+
 ## `@onesub/server` 0.24.0 → 0.25.0
 
 ### Apple and Google log lines carry `key=value` fields

--- a/packages/server/src/__tests__/route-log-fields.test.ts
+++ b/packages/server/src/__tests__/route-log-fields.test.ts
@@ -1,0 +1,316 @@
+/**
+ * What the routes, stores and webhook handlers put on a log line.
+ *
+ * This is the half of the migration that delivers the point of it. `userId` does not
+ * exist in the provider layer — it arrives in a request body — so "show me every
+ * rejection for this user" only became answerable when these call sites moved.
+ * `provider-log-fields.test.ts` covers Apple and Google; this covers the other 54.
+ *
+ * Driven through HTTP with supertest rather than by calling handlers, because two of
+ * the values under test (`userId`, `bundleId`) are attacker-supplied through the
+ * request and the escaping only matters on that path. `bundleId` in particular is
+ * read out of an **unverified** JWS by `peekAppleBundleId`, which makes
+ * `apps.ts`'s "No app configured" line the most attacker-reachable log site in the
+ * package.
+ *
+ * Exact-line assertions again, for the reason given in `provider-log-fields.test.ts`:
+ * a substring match cannot tell a field from a sentence that mentions the value.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { createOneSubMiddleware } from '../index.js';
+import type { OneSubMiddlewareConfig } from '../index.js';
+import { InMemoryPurchaseStore, InMemorySubscriptionStore } from '../store.js';
+import { setLogger } from '../logger.js';
+import { LOG_CONTINUATION } from '../log-format.js';
+
+/** Collects rendered lines; the facade hands the sink exactly one string. */
+function capture() {
+  const lines: string[] = [];
+  const push = (...args: unknown[]) => void lines.push(args[0] as string);
+  setLogger({ info: push, warn: push, error: push });
+  return lines;
+}
+
+afterEach(() => setLogger(console));
+
+/** A userId that tries to close its field and open a new record. */
+const FORGED_USER = 'mallory\n[onesub] entitlement granted to mallory';
+
+function makeApp(overrides: Partial<OneSubMiddlewareConfig> = {}) {
+  const store = new InMemorySubscriptionStore();
+  const purchaseStore = new InMemoryPurchaseStore();
+  const app = express();
+  app.use(
+    createOneSubMiddleware({
+      database: { url: '' },
+      adminSecret: 'test-admin-secret-that-is-long-enough',
+      apple: { bundleId: 'com.example.app', mockMode: true },
+      google: { packageName: 'com.example.app', mockMode: true },
+      store,
+      purchaseStore,
+      ...overrides,
+    }),
+  );
+  return { app, store, purchaseStore };
+}
+
+/** Only the first line may start with caller bytes; the rest must be ours. */
+function noForgedLine(rendered: string): boolean {
+  const cont = LOG_CONTINUATION.slice(1);
+  return rendered
+    .split('\n')
+    .slice(1)
+    .every((line) => line.startsWith(cont));
+}
+
+describe('validate route', () => {
+  it('an account-binding mismatch names the user and the transaction', async () => {
+    const { app } = makeApp();
+    const lines = capture();
+
+    const res = await request(app)
+      .post('/onesub/validate')
+      .send({
+        platform: 'apple',
+        receipt: 'MOCK_VALID#token=someone-else',
+        userId: 'alice',
+        productId: 'pro_monthly',
+      });
+
+    expect(res.status).toBe(409);
+    expect(lines).toHaveLength(1);
+    // originalTransactionId is a mock digest, so match around it rather than pinning it.
+    expect(lines[0]).toMatch(
+      /^\[onesub\/validate\] account binding mismatch — receipt token does not match userId originalTransactionId=mock_apple_orig_[0-9a-f]+ userId=alice$/,
+    );
+  });
+
+  it('quotes a forged userId instead of letting it start a record', async () => {
+    const { app } = makeApp();
+    const lines = capture();
+
+    await request(app)
+      .post('/onesub/validate')
+      .send({
+        platform: 'apple',
+        receipt: 'MOCK_VALID#token=someone-else',
+        userId: FORGED_USER,
+        productId: 'pro_monthly',
+      });
+
+    expect(lines).toHaveLength(1);
+    const [rendered] = lines as [string];
+    expect(noForgedLine(rendered)).toBe(true);
+    expect(rendered).toContain(' userId="mallory\\n[onesub] entitlement granted to mallory"');
+  });
+
+  it('an unexpected store failure reports the request it was serving', async () => {
+    // Before this migration the line was 'Unexpected error:' plus a stack, with
+    // nothing tying it to a user, product or platform.
+    const store = new InMemorySubscriptionStore();
+    store.save = () => Promise.reject(new Error('store is down'));
+    const { app } = makeApp({ store });
+    const lines = capture();
+
+    const res = await request(app)
+      .post('/onesub/validate')
+      .send({ platform: 'apple', receipt: 'MOCK_VALID', userId: 'alice', productId: 'pro_monthly' });
+
+    expect(res.status).toBe(500);
+    const [rendered] = lines as [string];
+    expect(rendered.split('\n')[0]).toBe(
+      '[onesub/validate] Unexpected error userId=alice productId=pro_monthly platform=apple ' +
+        'err=Error err.msg="store is down"',
+    );
+    // The stack is still there, as continuation lines.
+    expect(rendered).toContain(`${LOG_CONTINUATION}at `);
+  });
+});
+
+describe('purchase route', () => {
+  it('a reassignment records both users, so the move is auditable', async () => {
+    const { app, purchaseStore } = makeApp();
+    // Seed the transaction under a different user.
+    await request(app).post('/onesub/purchase/validate').send({
+      platform: 'apple',
+      receipt: 'MOCK_VALID_NC',
+      userId: 'alice',
+      productId: 'lifetime',
+      type: 'non_consumable',
+    });
+    const seeded = await purchaseStore.getPurchasesByUserId('alice');
+    expect(seeded).toHaveLength(1);
+
+    const lines = capture();
+    await request(app).post('/onesub/purchase/validate').send({
+      platform: 'apple',
+      receipt: 'MOCK_VALID_NC',
+      userId: 'bob',
+      productId: 'lifetime',
+      type: 'non_consumable',
+    });
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toBe(
+      `[onesub/purchase] reassigned transaction to a new user transactionId=${seeded[0]!.transactionId} ` +
+        'fromUserId=alice userId=bob',
+    );
+  });
+
+  it('a binding mismatch names the transaction and the user', async () => {
+    const { app } = makeApp();
+    const lines = capture();
+
+    const res = await request(app).post('/onesub/purchase/validate').send({
+      platform: 'apple',
+      receipt: 'MOCK_VALID_NC#token=someone-else',
+      userId: 'alice',
+      productId: 'lifetime',
+      type: 'non_consumable',
+    });
+
+    expect(res.status).toBe(409);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatch(
+      /^\[onesub\/purchase\] account binding mismatch — token does not match userId transactionId=\S+ userId=alice$/,
+    );
+  });
+});
+
+describe('status route', () => {
+  it('a store failure names the user whose status was being read', async () => {
+    const store = new InMemorySubscriptionStore();
+    store.getByUserId = () => Promise.reject(new Error('read timeout'));
+    const { app } = makeApp({ store });
+    const lines = capture();
+
+    const res = await request(app).get('/onesub/status').query({ userId: 'alice' });
+
+    expect(res.status).toBe(500);
+    expect(lines[0]!.split('\n')[0]).toBe(
+      '[onesub/status] Store error userId=alice err=Error err.msg="read timeout"',
+    );
+  });
+});
+
+describe('app registry — the most attacker-reachable log site in the package', () => {
+  it('quotes a bundleId taken from an unverified JWS', async () => {
+    // peekAppleBundleId (apps.ts) decodes the receipt WITHOUT verifying it, purely
+    // to pick an app. So this value is fully attacker-controlled and reaches a log
+    // line before any signature check has happened.
+    const jws = (payload: Record<string, unknown>) =>
+      `${Buffer.from(JSON.stringify({ alg: 'ES256' })).toString('base64url')}.` +
+      `${Buffer.from(JSON.stringify(payload)).toString('base64url')}.sig`;
+    const { app } = makeApp({
+      apple: { bundleId: 'com.example.app' },
+      apps: [{ id: 'main', apple: { bundleId: 'com.example.app' } }],
+    });
+    const lines = capture();
+
+    await request(app)
+      .post('/onesub/validate')
+      .send({
+        platform: 'apple',
+        receipt: jws({ bundleId: 'com.evil\n[onesub] admin granted premium', productId: 'p' }),
+        userId: 'alice',
+        productId: 'pro_monthly',
+      });
+
+    const offending = lines.filter((l) => l.startsWith('[onesub] No app configured for bundleId'));
+    expect(offending).toHaveLength(1);
+    expect(offending[0]).toBe(
+      '[onesub] No app configured for bundleId bundleId="com.evil\\n[onesub] admin granted premium"',
+    );
+    expect(noForgedLine(offending[0]!)).toBe(true);
+  });
+});
+
+describe('admin route', () => {
+  it('a sandbox override records who it was set for and to what', async () => {
+    const { app } = makeApp();
+    const lines = capture();
+
+    const res = await request(app)
+      .put('/onesub/admin/test-overrides/alice')
+      .set('x-admin-secret', 'test-admin-secret-that-is-long-enough')
+      .send({ entitled: false });
+
+    expect(res.status).toBe(200);
+    expect(lines).toEqual(['[onesub/admin] sandbox test override set userId=alice entitled=false']);
+  });
+});
+
+describe('webhook handlers', () => {
+  it('an unknown purchaseToken is a named field, which is what makes redaction possible', async () => {
+    // The token is logged in full — it is the lookup key an operator needs. Naming
+    // it is the prerequisite for a redaction pass, not the redaction itself.
+    const { app } = makeApp();
+    const lines = capture();
+
+    const notification = {
+      version: '1.0',
+      packageName: 'com.example.app',
+      eventTimeMillis: String(Date.now()),
+      subscriptionNotification: {
+        version: '1.0',
+        notificationType: 13, // EXPIRED
+        purchaseToken: 'tok_unknown_123',
+        subscriptionId: 'monthly',
+      },
+    };
+    const res = await request(app)
+      .post('/onesub/webhook/google')
+      .send({
+        message: {
+          data: Buffer.from(JSON.stringify(notification)).toString('base64'),
+          messageId: 'msg-1',
+        },
+        subscription: 'projects/p/subscriptions/s',
+      });
+
+    expect(res.status).toBe(200);
+    const line = lines.find((l) => l.includes('Unknown purchase token'));
+    expect(line).toBe(
+      '[onesub/webhook/google] Unknown purchase token and no serviceAccountKey to re-fetch ' +
+        'purchaseToken=tok_unknown_123',
+    );
+  });
+
+  it('a store failure during Apple processing is tied to the notification', async () => {
+    const store = new InMemorySubscriptionStore();
+    store.getByTransactionId = () => Promise.reject(new Error('store exploded'));
+    const { app } = makeApp({ store, apple: { bundleId: 'com.example.app', skipJwsVerification: true } });
+    const lines = capture();
+
+    const signed = (payload: Record<string, unknown>) =>
+      `${Buffer.from(JSON.stringify({ alg: 'ES256' })).toString('base64url')}.` +
+      `${Buffer.from(JSON.stringify(payload)).toString('base64url')}.sig`;
+
+    await request(app)
+      .post('/onesub/webhook/apple')
+      .send({
+        signedPayload: signed({
+          notificationType: 'DID_RENEW',
+          notificationUUID: 'uuid-1',
+          data: {
+            bundleId: 'com.example.app',
+            environment: 'Sandbox',
+            signedTransactionInfo: signed({
+              originalTransactionId: 'orig-1',
+              productId: 'monthly',
+              expiresDate: Date.now() + 86_400_000,
+              bundleId: 'com.example.app',
+            }),
+          },
+        }),
+      });
+
+    const line = lines.find((l) => l.includes('Store update error'));
+    expect(line?.split('\n')[0]).toBe(
+      '[onesub/webhook/apple] Store update error notificationUUID=uuid-1 err=Error err.msg="store exploded"',
+    );
+  });
+});

--- a/packages/server/src/apps.ts
+++ b/packages/server/src/apps.ts
@@ -65,7 +65,10 @@ export function buildAppRegistry(config: OneSubServerConfig): AppRegistry {
     (config.apple || config.google || apps.length === 1 ? apps[0] : undefined);
 
   if (apps.length > 1) {
-    log.info('[onesub] Multi-app mode:', apps.map(appName).join(', '), '| default:', defaultApp ? appName(defaultApp) : '(none)');
+    log.info('[onesub] Multi-app mode', {
+      appIds: apps.map(appName),
+      defaultAppId: defaultApp ? appName(defaultApp) : null,
+    });
   }
 
   function match(hint: AppHint): OneSubAppConfig | undefined {
@@ -79,7 +82,7 @@ export function buildAppRegistry(config: OneSubServerConfig): AppRegistry {
       if (byId) return byId;
       // An appId we don't serve must not silently fall through to the default —
       // that would validate it against some other app's credentials.
-      log.warn('[onesub] Unknown appId:', hint.appId);
+      log.warn('[onesub] Unknown appId', { appId: hint.appId });
       return undefined;
     }
 
@@ -87,7 +90,7 @@ export function buildAppRegistry(config: OneSubServerConfig): AppRegistry {
     if (hint.bundleId) {
       const byBundle = apps.find((a) => a.apple?.bundleId === hint.bundleId);
       if (byBundle) return byBundle;
-      log.warn('[onesub] No app configured for bundleId:', hint.bundleId);
+      log.warn('[onesub] No app configured for bundleId', { bundleId: hint.bundleId });
       return undefined;
     }
 

--- a/packages/server/src/log-format.ts
+++ b/packages/server/src/log-format.ts
@@ -53,6 +53,8 @@
  *   expected type subscriptionState purchaseState maxAgeHours purchaseDate
  *   receiptPreview receiptLength jwsParts looksLikeJws responseBody
  *   availableProductIds maxPages pageCount outcome
+ *   appIds defaultAppId store entitlement entitled fromUserId userIdSource
+ *   notificationUUID messageId linkedPurchaseToken kind deadLetterId
  * FIELD VOCABULARY END
  *
  * `err` is reserved: it always routes through the error renderer.

--- a/packages/server/src/providers/mock.ts
+++ b/packages/server/src/providers/mock.ts
@@ -55,7 +55,7 @@ function outcomePasses(outcome: MockReceiptOutcome, tag: string): boolean {
     throw new Error(`[onesub/mock/${tag}] simulated upstream network error`);
   }
   if (outcome.kind === 'valid' || outcome.kind === 'sandbox') return true;
-  log.warn(`[onesub/mock/${tag}] receipt rejected`, { outcome: outcome.kind });
+  log.warn('[onesub/mock] receipt rejected', { provider: tag, outcome: outcome.kind });
   return false;
 }
 

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -178,7 +178,7 @@ export function createAdminRouter(
       res.status(200).json(response);
     } catch (err) {
       // Bubble the message up but not the stack — admin clients log status code
-      log.error('[onesub/admin/subscriptions] list error:', err);
+      log.error('[onesub/admin/subscriptions] list error', { err });
       sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, 'Internal server error');
     }
   });
@@ -201,7 +201,10 @@ export function createAdminRouter(
       }
       res.status(200).json(sub);
     } catch (err) {
-      log.error('[onesub/admin/subscriptions/:transactionId] detail error:', err);
+      log.error('[onesub/admin/subscriptions/:transactionId] detail error', {
+        transactionId: params.transactionId,
+        err,
+      });
       sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, 'Internal server error');
     }
   });
@@ -250,7 +253,7 @@ export function createAdminRouter(
       };
       res.status(200).json(response);
     } catch (err) {
-      log.error('[onesub/admin/customers/:userId] error:', err);
+      log.error('[onesub/admin/customers/:userId] error', { userId: params.userId, err });
       sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, 'Internal server error');
     }
   });
@@ -290,7 +293,10 @@ export function createAdminRouter(
       await store.save(fresh);
       res.status(200).json({ ok: true, subscription: fresh });
     } catch (err) {
-      log.error('[onesub/admin/sync-apple] error:', err);
+      log.error('[onesub/admin/sync-apple] error', {
+        originalTransactionId: params.originalTransactionId,
+        err,
+      });
       sendError(res, 500, ONESUB_ERROR_CODE.INTERNAL_ERROR, 'Internal server error');
     }
   });
@@ -313,9 +319,10 @@ export function createAdminRouter(
     const body = parseOrSend(res, overrideBodySchema, req.body);
     if (!body) return;
     setTestOverride(params.userId, body.entitled);
-    log.warn(
-      `[onesub/admin] sandbox test override set for ${params.userId}: entitled=${body.entitled}`,
-    );
+    log.warn('[onesub/admin] sandbox test override set', {
+      userId: params.userId,
+      entitled: body.entitled,
+    });
     res.json({ ok: true, userId: params.userId, entitled: body.entitled, sandboxOnly: true });
   });
 
@@ -339,7 +346,7 @@ export function createAdminRouter(
         const items = await webhookQueue.listDeadLetters!();
         res.status(200).json({ items });
       } catch (err) {
-        log.error('[onesub/admin/webhook-deadletters] error:', err);
+        log.error('[onesub/admin/webhook-deadletters] error', { err });
         sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, 'Internal server error');
       }
     });
@@ -354,7 +361,7 @@ export function createAdminRouter(
         await webhookQueue.replayDeadLetter!(params.id);
         res.status(200).json({ ok: true });
       } catch (err) {
-        log.error('[onesub/admin/webhook-replay] error:', err);
+        log.error('[onesub/admin/webhook-replay] error', { deadLetterId: params.id, err });
         sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, 'Internal server error');
       }
     });

--- a/packages/server/src/routes/apple-offer.ts
+++ b/packages/server/src/routes/apple-offer.ts
@@ -70,7 +70,7 @@ export function createAppleOfferRouter(config: OneSubServerConfig): Router | nul
       // The message is deliberately generic: this route signs with the
       // promotional-offer private key, so a crypto/JOSE failure message is the
       // last thing to hand an unauthenticated-until-proven caller.
-      log.error('[onesub/apple/offer] signing error:', err);
+      log.error('[onesub/apple/offer] signing error', { productId: body.productId, err });
       sendError(res, 500, ONESUB_ERROR_CODE.INTERNAL_ERROR, 'Offer signing failed');
     }
   });

--- a/packages/server/src/routes/entitlements.ts
+++ b/packages/server/src/routes/entitlements.ts
@@ -147,7 +147,7 @@ export function createEntitlementRouter(
       const response: EntitlementResponse = { id, ...status };
       res.status(200).json(response);
     } catch (err) {
-      log.error('[onesub/entitlement] evaluation error:', err);
+      log.error('[onesub/entitlement] evaluation error', { userId, entitlement: id, err });
       sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, 'Internal server error');
     }
   });
@@ -182,7 +182,7 @@ export function createEntitlementRouter(
       };
       res.status(200).json(response);
     } catch (err) {
-      log.error('[onesub/entitlements] evaluation error:', err);
+      log.error('[onesub/entitlements] evaluation error', { userId, err });
       sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, 'Internal server error', { entitlements: {} });
     }
   });

--- a/packages/server/src/routes/metrics.ts
+++ b/packages/server/src/routes/metrics.ts
@@ -106,7 +106,7 @@ export function createMetricsRouter(
       );
       res.status(200).json(response);
     } catch (err) {
-      log.error('[onesub/metrics/active] error:', err);
+      log.error('[onesub/metrics/active] error', { err });
       sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, 'Internal server error');
     }
   });
@@ -206,7 +206,7 @@ export function createMetricsRouter(
         };
         res.status(200).json(response);
       } catch (err) {
-        log.error(`[onesub/metrics/${name}] error:`, err);
+        log.error('[onesub/metrics] error', { route: name, err });
         sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, 'Internal server error');
       }
     };

--- a/packages/server/src/routes/purchase.ts
+++ b/packages/server/src/routes/purchase.ts
@@ -182,9 +182,10 @@ export function createPurchaseRouter(
         ? boundAccountId && boundAccountId.toLowerCase() !== userId.toLowerCase()
         : boundAccountId && boundAccountId !== userId;
       if (bindingMismatch) {
-        log.warn(
-          `[onesub/purchase] account binding mismatch for transaction ${transactionId}: token does not match userId ${userId}`,
-        );
+        log.warn('[onesub/purchase] account binding mismatch — token does not match userId', {
+          transactionId,
+          userId,
+        });
         sendError(
           res,
           409,
@@ -208,9 +209,11 @@ export function createPurchaseRouter(
         if (existing.userId !== userId) {
           if (type === PURCHASE_TYPE.NON_CONSUMABLE) {
             await purchaseStore.reassignPurchase(transactionId, userId);
-            log.info(
-              `[onesub/purchase] reassigned transaction ${transactionId} from ${existing.userId} to ${userId}`,
-            );
+            log.info('[onesub/purchase] reassigned transaction to a new user', {
+              transactionId,
+              fromUserId: existing.userId,
+              userId,
+            });
           } else {
             sendError(
               res,
@@ -265,7 +268,7 @@ export function createPurchaseRouter(
       };
       res.status(200).json(response);
     } catch (err) {
-      log.error('[onesub/purchase/validate] Unexpected error:', err);
+      log.error('[onesub/purchase/validate] Unexpected error', { userId, productId, platform, type, err });
       sendError(res, 500, ONESUB_ERROR_CODE.INTERNAL_ERROR, 'Internal server error during purchase validation', NO_PURCHASE);
     }
   });
@@ -295,7 +298,7 @@ export function createPurchaseRouter(
       const response: PurchaseStatusResponse = { purchases };
       res.status(200).json(response);
     } catch (err) {
-      log.error('[onesub/purchase/status] Store error:', err);
+      log.error('[onesub/purchase/status] Store error', { userId, productId, err });
       sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, 'Internal server error', { purchases: [] });
     }
   });

--- a/packages/server/src/routes/status.ts
+++ b/packages/server/src/routes/status.ts
@@ -57,7 +57,7 @@ export function createStatusRouter(store: SubscriptionStore): Router {
       const response: StatusResponse = { active, subscription: sub };
       res.status(200).json(response);
     } catch (err) {
-      log.error('[onesub/status] Store error:', err);
+      log.error('[onesub/status] Store error', { userId, err });
       sendError(res, 500, ONESUB_ERROR_CODE.STORE_ERROR, 'Internal server error', NO_SUB);
     }
   });

--- a/packages/server/src/routes/validate.ts
+++ b/packages/server/src/routes/validate.ts
@@ -77,9 +77,10 @@ export function createValidateRouter(
         ? boundAccountId && boundAccountId.toLowerCase() !== userId.toLowerCase()
         : boundAccountId && boundAccountId !== userId;
       if (bindingMismatch) {
-        log.warn(
-          `[onesub/validate] account binding mismatch for ${sub.originalTransactionId}: receipt token does not match userId ${userId}`,
-        );
+        log.warn('[onesub/validate] account binding mismatch — receipt token does not match userId', {
+          originalTransactionId: sub.originalTransactionId,
+          userId,
+        });
         sendError(
           res,
           409,
@@ -98,7 +99,7 @@ export function createValidateRouter(
       const isSandbox = sub.sandbox === true;
       delete sub.sandbox;
       if (isSandbox && getTestOverride(userId) === false) {
-        log.warn(`[onesub/validate] sandbox test override active for ${userId}: forcing not-entitled`);
+        log.warn('[onesub/validate] sandbox test override active — forcing not-entitled', { userId });
         sub.status = SUBSCRIPTION_STATUS.EXPIRED;
         sub.willRenew = false;
       }
@@ -116,7 +117,7 @@ export function createValidateRouter(
       const response: ValidateReceiptResponse = { valid: true, subscription: sub };
       res.status(200).json(response);
     } catch (err) {
-      log.error('[onesub/validate] Unexpected error:', err);
+      log.error('[onesub/validate] Unexpected error', { userId, productId, platform, err });
       sendError(res, 500, ONESUB_ERROR_CODE.INTERNAL_ERROR, 'Internal server error during receipt validation', NO_SUB);
     }
   });

--- a/packages/server/src/routes/webhook-apple.ts
+++ b/packages/server/src/routes/webhook-apple.ts
@@ -119,7 +119,7 @@ export async function processAppleNotification(
           });
         }
       } catch (err) {
-        log.warn('[onesub/webhook/apple] consumptionInfoProvider failed:', err);
+        log.warn('[onesub/webhook/apple] consumptionInfoProvider failed', { transactionId, err });
       }
     })();
   }
@@ -138,7 +138,7 @@ export async function processAppleNotification(
     const lookupId = transactionId ?? originalTransactionId;
     const removed = await purchaseStore.deletePurchaseByTransactionId(lookupId);
     if (!removed) {
-      log.warn('[onesub/webhook/apple] IAP refund for unknown transaction:', lookupId);
+      log.warn('[onesub/webhook/apple] IAP refund for unknown transaction', { transactionId: lookupId });
     }
     return;
   }
@@ -156,7 +156,10 @@ export async function processAppleNotification(
         ? appAccountToken
         : existing.userId;
     if (correctedUserId !== existing.userId) {
-      log.info('[onesub/webhook/apple] correcting userId from originalTransactionId to appAccountToken:', correctedUserId);
+      log.info('[onesub/webhook/apple] correcting userId from originalTransactionId to appAccountToken', {
+        originalTransactionId,
+        userId: correctedUserId,
+      });
     }
 
     const updated: SubscriptionInfo = keepEntitlement
@@ -177,20 +180,22 @@ export async function processAppleNotification(
       fresh.userId = appAccountToken ?? originalTransactionId;
       if (inAppOwnershipType === 'FAMILY_SHARED') {
         const source = appAccountToken ? 'appAccountToken' : 'originalTransactionId (fallback)';
-        log.info(`[onesub/webhook/apple] FAMILY_SHARED — userId: ${fresh.userId} (source: ${source})`);
+        log.info('[onesub/webhook/apple] FAMILY_SHARED', {
+          originalTransactionId,
+          userId: fresh.userId,
+          userIdSource: source,
+        });
       }
       await store.save(fresh);
     } else {
-      log.warn(
-        '[onesub/webhook/apple] Unknown transaction and Status API returned no record:',
+      log.warn('[onesub/webhook/apple] Unknown transaction and Status API returned no record', {
         originalTransactionId,
-      );
+      });
     }
   } else {
-    log.warn(
-      '[onesub/webhook/apple] Received notification for unknown transaction (no API creds to recover):',
+    log.warn('[onesub/webhook/apple] Received notification for unknown transaction (no API creds to recover)', {
       originalTransactionId,
-    );
+    });
   }
 }
 
@@ -217,7 +222,7 @@ export async function handleAppleWebhook(
       config.apple?.skipJwsVerification,
     );
   } catch (err) {
-    log.error('[onesub/webhook/apple] Failed to decode signedPayload:', err);
+    log.error('[onesub/webhook/apple] Failed to decode signedPayload', { err });
     sendError(res, 400, ONESUB_ERROR_CODE.INVALID_SIGNED_PAYLOAD, 'Invalid signedPayload');
     return;
   }
@@ -230,7 +235,9 @@ export async function handleAppleWebhook(
   if (webhookEventStore && typeof payload.notificationUUID === 'string') {
     const fresh = await webhookEventStore.markIfNew('apple', payload.notificationUUID);
     if (!fresh) {
-      log.info('[onesub/webhook/apple] dedupe: already processed', payload.notificationUUID);
+      log.info('[onesub/webhook/apple] dedupe: already processed', {
+        notificationUUID: payload.notificationUUID,
+      });
       res.status(200).json({ received: true, deduped: true });
       return;
     }
@@ -249,7 +256,7 @@ export async function handleAppleWebhook(
   // still rejects everything else.
   const notifiedApp = getAppRegistry(config).configFor({ bundleId: decoded.bundleId });
   if (decoded.bundleId && !notifiedApp.apple) {
-    log.warn('[onesub/webhook/apple] No app configured for bundleId:', decoded.bundleId);
+    log.warn('[onesub/webhook/apple] No app configured for bundleId', { bundleId: decoded.bundleId });
     sendError(res, 400, ONESUB_ERROR_CODE.BUNDLE_ID_MISMATCH, 'Bundle ID mismatch');
     return;
   }
@@ -284,7 +291,10 @@ export async function handleAppleWebhook(
       // Enqueue itself failed (e.g. Redis down) — the job was never durably
       // accepted, so the queue can't retry it. Fall back to source-retry
       // semantics: unmark + 5xx so Apple redelivers.
-      log.error('[onesub/webhook/apple] Failed to enqueue webhook job:', err);
+      log.error('[onesub/webhook/apple] Failed to enqueue webhook job', {
+        notificationUUID: payload.notificationUUID,
+        err,
+      });
       await unmarkWebhookEvent(webhookEventStore, 'apple', markedEventId);
       sendError(res, 500, ONESUB_ERROR_CODE.WEBHOOK_PROCESSING_FAILED, 'Failed to update subscription');
     }
@@ -299,7 +309,10 @@ export async function handleAppleWebhook(
     await processAppleNotification(work, config, store, purchaseStore);
     res.status(200).json({ received: true });
   } catch (err) {
-    log.error('[onesub/webhook/apple] Store update error:', err);
+    log.error('[onesub/webhook/apple] Store update error', {
+      notificationUUID: payload.notificationUUID,
+      err,
+    });
     await unmarkWebhookEvent(webhookEventStore, 'apple', markedEventId);
     sendError(res, 500, ONESUB_ERROR_CODE.WEBHOOK_PROCESSING_FAILED, 'Failed to update subscription');
   }

--- a/packages/server/src/routes/webhook-google.ts
+++ b/packages/server/src/routes/webhook-google.ts
@@ -82,15 +82,15 @@ export type GoogleWebhookWork =
 /** Per-kind log prefixes / error messages, kept identical to the pre-refactor inline handlers. */
 const GOOGLE_FAILURE_MESSAGES: Record<GoogleWebhookWork['kind'], { logPrefix: string; message: string }> = {
   voided: {
-    logPrefix: '[onesub/webhook/google] voided notification error:',
+    logPrefix: '[onesub/webhook/google] voided notification error',
     message: 'Failed to process voided notification',
   },
   oneTimeProduct: {
-    logPrefix: '[onesub/webhook/google] oneTimeProduct error:',
+    logPrefix: '[onesub/webhook/google] oneTimeProduct error',
     message: 'Failed to process oneTimeProduct notification',
   },
   subscription: {
-    logPrefix: '[onesub/webhook/google] Error handling notification:',
+    logPrefix: '[onesub/webhook/google] Error handling notification',
     message: 'Failed to process notification',
   },
 };
@@ -206,12 +206,14 @@ export async function processGoogleNotification(
           : { ...existing, status: SUBSCRIPTION_STATUS.CANCELED };
         await store.save(updated);
       } else {
-        log.warn('[onesub/webhook/google] voided subscription for unknown purchaseToken:', voided.purchaseToken);
+        log.warn('[onesub/webhook/google] voided subscription for unknown purchaseToken', {
+          purchaseToken: voided.purchaseToken,
+        });
       }
     } else {
       const removed = await purchaseStore.deletePurchaseByTransactionId(voided.orderId);
       if (!removed) {
-        log.warn('[onesub/webhook/google] voided IAP for unknown orderId:', voided.orderId);
+        log.warn('[onesub/webhook/google] voided IAP for unknown orderId', { orderId: voided.orderId });
       }
     }
     return;
@@ -224,16 +226,20 @@ export async function processGoogleNotification(
   if (work.kind === 'oneTimeProduct') {
     const { notificationType, purchaseToken, sku } = work.oneTimeProduct;
     if (notificationType === 1 /* PURCHASED */) {
-      log.info('[onesub/webhook/google] oneTimeProduct PURCHASED:', sku);
+      log.info('[onesub/webhook/google] oneTimeProduct PURCHASED', { productId: sku });
       const googleCfg = googleFor(work.oneTimeProduct.packageName);
       if (googleCfg?.serviceAccountKey && googleCfg.packageName) {
         void acknowledgeGoogleProduct(purchaseToken, sku, googleCfg).catch(
-          (err) => log.warn(`[onesub/webhook/google] oneTimeProduct ack failed for SKU ${sku} — 3-day auto-refund risk:`, err),
+          (err) =>
+            log.warn('[onesub/webhook/google] oneTimeProduct ack failed — 3-day auto-refund risk', {
+              productId: sku,
+              err,
+            }),
         );
       }
     } else {
       // notificationType === 2: CANCELED (user aborted before purchase completed)
-      log.info('[onesub/webhook/google] oneTimeProduct CANCELED (pre-completion):', sku);
+      log.info('[onesub/webhook/google] oneTimeProduct CANCELED (pre-completion)', { productId: sku });
     }
     return;
   }
@@ -270,7 +276,7 @@ export async function processGoogleNotification(
     const hook = subGoogleCfg.onPriceChangeConfirmed;
     void Promise.resolve()
       .then(() => hook({ purchaseToken, subscriptionId, packageName }))
-      .catch((err) => log.warn('[onesub/webhook/google] onPriceChangeConfirmed hook failed:', err));
+      .catch((err) => log.warn('[onesub/webhook/google] onPriceChangeConfirmed hook failed', { err }));
   }
 
   if (existing) {
@@ -311,7 +317,11 @@ export async function processGoogleNotification(
           const previous = await store.getByTransactionId(fresh.linkedPurchaseToken);
           fresh.userId = previous ? previous.userId : boundAccountId ?? purchaseToken;
           if (previous) {
-            log.info(`[onesub/webhook/google] inherited userId ${previous.userId} from linkedPurchaseToken ${fresh.linkedPurchaseToken} → new token ${purchaseToken}`);
+            log.info('[onesub/webhook/google] inherited userId from linkedPurchaseToken', {
+              userId: previous.userId,
+              linkedPurchaseToken: fresh.linkedPurchaseToken,
+              purchaseToken,
+            });
           }
         } else {
           fresh.userId = boundAccountId ?? purchaseToken;
@@ -319,7 +329,9 @@ export async function processGoogleNotification(
         await store.save(fresh);
       }
     } else {
-      log.warn('[onesub/webhook/google] Unknown purchase token and no serviceAccountKey to re-fetch:', purchaseToken);
+      log.warn('[onesub/webhook/google] Unknown purchase token and no serviceAccountKey to re-fetch', {
+        purchaseToken,
+      });
     }
   }
 }
@@ -369,7 +381,9 @@ export async function handleGoogleWebhook(
   if (webhookEventStore && typeof body.message.messageId === 'string') {
     const fresh = await webhookEventStore.markIfNew('google', body.message.messageId);
     if (!fresh) {
-      log.info('[onesub/webhook/google] dedupe: already processed', body.message.messageId);
+      log.info('[onesub/webhook/google] dedupe: already processed', {
+        messageId: body.message.messageId,
+      });
       res.status(200).json({ received: true, deduped: true });
       return;
     }
@@ -389,7 +403,9 @@ export async function handleGoogleWebhook(
   const voided = decodeGoogleVoidedNotification(body as GoogleNotificationPayload);
   if (voided) {
     if (!servesPackage(voided.packageName)) {
-      log.warn('[onesub/webhook/google] voided package name not served:', voided.packageName);
+      log.warn('[onesub/webhook/google] voided package name not served', {
+        packageName: voided.packageName,
+      });
       sendError(res, 400, ONESUB_ERROR_CODE.PACKAGE_NAME_MISMATCH, 'Package name mismatch');
       return;
     }
@@ -398,7 +414,9 @@ export async function handleGoogleWebhook(
     const oneTimeProduct = decodeGoogleOneTimeProductNotification(body as GoogleNotificationPayload);
     if (oneTimeProduct) {
       if (!servesPackage(oneTimeProduct.packageName)) {
-        log.warn('[onesub/webhook/google] oneTimeProduct package name not served:', oneTimeProduct.packageName);
+        log.warn('[onesub/webhook/google] oneTimeProduct package name not served', {
+          packageName: oneTimeProduct.packageName,
+        });
         sendError(res, 400, ONESUB_ERROR_CODE.PACKAGE_NAME_MISMATCH, 'Package name mismatch');
         return;
       }
@@ -410,7 +428,9 @@ export async function handleGoogleWebhook(
         return;
       }
       if (!servesPackage(notification.packageName)) {
-        log.warn('[onesub/webhook/google] Package name not served:', notification.packageName);
+        log.warn('[onesub/webhook/google] Package name not served', {
+          packageName: notification.packageName,
+        });
         sendError(res, 400, ONESUB_ERROR_CODE.PACKAGE_NAME_MISMATCH, 'Package name mismatch');
         return;
       }
@@ -443,7 +463,11 @@ export async function handleGoogleWebhook(
       // Enqueue itself failed (e.g. Redis down) — the job was never durably
       // accepted, so the queue can't retry it. Fall back to source-retry
       // semantics: unmark + 5xx so Pub/Sub redelivers.
-      log.error('[onesub/webhook/google] Failed to enqueue webhook job:', err);
+      log.error('[onesub/webhook/google] Failed to enqueue webhook job', {
+        kind: work.kind,
+        messageId: body.message.messageId,
+        err,
+      });
       await unmarkWebhookEvent(webhookEventStore, 'google', markedEventId);
       sendError(res, 500, ONESUB_ERROR_CODE.WEBHOOK_PROCESSING_FAILED, GOOGLE_FAILURE_MESSAGES[work.kind].message);
     }
@@ -459,7 +483,7 @@ export async function handleGoogleWebhook(
     res.status(200).json({ received: true });
   } catch (err) {
     const { logPrefix, message } = GOOGLE_FAILURE_MESSAGES[work.kind];
-    log.error(logPrefix, err);
+    log.error(logPrefix, { kind: work.kind, err });
     await unmarkWebhookEvent(webhookEventStore, 'google', markedEventId);
     sendError(res, 500, ONESUB_ERROR_CODE.WEBHOOK_PROCESSING_FAILED, message);
   }

--- a/packages/server/src/stores/postgres.ts
+++ b/packages/server/src/stores/postgres.ts
@@ -34,7 +34,7 @@ async function createPgPool(connectionString: string, label: string): Promise<im
   // an unhandled EventEmitter 'error' — it crashes the process. Log it and
   // let the pool replace the client.
   pool.on('error', (err) => {
-    log.error(`[onesub] ${label} pool error (idle client):`, err);
+    log.error('[onesub] Postgres pool error (idle client)', { store: label, err });
   });
   return pool;
 }

--- a/packages/server/src/webhook-queue.ts
+++ b/packages/server/src/webhook-queue.ts
@@ -187,7 +187,7 @@ export class BullMQWebhookQueue implements WebhookQueue {
         // Without an 'error' listener, a Redis hiccup on the EventEmitter
         // becomes an uncaught 'error' event and crashes the process.
         queue.on?.('error', (err) => {
-          log.error('[onesub] BullMQ queue error:', err);
+          log.error('[onesub] BullMQ queue error', { err });
         });
         return queue;
       })();
@@ -214,7 +214,7 @@ export class BullMQWebhookQueue implements WebhookQueue {
         // Same rationale as the queue's 'error' listener above. Job failures
         // are NOT this event — they go through the retry/dead-letter flow.
         worker.on?.('error', (err) => {
-          log.error('[onesub] BullMQ worker error:', err);
+          log.error('[onesub] BullMQ worker error', { err });
         });
         return worker;
       })();
@@ -223,7 +223,7 @@ export class BullMQWebhookQueue implements WebhookQueue {
       // missing) and surface it on the next enqueue instead.
       this.workerPromise.catch((err) => {
         this.workerStartupError = err instanceof Error ? err : new Error(String(err));
-        log.error('[onesub] BullMQ worker failed to start:', err);
+        log.error('[onesub] BullMQ worker failed to start', { err });
       });
     }
   }


### PR DESCRIPTION
PR 3 — the last of the structured-logging migration. **54 call sites across 12 files**: routes, the app registry, both webhook handlers, the BullMQ queue, the Postgres pool, and the mock provider.

## Why this half is the one that matters

`userId` arrives in a request body, so it exists in the route layer and **nowhere in the providers**. PR 2 could not deliver it. "Show me every rejection for this user" only becomes answerable here.

```text
before  [onesub/validate] account binding mismatch for 2000000123: receipt token does not match userId alice
after   [onesub/validate] account binding mismatch — receipt token does not match userId originalTransactionId=2000000123 userId=alice
```

Error paths got the same treatment: every `catch` passes the `Error` itself, and carries the request it was serving rather than a bare stack.

## Three prefixes changed — the rest did not

Where the prefix itself held an interpolated value, that value moved to a field:

| before | after |
|---|---|
| `[onesub/metrics/started] error:` | `[onesub/metrics] error route=started` |
| `[onesub/mock/apple] receipt rejected` | `[onesub/mock] receipt rejected provider=apple` |
| `[onesub] PostgresSubscriptionStore pool error (idle client):` | `[onesub] Postgres pool error (idle client) store=PostgresSubscriptionStore` |

Keeping the value in the prefix would have kept it greppable but not filterable — the same trade already made for the providers. `[onesub/validate]`, `[onesub/webhook/*]` and `[onesub/admin/*]` greps are unaffected.

`webhook-google.ts`'s `GOOGLE_FAILURE_MESSAGES` table keeps its three distinct messages (static literals selected at runtime); the work `kind` now rides alongside as a field.

## A real defect the new test caught

`notificationUUID` and `messageId` were read from `markedEventId` — which is **only set when a `webhookEventStore` is configured**. On the common path the field silently rendered as nothing, so the enqueue-failure and store-failure lines would have shipped with no identifier at all. Now read from the payload. Re-introducing it is one of the mutations below.

## The `apps.ts` site flagged in PR 2

`peekAppleBundleId` decodes the receipt **without verifying it** to pick an app, so that `bundleId` is fully attacker-controlled and reaches a log line before any signature check. It is now a quoted field, with a test:

```text
[onesub] No app configured for bundleId bundleId="com.evil\n[onesub] admin granted premium"
```

## Verification

| Check | Result |
|---|---|
| `npm test` (with `DATABASE_URL`) | **857 passed** (847 → 857) |
| `npm run build` / `type-check` | pass / 0 errors |
| `npm run size -w @onesub/server` | 37.77 / 38.10 KB vs 40 KB |
| `npm run docs:check` | pass |
| `pwsh ./validate-unity-packages.ps1` | pass |
| Each of the 3 commits, independently | build + full suite green |

**The commit order was wrong on the first attempt and the vocabulary test caught it.** The route commit landed before the vocabulary extension, so commit 1 alone failed with 16 unlisted field names. Reordered: vocabulary → routes → docs.

**Mutations, baseline committed first** — all 6 caught: reverting `userId` into the message, `fromUserId`→`previousUserId`, dropping `userId` from the status line, re-interpolating `apps.ts`'s `bundleId`, `purchaseToken`→`token`, and re-introducing the `markedEventId` defect.

**Real server**, hostile `userId` crafted to forge *this PR's own new admin line format*:

```text
[onesub/validate] account binding mismatch — receipt token does not match userId originalTransactionId=mock_apple_orig_d85f487… userId="mallory\n[onesub/admin] sandbox test override set userId=mallory entitled=true"
```

One record. The impersonation attempt stays legible and cannot start a line.

## Still not redacted

`purchaseToken` and `orderId` remain logged in full on the Google webhook paths that already logged them, now under those field names. They are the lookup keys an operator needs, so truncating defeats the line. Naming them is what makes a redaction pass expressible — that, plus the optional typed `structuredLogger` sink, is what remains after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)