### PR TITLE
feat(server)!: refuse Google RTDN requests that cannot be attributed to Google

### DIFF
--- a/.changeset/brave-gates-refuse.md
+++ b/.changeset/brave-gates-refuse.md
@@ -1,0 +1,32 @@
+---
+'@onesub/shared': minor
+'@onesub/server': minor
+---
+
+**Breaking in production:** `POST /onesub/webhook/google` now answers 401 when no
+configured app sets `google.pushAudience`, instead of accepting the request. Adds
+`google.allowUnauthenticatedWebhook` for deployments that authenticate the request in
+front of the server (Cloud Run IAM, VPC-internal ingress, mTLS at a proxy). Nothing
+changes outside `NODE_ENV=production`, matching how the mockMode guard and
+sandbox-receipt rejection are gated.
+
+The exposure this closes was entitlement *revocation*, not forged entitlement: the
+voided-purchase RTDN path acts on the payload alone, so a caller who knew a
+`purchaseToken` or `orderId` could cancel a subscription or delete a one-time purchase
+row.
+
+Masking those ids in logs — the obvious-looking fix — does not work. For a Google
+subscription the purchase token **is** the record's `originalTransactionId`,
+deliberately, because RTDNs and `linkedPurchaseToken` chains carry nothing else. It is
+in the database, in every notification payload, and in the webhook lines that
+investigate it. Redacting it from logs would have left the capability intact while
+implying it was protected.
+
+The startup warning now distinguishes "will reject every request with 401" from "runs
+unauthenticated by explicit opt-in"; update any alert matching the old wording.
+
+Also, with no configuration: each log field value is cut at 512 characters with
+`…+N more` (an upstream Play error body was interpolated whole into an `Error`
+message, so `err.msg` was unbounded), and a purchase token echoed inside a Play API
+URL is replaced with `/tokens/[redacted]` so it cannot reach the acknowledge, consume
+and validation-failure lines that carry no token field.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -75,14 +75,24 @@ degraded mode and must be excluded from production configuration.
 |---|---|---|
 | `packageName` | Yes when Google is enabled | Play application ID and multi-app identity |
 | `serviceAccountKey` | For Play API validation/actions | JSON string containing the service-account key |
-| `pushAudience` | Strongly recommended for RTDN | Expected OIDC `aud`, normally the public webhook URL |
+| `pushAudience` | Yes in production | Expected OIDC `aud`, normally the public webhook URL |
 | `pushServiceAccountEmail` | Strongly recommended with `pushAudience` | Restricts push tokens to the configured service account email |
+| `allowUnauthenticatedWebhook` | No | Run the RTDN webhook unauthenticated in production on purpose — only with upstream authentication |
 | `productReceiptMaxAgeHours` | No | One-time receipt maximum age; default 72 hours |
 | `onPriceChangeConfirmed` | No | Fire-and-forget host callback for confirmed subscription price changes |
 | `mockMode` | Development only | Uses deterministic mock validation without Play API calls |
 
-If `pushAudience` is omitted, the current webhook remains backward compatible but does not
-authenticate the Pub/Sub bearer token. Configure both push fields in production.
+With `pushAudience` omitted, `POST /onesub/webhook/google` cannot attribute a request to Google and
+answers **401** when `NODE_ENV=production`. Outside production it still accepts unauthenticated
+requests, so local and CI setups need no Pub/Sub credentials.
+
+Set `allowUnauthenticatedWebhook: true` only when something in front of the server already
+authenticates the request — Cloud Run with IAM, a VPC-internal ingress, mTLS at a proxy. It is not a
+way to postpone configuring `pushAudience`: with neither set, an RTDN is accepted from anyone who can
+reach the endpoint, and a caller who knows a `purchaseToken` or `orderId` can cancel a subscription or
+delete a one-time purchase. Those values are not secrets — for a Google subscription the purchase
+token *is* the record's `originalTransactionId`. See [SECURITY.md](./SECURITY.md) → *Webhook
+Endpoints*.
 
 ## Multi-App Configuration
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -4,6 +4,68 @@ Upgrade notes for releases of `@onesub/server` that need one. While the package 
 
 ---
 
+## `@onesub/server` 0.26.x → 0.27.0
+
+### Breaking: the Google RTDN webhook refuses unauthenticated requests in production
+
+**Who is affected.** A production deployment (`NODE_ENV=production`) where no configured
+app sets `google.pushAudience`. `POST /onesub/webhook/google` used to accept those
+requests; it now answers **401**. Nothing changes outside production, and nothing
+changes if you already set `pushAudience`.
+
+**Fix, in order of preference:**
+
+```ts
+// 1. Configure Pub/Sub push authentication — the intended setup.
+google: {
+  packageName: 'com.example.app',
+  pushAudience: 'https://your-server.example.com/onesub/webhook/google',
+  pushServiceAccountEmail: 'push@your-project.iam.gserviceaccount.com',
+}
+
+// 2. Or state that something in front of the server already authenticates the
+//    request — Cloud Run with IAM, a VPC-internal ingress, mTLS at a proxy.
+google: { packageName: 'com.example.app', allowUnauthenticatedWebhook: true }
+```
+
+Option 2 is not a way to postpone option 1. With neither, an RTDN is accepted from
+anyone who can reach the endpoint.
+
+**Why this, and not masking the ids in logs.** The exposure was never forged
+entitlement — the subscription paths re-fetch state from Google before writing — but
+*revocation*: the voided-purchase path acts on the payload alone, so a caller who knew
+a `purchaseToken` or `orderId` could cancel a subscription or delete a one-time
+purchase row.
+
+The obvious-looking fix is to stop putting those ids in logs. It does not work. For a
+Google subscription the purchase token **is** the record's `originalTransactionId` —
+deliberately, because RTDNs and `linkedPurchaseToken` chains carry nothing else — so it
+is in the database, in every notification payload, and in the webhook lines where it is
+the subject of the investigation. Redacting it from logs would have left the capability
+intact while implying it was protected. Refusing requests that cannot be attributed to
+Google removes the capability.
+
+**The startup warning changed accordingly.** Where it used to say the endpoint
+"accepts unauthenticated requests", it now either says the endpoint *will reject every
+request with 401* (no `pushAudience`, no opt-in) or that it *runs unauthenticated by
+explicit opt-in*. If you alert on that text, update the pattern.
+
+### Log values are bounded and Play URLs are scrubbed
+
+Two smaller changes, no configuration:
+
+- **Each field value is cut at 512 characters**, with `…+N more` saying how much was
+  dropped. This bites on upstream error bodies: `fetchSubscriptionPurchaseV2`
+  interpolates the whole Play error body into its `Error` message, so `err.msg` was as
+  unbounded as `responseBody`.
+- **A purchase token echoed in a Play API URL is replaced** with
+  `/tokens/[redacted]`. A Play error body can quote the request URL, which would put
+  the token on the acknowledge, consume and validation-failure lines — the ones that
+  deliberately log `productId` and `httpStatus` and no token. A `purchaseToken` field
+  is *not* masked, for the reason above.
+
+---
+
 ## `@onesub/server` 0.25.x → 0.26.0
 
 ### The remaining log lines carry `key=value` fields

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -37,14 +37,23 @@
 - **Apple**: Only JWS-signed `signedPayload` accepted. The embedded `x5c` certificate chain is
   validated to the pinned Apple Root CA G3, then the leaf key verifies the payload signature
 - **Google**: When `pushAudience` is configured, `Authorization: Bearer` JWT is verified against
-  Google JWKS with audience claim check. **When no configured app sets it, the verification step is
-  skipped and the route accepts any well-formed notification body**. The subscription paths re-fetch
-  state from Google before writing, so a forged notification cannot fabricate an entitlement; the
-  voided-purchase path acts on the payload alone, so a caller who knows a `purchaseToken` or `orderId`
-  can cancel a subscription or delete a one-time purchase row. Configure `pushAudience` and
-  `pushServiceAccountEmail`. As of `@onesub/server@0.21.2` the server warns at startup when this
-  applies and `NODE_ENV=production`; as of `0.22.0` the route is mounted only when the config serves
-  Google Play at all, so an Apple-only deployment no longer exposes it
+  Google JWKS with audience claim check. **When no configured app sets it, an unattributable request
+  is refused with 401 under `NODE_ENV=production`** (`@onesub/server@0.27.0`), unless
+  `google.allowUnauthenticatedWebhook` is set — which is only correct when something in front of the
+  server already authenticates the request. Outside production the route still accepts
+  unauthenticated requests, matching how the mockMode guard and sandbox-receipt rejection are gated.
+
+  Why refusing rather than masking the ids. The exposure was never forged entitlement — the
+  subscription paths re-fetch state from Google before writing — but *revocation*: the voided-purchase
+  path acts on the payload alone, so a caller who knew a `purchaseToken` or `orderId` could cancel a
+  subscription or delete a one-time purchase row. Those ids cannot be protected by treating them as
+  secrets. For a Google subscription the purchase token **is** the record's `originalTransactionId`,
+  deliberately, because RTDNs and `linkedPurchaseToken` chains carry nothing else — so it is in the
+  database, in every notification payload, and in the logs that investigate it. Refusing requests that
+  cannot be attributed to Google removes the capability instead of hiding its key.
+
+  Earlier steps on the same path: `0.21.2` added the startup warning, and `0.22.0` mounts the route
+  only when the config serves Google Play at all, so an Apple-only deployment does not expose it
 
 ### Validate / Status Endpoints
 - Currently open by design (consumer adds their own auth middleware)
@@ -93,7 +102,8 @@ authentication middleware.
    Express. Webhook routes are the exception and should not be volume-limited: shedding them can
    permanently lose a state transition once Apple/Google exhaust their retries. Their correct control is
    caller authentication, which for Google means configuring `pushAudience` — without it the Google
-   webhook skips authentication entirely. See *Request Limits* in [DEPLOYMENT.md](./DEPLOYMENT.md)
+   webhook has no way to attribute a request and refuses it in production. See *Request Limits* in
+   [DEPLOYMENT.md](./DEPLOYMENT.md)
 
 ## Reporting Vulnerabilities
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -323,7 +323,9 @@ Canonical Postgres DDL shipped at [`sql/schema.sql`](./sql/schema.sql). Apply wi
 ## Security
 
 - Apple JWS signature verified end-to-end against **Apple Root CA G3** (as of `0.6.0`)
-- Google RTDN: `Authorization: Bearer` JWT verified against Google JWKS when `pushAudience` is configured
+- Google RTDN: `Authorization: Bearer` JWT verified against Google JWKS when `pushAudience` is
+  configured. Without it the request cannot be attributed to Google and is refused with 401 under
+  `NODE_ENV=production`, unless `google.allowUnauthenticatedWebhook` opts in
 - `transactionId` ownership enforced — same receipt can't be reused across users (`0.5.0+`)
 - zod input validation + 50 KB body cap
 - Full write-up: [`docs/SECURITY.md`](../../docs/SECURITY.md)

--- a/packages/server/src/__tests__/google-webhook-open-warning.test.ts
+++ b/packages/server/src/__tests__/google-webhook-open-warning.test.ts
@@ -1,12 +1,20 @@
 /**
- * Startup warning for the two conditions that leave the Google RTDN route open.
+ * Startup warnings for the Google RTDN route's two loose conditions.
  *
- * `POST /onesub/webhook/google` verifies the Pub/Sub OIDC token only when an app
- * declares `pushAudience`, and serves any `packageName` when none declares one.
- * The route is mounted either way. Both behaviours are pre-existing and
- * deliberate — a host may front the route with its own verification — so this
- * warns instead of refusing, and these tests pin down that it says so exactly
- * when it should and stays quiet otherwise.
+ * The authentication half changed in 0.27.0: without a `pushAudience` the route used
+ * to accept the request, and now refuses it with 401 in production unless
+ * `google.allowUnauthenticatedWebhook` says otherwise. So there are two warnings to
+ * tell apart, and getting them backwards would be worse than having none — an
+ * operator reading "insecure" when the endpoint is actually refusing traffic goes
+ * hunting for a breach instead of a missing config value.
+ *
+ * Open mode (no `packageName`) is unchanged: it still warns rather than refusing.
+ *
+ * The assertions here were rewritten, not adjusted. Three of them were negative
+ * matches against the old warning's wording — text this file no longer produces at
+ * all, so they would have passed however loudly the new warning fired. A negative
+ * assertion against a string that cannot occur is not coverage, so each one now
+ * names both current warnings explicitly.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -49,22 +57,42 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+/** Text unique to each of the two warnings, so a test cannot match the wrong one. */
+const WILL_REJECT = 'will reject every request with 401';
+const OPTED_IN = 'runs unauthenticated by explicit opt-in';
+
 describe('unauthenticated Google webhook', () => {
-  it('warns when a Google app has no pushAudience', () => {
+  it('says the route will refuse traffic when no pushAudience is set', () => {
     const { logger, joined } = recordingLogger();
     build({ google: { packageName: 'com.example.app', serviceAccountKey: '{}' } }, logger);
 
-    expect(joined()).toContain('accepts unauthenticated requests');
+    expect(joined()).toContain(WILL_REJECT);
     expect(joined()).toContain('google.pushAudience');
+    // It must also offer the escape hatch, or an operator who genuinely
+    // authenticates upstream has been told to do something they cannot do.
+    expect(joined()).toContain('google.allowUnauthenticatedWebhook');
+    expect(joined()).not.toContain(OPTED_IN);
   });
 
-  it('names the actual consequence, not just the setting', () => {
-    // The subscription paths re-fetch from Google, so the exposure is
-    // revocation rather than forged entitlement. The warning has to say which.
+  it('warns differently, and names the consequence, when the host opts in', () => {
+    // Opting in is legitimate behind Cloud Run IAM or mTLS, so this is not an
+    // error — but it prints every boot, because during an incident nobody should
+    // have to go and read the config to learn this endpoint trusts its caller.
     const { logger, joined } = recordingLogger();
-    build({ google: { packageName: 'com.example.app', serviceAccountKey: '{}' } }, logger);
+    build(
+      {
+        google: {
+          packageName: 'com.example.app',
+          serviceAccountKey: '{}',
+          allowUnauthenticatedWebhook: true,
+        },
+      },
+      logger,
+    );
 
+    expect(joined()).toContain(OPTED_IN);
     expect(joined()).toMatch(/cancel a subscription or delete a one-time purchase/);
+    expect(joined()).not.toContain(WILL_REJECT);
   });
 
   it('stays quiet once pushAudience is configured', () => {
@@ -80,7 +108,8 @@ describe('unauthenticated Google webhook', () => {
       logger,
     );
 
-    expect(joined()).not.toContain('accepts unauthenticated requests');
+    expect(joined()).not.toContain(WILL_REJECT);
+    expect(joined()).not.toContain(OPTED_IN);
   });
 
   it('is satisfied when any app in a multi-app config sets pushAudience', () => {
@@ -103,7 +132,8 @@ describe('unauthenticated Google webhook', () => {
 
     // One shared push endpoint across apps is the documented topology, so this
     // must not nag when it is set on the app that actually receives the push.
-    expect(joined()).not.toContain('accepts unauthenticated requests');
+    expect(joined()).not.toContain(WILL_REJECT);
+    expect(joined()).not.toContain(OPTED_IN);
   });
 
   it('does not warn about authentication when Google is not configured at all', () => {
@@ -112,7 +142,8 @@ describe('unauthenticated Google webhook', () => {
     const { logger, joined } = recordingLogger();
     build({ apple: { bundleId: 'com.example.app' } }, logger);
 
-    expect(joined()).not.toContain('accepts unauthenticated requests');
+    expect(joined()).not.toContain(WILL_REJECT);
+    expect(joined()).not.toContain(OPTED_IN);
   });
 });
 

--- a/packages/server/src/__tests__/google-webhook-unauthenticated.test.ts
+++ b/packages/server/src/__tests__/google-webhook-unauthenticated.test.ts
@@ -1,0 +1,170 @@
+/**
+ * `POST /onesub/webhook/google` refuses requests it cannot attribute to Google.
+ *
+ * ## Why this replaced masking the purchase token
+ *
+ * The RTDN paths are only dangerous because a caller who knows a `purchaseToken` or
+ * an `orderId` could reach them unauthenticated: the voided-purchase branch acts on
+ * the payload alone, cancelling a subscription by token or deleting a one-time
+ * purchase row by order id.
+ *
+ * Treating those ids as secrets does not work. For a Google subscription the purchase
+ * token **is** the record's `originalTransactionId` (`providers/google.ts` keys on it
+ * deliberately — RTDNs and `linkedPurchaseToken` chains carry nothing else), so it
+ * lives in the database, in every notification payload, and in the webhook lines
+ * where it is the subject of the investigation. Redacting it from logs would have left
+ * the capability intact while suggesting otherwise.
+ *
+ * Refusing unattributable requests removes the capability instead.
+ *
+ * ## Production-gated, and why that is not a loophole
+ *
+ * Locally and in CI no real RTDN arrives, and requiring Pub/Sub credentials there
+ * would break every webhook test in this repo and the `onesub dev` server for no
+ * security gain. This matches how the mockMode hard guard and the sandbox-receipt
+ * rejection are already gated. The residual risk — a production deployment that
+ * forgets `NODE_ENV=production` — is the same one those two already carry, so this
+ * adds no new footgun, and the boot warning fires on the same condition.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { ONESUB_ERROR_CODE } from '@onesub/shared';
+import type { OneSubMiddlewareConfig } from '../index.js';
+import { createOneSubMiddleware } from '../index.js';
+import { InMemoryPurchaseStore, InMemorySubscriptionStore } from '../store.js';
+
+const originalNodeEnv = process.env['NODE_ENV'];
+
+afterEach(() => {
+  if (originalNodeEnv === undefined) delete process.env['NODE_ENV'];
+  else process.env['NODE_ENV'] = originalNodeEnv;
+});
+
+function build(google: NonNullable<OneSubMiddlewareConfig['google']>) {
+  const app = express();
+  app.use(
+    createOneSubMiddleware({
+      database: { url: '' },
+      adminSecret: 'test-admin-secret-that-is-long-enough',
+      google,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      store: new InMemorySubscriptionStore(),
+      purchaseStore: new InMemoryPurchaseStore(),
+    }),
+  );
+  return app;
+}
+
+/** A voided-purchase RTDN — the branch that acts on the payload without re-fetching. */
+function voidedRtdn() {
+  const notification = {
+    version: '1.0',
+    packageName: 'com.example.app',
+    eventTimeMillis: '1700000000000',
+    voidedPurchaseNotification: {
+      purchaseToken: 'tok_victim',
+      orderId: 'GPA.victim',
+      productType: 1,
+      refundType: 1,
+    },
+  };
+  return {
+    message: { data: Buffer.from(JSON.stringify(notification)).toString('base64'), messageId: 'm1' },
+    subscription: 'projects/p/subscriptions/s',
+  };
+}
+
+describe('in production', () => {
+  beforeEach(() => {
+    process.env['NODE_ENV'] = 'production';
+  });
+
+  it('refuses a request it cannot attribute to Google', async () => {
+    const app = build({ packageName: 'com.example.app' });
+
+    const res = await request(app).post('/onesub/webhook/google').send(voidedRtdn());
+
+    expect(res.status).toBe(401);
+    expect(res.body.errorCode).toBe(ONESUB_ERROR_CODE.UNAUTHORIZED);
+  });
+
+  it('does not act on the payload before refusing', async () => {
+    // The point of the 401 is that the revocation never happens. A 401 that still
+    // cancelled the subscription would be worse than the old fail-open, because it
+    // would look safe.
+    const store = new InMemorySubscriptionStore();
+    await store.save({
+      userId: 'alice',
+      productId: 'monthly',
+      platform: 'google',
+      status: 'active',
+      expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
+      originalTransactionId: 'tok_victim',
+      purchasedAt: new Date().toISOString(),
+      willRenew: true,
+    });
+    const app = express();
+    app.use(
+      createOneSubMiddleware({
+        database: { url: '' },
+        adminSecret: 'test-admin-secret-that-is-long-enough',
+        google: { packageName: 'com.example.app' },
+        logger: { info: () => {}, warn: () => {}, error: () => {} },
+        store,
+        purchaseStore: new InMemoryPurchaseStore(),
+      }),
+    );
+
+    await request(app).post('/onesub/webhook/google').send(voidedRtdn());
+
+    const after = await store.getByTransactionId('tok_victim');
+    expect(after?.status).toBe('active');
+    expect(after?.willRenew).toBe(true);
+  });
+
+  it('accepts when the host opts in explicitly', async () => {
+    const app = build({ packageName: 'com.example.app', allowUnauthenticatedWebhook: true });
+
+    const res = await request(app).post('/onesub/webhook/google').send(voidedRtdn());
+
+    expect(res.status).toBe(200);
+  });
+
+  it('still refuses a bad token when pushAudience IS configured', async () => {
+    // The opt-in must not become a way to bypass verification that was asked for.
+    const app = build({
+      packageName: 'com.example.app',
+      pushAudience: 'https://api.example.com/onesub/webhook/google',
+      allowUnauthenticatedWebhook: true,
+    });
+
+    const res = await request(app)
+      .post('/onesub/webhook/google')
+      .set('Authorization', 'Bearer not-a-real-google-token')
+      .send(voidedRtdn());
+
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('outside production', () => {
+  it('accepts an unauthenticated request, so dev and CI need no credentials', async () => {
+    process.env['NODE_ENV'] = 'development';
+    const app = build({ packageName: 'com.example.app' });
+
+    const res = await request(app).post('/onesub/webhook/google').send(voidedRtdn());
+
+    expect(res.status).toBe(200);
+  });
+
+  it('accepts with NODE_ENV unset', async () => {
+    delete process.env['NODE_ENV'];
+    const app = build({ packageName: 'com.example.app' });
+
+    const res = await request(app).post('/onesub/webhook/google').send(voidedRtdn());
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/packages/server/src/__tests__/log-format.test.ts
+++ b/packages/server/src/__tests__/log-format.test.ts
@@ -207,3 +207,92 @@ describe('exact shape', () => {
     );
   });
 });
+
+describe('bounding an over-long value', () => {
+  // The values that reach this bound are upstream response bodies, which Apple and
+  // Google produce — not attacker input. `fetchSubscriptionPurchaseV2` interpolates
+  // the whole Play error body into its Error message, so `err.msg` was as unbounded
+  // as `responseBody`; bounding in renderValue covers both.
+  const LIMIT = 512;
+
+  it('leaves a value at the limit untouched', () => {
+    const body = 'x'.repeat(LIMIT);
+    expect(formatLogArgs(['m', { responseBody: body }])).toBe(`m responseBody=${body}`);
+  });
+
+  it('cuts past the limit and says how much was dropped', () => {
+    // The count is the point: `…` alone cannot distinguish 20 characters too long
+    // from a megabyte, which is the difference between "read the rest upstream" and
+    // "something is very wrong upstream".
+    //
+    // It comes back quoted, and that is load-bearing rather than incidental: the
+    // marker contains a space, so an unquoted value would make a logfmt parser read
+    // `more` as a second field. The clamp cannot bypass the field-injection guard
+    // because it runs before the quoting decision, not after it.
+    const rendered = formatLogArgs(['m', { responseBody: 'x'.repeat(LIMIT + 300) }]);
+    expect(rendered).toBe(`m responseBody="${'x'.repeat(LIMIT)}…+300 more"`);
+  });
+
+  it('bounds an Error message, not just a field', () => {
+    const rendered = formatLogArgs(['m', { err: new Error('E'.repeat(LIMIT + 7)) }]);
+    expect(rendered.split('\n')[0]).toBe(`m err=Error err.msg="${'E'.repeat(LIMIT)}…+7 more"`);
+  });
+
+  it('bounds a serialised object, which is the attacker-shaped case', () => {
+    // A webhook payload is arbitrarily large and arbitrarily deep. Bounding only the
+    // string branch would have left exactly the shape a caller controls unbounded.
+    const rendered = formatLogArgs(['m', { responseBody: { blob: 'y'.repeat(LIMIT * 2) } }]);
+    expect(rendered.length).toBeLessThan(LIMIT + 80);
+    expect(rendered).toContain('more');
+  });
+
+  it('counts the caller’s characters, not the escaped expansion', () => {
+    // Escaping doubles a newline. Bounding after escaping would cut a value made of
+    // newlines at half the length of an ordinary one, for no stated reason.
+    const rendered = formatLogArgs(['m', { responseBody: '\n'.repeat(LIMIT + 5) }]);
+    expect(rendered).toContain('…+5 more');
+    expect(rendered.split('\n')).toHaveLength(1);
+  });
+});
+
+describe('redacting a purchase token echoed in a Play API URL', () => {
+  // Deliberately narrow. For a Google subscription the purchase token IS the record's
+  // originalTransactionId, so it is in the database, in every RTDN payload, and in the
+  // three webhook lines where it is the subject. It cannot be treated as a secret in
+  // general. What this stops is it leaking onto the lines that chose not to log it —
+  // acknowledge, consume and validation-failure log productId and httpStatus, no token.
+  const URL_ECHO =
+    'POST https://androidpublisher.googleapis.com/androidpublisher/v3/applications/' +
+    'com.example.app/purchases/products/coins/tokens/kjacgmnbdkjhpgfeknmnhcaa.AO-J1OwSECRET:consume';
+
+  it('removes it from a response body', () => {
+    const rendered = formatLogArgs(['m', { responseBody: URL_ECHO }]);
+    expect(rendered).not.toContain('AO-J1OwSECRET');
+    expect(rendered).toContain('/tokens/[redacted]:consume');
+  });
+
+  it('removes it from an Error message, where the body is interpolated', () => {
+    const rendered = formatLogArgs(['m', { err: new Error(`Play API error 400: ${URL_ECHO}`) }]);
+    expect(rendered).not.toContain('AO-J1OwSECRET');
+    expect(rendered).toContain('/tokens/[redacted]');
+  });
+
+  it('removes it from a serialised object', () => {
+    const rendered = formatLogArgs(['m', { responseBody: { error: { request: URL_ECHO } } }]);
+    expect(rendered).not.toContain('AO-J1OwSECRET');
+  });
+
+  it('leaves a bare purchaseToken field alone, which is deliberate', () => {
+    // Masking it here would suggest the token is protected while the same value
+    // renders unmasked as originalTransactionId two lines earlier.
+    expect(formatLogArgs(['m', { purchaseToken: 'kjacgmnbdkjhpgfeknmnhcaa.AO-J1OwSECRET' }])).toBe(
+      'm purchaseToken=kjacgmnbdkjhpgfeknmnhcaa.AO-J1OwSECRET',
+    );
+  });
+
+  it('does not mangle a path that merely contains the word tokens', () => {
+    expect(formatLogArgs(['m', { responseBody: 'see https://example.com/tokens' }])).toBe(
+      'm responseBody="see https://example.com/tokens"',
+    );
+  });
+});

--- a/packages/server/src/log-format.ts
+++ b/packages/server/src/log-format.ts
@@ -77,6 +77,33 @@ const BARE_VALUE = /^[\w.:/@+-]+$/;
 /** Any character that could end a line, including the two Unicode separators. */
 const LINE_TERMINATORS = /\r\n|\r|\n|\u2028|\u2029/;
 
+/**
+ * Longest a single field value may render before it is cut.
+ *
+ * This is log hygiene, not defence against a caller: the values that actually reach
+ * this bound are upstream response bodies, which Apple and Google produce, not an
+ * attacker. `fetchSubscriptionPurchaseV2` interpolates the whole Play error body into
+ * its `Error` message, so `err.msg` was as unbounded as `responseBody` \u2014 bounding in
+ * `renderValue` covers both, and every future field, from one place.
+ */
+const MAX_VALUE_CHARS = 512;
+
+/**
+ * Google Play Developer API URL segment carrying a purchase token.
+ *
+ * A Play error body, and the `Error` message that embeds it, can echo the request
+ * URL \u2014 `.../purchases/products/<productId>/tokens/<purchaseToken>:consume`. That
+ * puts the token on log lines that deliberately do not carry it: the acknowledge,
+ * consume and validation-failure sites log `productId` and `httpStatus` and no token.
+ *
+ * This is not an attempt to treat the purchase token as a secret in general \u2014 it
+ * cannot be. For a Google subscription the token *is* the record's
+ * `originalTransactionId`, so it is in the database, in every RTDN payload, and in
+ * the three webhook lines where it is the subject of the investigation. What this
+ * does is stop it leaking onto the lines that had decided not to log it.
+ */
+const PLAY_TOKEN_IN_URL = /\/tokens\/[^/:"'\s\\]+/g;
+
 /** How far to follow `Error.cause`, and how many `AggregateError.errors` to render. */
 const MAX_CAUSE_DEPTH = 2;
 const MAX_AGGREGATE_ERRORS = 3;
@@ -120,6 +147,34 @@ function escQuoted(value: string): string {
 }
 
 /**
+ * Cut an over-long value, saying how much was dropped.
+ *
+ * The count matters: `…` alone leaves an operator unable to tell a body that was
+ * 20 characters too long from one that was a megabyte, which is the difference
+ * between "read the rest upstream" and "something is very wrong upstream".
+ *
+ * Applied before escaping, so the bound is on the caller's characters rather than on
+ * the expansion — otherwise a value made entirely of newlines would be cut at half
+ * the length of an ordinary one.
+ */
+function clamp(value: string): string {
+  if (value.length <= MAX_VALUE_CHARS) return value;
+  return `${value.slice(0, MAX_VALUE_CHARS)}…+${value.length - MAX_VALUE_CHARS} more`;
+}
+
+/**
+ * Redact then bound — every rendered value goes through here.
+ *
+ * One helper rather than three call sites, because the object and symbol branches
+ * produce strings too: a serialised webhook payload can be arbitrarily large and can
+ * carry the same Play URL. Applying this only to the `string` branch would have left
+ * exactly the shapes an attacker controls unbounded.
+ */
+function sanitize(value: string): string {
+  return clamp(value.replace(PLAY_TOKEN_IN_URL, '/tokens/[redacted]'));
+}
+
+/**
  * Render one field value in logfmt.
  *
  * The quoting is a security control, not formatting. An unquoted `userId` of
@@ -138,21 +193,23 @@ function renderValue(value: unknown): string | undefined {
       return String(value);
     case 'bigint':
       return `${value}n`;
-    case 'string':
-      return BARE_VALUE.test(value) ? value : `"${escQuoted(value)}"`;
+    case 'string': {
+      const safe = sanitize(value);
+      return BARE_VALUE.test(safe) ? safe : `"${escQuoted(safe)}"`;
+    }
     case 'object':
       // Depth 1 only, and inside a try/catch. Webhook payloads are attacker-shaped
       // and arbitrarily deep; a recursive walk here would be both bundle weight and
       // a CPU-DoS surface, and JSON.stringify already throws on cycles.
       try {
-        return `"${escQuoted(JSON.stringify(value) ?? 'null')}"`;
+        return `"${escQuoted(sanitize(JSON.stringify(value) ?? 'null'))}"`;
       } catch {
         return '"[unserialisable]"';
       }
     default:
       // symbol, function — String() is safe for both.
       try {
-        return `"${escQuoted(String(value))}"`;
+        return `"${escQuoted(sanitize(String(value)))}"`;
       } catch {
         return '"[unrenderable]"';
       }

--- a/packages/server/src/routes/webhook-google.ts
+++ b/packages/server/src/routes/webhook-google.ts
@@ -126,23 +126,53 @@ export function servesGoogle(config: OneSubServerConfig): boolean {
  * `orderId`. So the exposure is entitlement *revocation* for a caller who knows
  * or guesses one of those ids — not free entitlement.
  */
+/**
+ * True when at least one app declares a `pushAudience`, so an incoming RTDN can be
+ * cryptographically attributed to Google.
+ *
+ * Shared by the boot warning and the handler on purpose. When those two answered the
+ * question separately they could disagree — the warning saying the endpoint is open
+ * while the handler rejects, or worse the reverse.
+ */
+function googleWebhookIsAuthenticated(config: OneSubServerConfig): boolean {
+  return getAppRegistry(config).apps.some((a) => a.google?.pushAudience);
+}
+
+/** True when an app opts into running the webhook unauthenticated in production. */
+function googleWebhookAllowsUnauthenticated(config: OneSubServerConfig): boolean {
+  return getAppRegistry(config).apps.some((a) => a.google?.allowUnauthenticatedWebhook);
+}
+
 export function warnIfGoogleWebhookOpen(config: OneSubServerConfig): void {
   if (process.env['NODE_ENV'] !== 'production') return;
   // Nothing to warn about when the route is not mounted at all.
   if (!servesGoogle(config)) return;
 
   const apps = getAppRegistry(config).apps;
-  const googleApps = apps.map((a) => a.google).filter((g): g is NonNullable<typeof g> => !!g);
 
-  // Authentication is skipped entirely when no app declares a pushAudience —
-  // see handleGoogleWebhook, which only verifies when it has one to verify.
-  if (!googleApps.some((g) => g.pushAudience)) {
-    log.warn(
-      '[onesub] SECURITY: POST /onesub/webhook/google accepts unauthenticated requests — ' +
-        'no configured app sets google.pushAudience, so the Pub/Sub OIDC token is never verified. ' +
-        'A caller who knows a purchaseToken or orderId can cancel a subscription or delete a ' +
-        'one-time purchase. Set google.pushAudience (and google.pushServiceAccountEmail).',
-    );
+  if (!googleWebhookIsAuthenticated(config)) {
+    if (googleWebhookAllowsUnauthenticated(config)) {
+      // Explicitly opted in. Still worth a line every boot: whoever reads the logs
+      // during an incident should not have to go and check the config to learn that
+      // this endpoint trusts its caller.
+      log.warn(
+        '[onesub] SECURITY: POST /onesub/webhook/google runs unauthenticated by explicit opt-in — ' +
+          'google.allowUnauthenticatedWebhook is set and no app sets google.pushAudience. Anything ' +
+          'that can reach this endpoint can cancel a subscription or delete a one-time purchase, so ' +
+          'the request must already be authenticated in front of this server.',
+      );
+    } else {
+      // Was a silent accept before 0.27.0. It is now a 401, so the warning has to
+      // say the endpoint is refusing traffic — an operator reading "insecure" would
+      // go looking for a security problem instead of a missing config value.
+      log.warn(
+        '[onesub] POST /onesub/webhook/google will reject every request with 401 — no configured ' +
+          'app sets google.pushAudience, so the Pub/Sub OIDC token cannot be verified. Set ' +
+          'google.pushAudience (and google.pushServiceAccountEmail), or set ' +
+          'google.allowUnauthenticatedWebhook when something in front of this server already ' +
+          'authenticates the request.',
+      );
+    }
   }
 
   // Open mode: any packageName is served, so a notification does not even have
@@ -352,7 +382,22 @@ export async function handleGoogleWebhook(
     .apps.map((app) => app.google)
     .filter((g): g is NonNullable<typeof g> => !!g?.pushAudience);
 
-  if (pushIdentities.length > 0) {
+  if (pushIdentities.length === 0) {
+    // No push identity to verify against. Before 0.27.0 this accepted the request,
+    // which made a `purchaseToken` or `orderId` sufficient to revoke an entitlement
+    // — and for a Google subscription the purchase token IS the record's
+    // originalTransactionId, so it is in the database, in RTDN payloads and in logs.
+    // Treating it as a secret was never going to work; refusing unattributable
+    // requests is what actually removes the capability.
+    //
+    // Production-gated, matching the mockMode guard and the sandbox-receipt
+    // rejection: locally and in CI no real RTDN arrives, and requiring credentials
+    // there would break every test and the `onesub dev` server for no security gain.
+    if (process.env['NODE_ENV'] === 'production' && !googleWebhookAllowsUnauthenticated(config)) {
+      sendError(res, 401, ONESUB_ERROR_CODE.UNAUTHORIZED, 'Unauthorized');
+      return;
+    }
+  } else {
     let authenticated = false;
     for (const google of pushIdentities) {
       if (await verifyGooglePushToken(req, google.pushAudience!, google.pushServiceAccountEmail)) {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -281,12 +281,30 @@ export interface OneSubServerConfig {
      * Expected `aud` claim for incoming Pub/Sub push JWT tokens.
      * When set, the Google webhook endpoint verifies the `Authorization: Bearer <token>`
      * header as a Google-signed JWT whose `aud` matches this value.
-     * If omitted, no authentication is performed on the webhook (backward compatible).
+     *
+     * **Required in production** unless `allowUnauthenticatedWebhook` is set. With
+     * neither, `POST /onesub/webhook/google` answers 401 when `NODE_ENV=production`.
+     * Outside production the webhook still accepts unauthenticated requests so local
+     * and CI setups need no credentials.
      *
      * Set this to the push endpoint URL registered in your Pub/Sub subscription,
      * e.g. `https://your-server.example.com/onesub/webhook/google`.
      */
     pushAudience?: string;
+    /**
+     * Run the Google webhook unauthenticated in production, on purpose.
+     *
+     * Only correct when something in front of the server already authenticates the
+     * request — Cloud Run with IAM, a VPC-internal ingress, mTLS at a proxy. It is
+     * not a way to postpone configuring `pushAudience`: with neither set, an RTDN is
+     * accepted from anyone who can reach the endpoint, and a caller who knows a
+     * `purchaseToken` or `orderId` can cancel a subscription or delete a one-time
+     * purchase. Those values are not secrets — for Google subscriptions the
+     * purchase token *is* the record's `originalTransactionId`.
+     *
+     * Ignored outside production, where the webhook is unauthenticated regardless.
+     */
+    allowUnauthenticatedWebhook?: boolean;
     /**
      * Service-account email your Pub/Sub push subscription authenticates as.
      * When set (together with `pushAudience`), incoming push JWTs must carry a


### PR DESCRIPTION
The follow-on I flagged after the logging migration was "mask `purchaseToken` / `orderId` in logs". **Investigating it showed that is the wrong fix**, so this PR does something different. That reasoning is the main thing to review.

## Why masking does not work

For a Google subscription the purchase token **is** the record's `originalTransactionId` — deliberately (`providers/google.ts:592`), because RTDNs and `linkedPurchaseToken` chains carry nothing else. So the same value flows under three field names, and is in the database besides:

| name | where |
|---|---|
| `purchaseToken` | 3 webhook lines |
| `originalTransactionId` | `validate.ts:81` + the DB primary key |
| `userId` | the recovery path uses it as the placeholder (`webhook-google.ts:318,327`) — and that is **persisted**, pinned by `linked-purchase-token.test.ts:232` |

I confirmed the third one empirically rather than reasoning about it: a throwaway test proved a store-error line prints the token as `userId=…`.

Masking one field name would have left the capability intact **and** added confidence it was gone. That is worse than not doing it.

## What the capability actually is

Not forged entitlement — the subscription paths re-fetch state from Google before writing. It is **revocation**: the voided-purchase branch acts on the payload alone, cancelling by token or deleting a one-time purchase row by order id. And it only reaches that branch because auth is skipped entirely when no app sets `pushAudience` (`if (pushIdentities.length > 0)`).

So the fix is to refuse requests that cannot be attributed to Google. Then a leaked token is worthless and the log question is moot.

## A — Google webhook fails closed (breaking, production only)

| condition | before | after |
|---|---|---|
| prod + `pushAudience` | verify | verify (unchanged) |
| prod, none, no opt-in | **accept** | **401** |
| prod, none, opt-in | accept | accept |
| non-production | accept | accept (unchanged) |

New `google.allowUnauthenticatedWebhook` for deployments that authenticate upstream (Cloud Run IAM, VPC-internal ingress, mTLS).

**Production-gated on purpose.** ~10 test files, the MCP simulation tool, `examples/` and `bench/` all POST to this route without `pushAudience`; requiring credentials there breaks them for no security gain, and forcing the insecure flag into `examples/` would teach the wrong thing. This matches the existing idiom — the mockMode hard guard and both sandbox-receipt rejections are gated the same way. Same residual footgun as those (unset `NODE_ENV` in prod), no new one.

The predicate is one shared helper, so the boot warning and the handler cannot disagree.

## B — Log values bounded, Play URL tokens scrubbed

`fetchSubscriptionPurchaseV2` interpolates the **whole Play error body** into its `Error` message, so `err.msg` was as unbounded as `responseBody`. Both now go through one `sanitize()` in `renderValue`, which also covers the object branch — a serialised webhook payload is the shape a caller controls.

- values cut at 512 chars with `…+N more` (the count distinguishes "read the rest upstream" from "something is very wrong upstream")
- `/tokens/<token>` → `/tokens/[redacted]`, so the token cannot reach the acknowledge / consume / validation-failure lines that carry `productId` and `httpStatus` and **no** token field
- a bare `purchaseToken` field is left alone, with a test saying why

## Tests rewritten, not adjusted

`google-webhook-open-warning.test.ts` had **three vacuous assertions**: negative matches on `'accepts unauthenticated requests'`, a string this change stops producing entirely — they would have passed however loudly the new warning fired. Each now names both current warnings explicitly. The file's header also claimed the code "warns instead of refusing", which is no longer true; rewritten.

## Verification

| Check | Result |
|---|---|
| `npm test` (with `DATABASE_URL`) | **873 passed** (857 → 873) |
| `npm run build` / `type-check` | pass / 0 errors |
| `npm run size -w @onesub/server` | 38.06 / 38.40 KB vs 40 KB |
| dashboard type-check + build | pass (shared changed) |
| `npm run docs:check` | pass |
| `pwsh ./validate-unity-packages.ps1` | pass |
| Each of the 4 commits, independently | build + full suite green |

**Mutations, baseline committed first** — all 6 caught: removing the 401 gate, ignoring the opt-in, removing the URL scrub, removing the clamp, omitting `sanitize` from the object branch only, and changing the limit.

One test asserts the 401 **does not act on the payload before refusing** — a 401 that still cancelled the subscription would be worse than the old fail-open, because it would look safe.

**Real server, `NODE_ENV=production`**, unauthenticated voided RTDN:

```text
HTTP 401
[onesub] POST /onesub/webhook/google will reject every request with 401 — no configured app sets google.pushAudience, …
```

## Contract checklist

Config field → `packages/shared/src/types.ts` → rebuilt `@onesub/shared` before testing → consuming code → `docs/CONFIGURATION.md` (`pushAudience` promoted to "yes in production") → `docs/SECURITY.md` → `packages/server/README.md` → `docs/MIGRATION.md` (breaking entry, both fixes in preference order) → changeset.

## Left alone, deliberately

The purchase token stays the Google subscription primary key and the placeholder `userId`. Changing that is a persisted-data change needing its own decision, and with the webhook failing closed the token is no longer a capability — so it is no longer urgent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)