### PR TITLE
fix(cli): stop scaffolding projects pinned to a server from twenty minors ago

### DIFF
--- a/.changeset/stale-pins-refresh.md
+++ b/.changeset/stale-pins-refresh.md
@@ -1,0 +1,19 @@
+---
+'@onesub/cli': patch
+'@onesub/mcp-server': patch
+---
+
+Fix `onesub init` scaffolding a project pinned to `@onesub/server@^0.7.0`.
+
+A caret range on a `0.x` version admits only patches, so every scaffolded project
+installed `0.7.x` — twenty minors behind, without the log formatter, the conditional
+Google webhook mount, or the webhook authentication requirement. Nothing caught it:
+Changesets bumps workspace versions, and this is copied template content, not a
+workspace. `packages/cli/src/__tests__/templates.test.ts` now fails when the pin
+cannot install the current server version, so a server release that outruns the
+template is caught at that release.
+
+The template also documents that `GOOGLE_PUSH_AUDIENCE` is required in production as of
+`@onesub/server@0.27.0`, and passes `pushServiceAccountEmail` through. The
+`simulate_webhook` MCP tool description notes that the Google endpoint needs
+`pushAudience` or `allowUnauthenticatedWebhook` against a production server.

--- a/SKILL.md
+++ b/SKILL.md
@@ -58,7 +58,7 @@ app.listen(4100);
 | `POST /onesub/validate` | Verify subscription receipt (Apple JWS or Google token) |
 | `GET  /onesub/status?userId=` | Check subscription state |
 | `POST /onesub/webhook/apple` | App Store Server Notifications V2 (JWS-verified) |
-| `POST /onesub/webhook/google` | Google Play RTDN (Pub/Sub JWT-verified) |
+| `POST /onesub/webhook/google` | Google Play RTDN (Pub/Sub JWT-verified; 401 in production without `pushAudience`) |
 | `POST /onesub/purchase/validate` | One-time purchase (consumable / non-consumable) |
 | `GET  /onesub/purchase/status?userId=` | List user's one-time purchases |
 | `DELETE /onesub/purchase/admin/:userId/:productId` | Reset a non-consumable for re-testing (admin) |
@@ -175,10 +175,17 @@ interface OneSubServerConfig {
   google?: {
     packageName: string;
     serviceAccountKey?: string;  // JSON string of service account
-    pushAudience?: string;       // Pub/Sub push endpoint URL for JWT verification
+    pushAudience?: string;       // REQUIRED IN PRODUCTION: Pub/Sub push endpoint URL, verified
+                                 // as the OIDC `aud`. Without it POST /onesub/webhook/google
+                                 // cannot attribute a request to Google and answers 401 when
+                                 // NODE_ENV=production. Unauthenticated outside production.
     pushServiceAccountEmail?: string;  // STRONGLY RECOMMENDED in production: with pushAudience,
                                        // requires the push JWT to carry this exact email, so any
                                        // Google-signed token no longer suffices
+    allowUnauthenticatedWebhook?: boolean;  // Run the RTDN webhook unauthenticated in production
+                                            // ON PURPOSE — only when something in front of the
+                                            // server already authenticates (Cloud Run IAM, mTLS,
+                                            // VPC-internal ingress). Not a way to skip the setup
     mockMode?: boolean;          // DEV ONLY
     productReceiptMaxAgeHours?: number;  // default 72
   };

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -174,7 +174,7 @@ This matters because the most expensive routes are the unauthenticated ones. Cos
 | `GET /onesub/entitlement`, `/onesub/entitlements` | none | At most two store reads, independent of how many entitlements are configured |
 | `GET /onesub/purchase/status` | none | One store read; **unbounded response** without `?productId=`, since it returns the user's full purchase history |
 | `POST /onesub/webhook/apple` | JWS signature | See the warning below — do not limit these like public traffic |
-| `POST /onesub/webhook/google` | JWT, **only if `pushAudience` is set** | Same, and see the note below |
+| `POST /onesub/webhook/google` | JWT; **401 in production without `pushAudience`** | Same, and see the note below |
 | `/onesub/admin/*`, `/onesub/metrics/*` | `adminSecret` | Metrics reduce every record in the store; responses are cached for `metricsCacheTtlSeconds` |
 
 > **Do not rate-limit the webhook routes on request volume.** A `429` is not a
@@ -188,17 +188,25 @@ The control that belongs on a webhook route is caller authentication, not a requ
 quota — and the two routes differ in whether you get it by default:
 
 - **Apple** always verifies the `signedPayload` JWS against the bundled Apple roots.
-- **Google** verifies the Pub/Sub OIDC token **only when `google.pushAudience` is
-  configured**. With no app configuring it, the authentication step is skipped and
-  the route accepts any well-formed notification body. That is the reason
-  `pushAudience` and `pushServiceAccountEmail` are on the production checklist:
-  without them the endpoint is both public and unauthenticated, and a forged
-  notification can move subscription state. Configure them rather than reaching for
-  a rate limit.
+- **Google** verifies the Pub/Sub OIDC token when `google.pushAudience` is configured.
+  With no app configuring it there is nothing to verify against, so as of
+  `@onesub/server@0.27.0` the route **answers 401 under `NODE_ENV=production`** rather
+  than accepting the body. Set `pushAudience` and `pushServiceAccountEmail`; the
+  endpoint does not work in production without them.
+
+  If something in front of the server already authenticates the request — Cloud Run
+  with IAM, a VPC-internal ingress, mTLS at a proxy — set
+  `google.allowUnauthenticatedWebhook: true` to say so. It is not a way to postpone
+  the Pub/Sub setup: with neither set, an RTDN is accepted from anyone who can reach
+  the endpoint, and knowing a `purchaseToken` or `orderId` is then enough to cancel a
+  subscription or delete a one-time purchase. Configure authentication rather than
+  reaching for a rate limit — see *Request Limits* above for why these routes must not
+  be volume-limited.
 
   Note also that a server where no app declares `google.packageName` runs in open
-  mode — it serves notifications for any package. As of `@onesub/server@0.21.2` the
-  server warns at startup for both conditions when `NODE_ENV=production`.
+  mode — it serves notifications for any package. That one still warns rather than
+  refusing. `@onesub/server@0.21.2` added the startup warning for both conditions when
+  `NODE_ENV=production`.
 
   As of `0.22.0` the route is mounted only when the config serves Google Play — a
   top-level `google` block, or a `google` block on any `apps[]` entry. An Apple-only

--- a/examples/expo-app/package.json
+++ b/examples/expo-app/package.json
@@ -9,7 +9,7 @@
     "ios": "expo run:ios"
   },
   "dependencies": {
-    "@jeonghwanko/onesub-sdk": "^0.7.0",
+    "@jeonghwanko/onesub-sdk": "^0.10.6",
     "expo": "~54.0.0",
     "expo-router": "~6.0.0",
     "expo-status-bar": "~3.0.0",

--- a/examples/server/package.json
+++ b/examples/server/package.json
@@ -8,7 +8,7 @@
     "dev": "node --watch server.js"
   },
   "dependencies": {
-    "@onesub/server": "^0.14.0",
+    "@onesub/server": "^0.27.0",
     "bullmq": "^5.0.0",
     "dotenv": "^16.4.0",
     "express": "^4.19.2",

--- a/examples/server/server.js
+++ b/examples/server/server.js
@@ -88,6 +88,11 @@ app.use(
       ? {
           packageName: process.env.GOOGLE_PACKAGE_NAME,
           serviceAccountKey: process.env.GOOGLE_SERVICE_ACCOUNT_KEY,
+          // Required in production. Without it POST /onesub/webhook/google cannot
+          // attribute a request to Google and answers 401 when NODE_ENV=production.
+          // Unset here so this example runs locally with no Pub/Sub setup.
+          pushAudience: process.env.GOOGLE_PUSH_AUDIENCE,
+          pushServiceAccountEmail: process.env.GOOGLE_PUSH_SERVICE_ACCOUNT_EMAIL,
         }
       : undefined,
     database: { url: process.env.DATABASE_URL ?? '' },

--- a/packages/cli/src/__tests__/templates.test.ts
+++ b/packages/cli/src/__tests__/templates.test.ts
@@ -1,0 +1,120 @@
+/**
+ * The `onesub init` templates must scaffold a project on a current server.
+ *
+ * ## Why this test exists
+ *
+ * `templates/package.json` pinned `@onesub/server: ^0.7.0` while the published server
+ * was on `0.27.0`. A caret range on a `0.x` version admits only patches — `^0.7.0`
+ * resolves to `0.7.x` — so every `onesub init` scaffolded a project **twenty minors
+ * behind**, missing the log formatter, the conditional webhook mount and the webhook
+ * authentication requirement. It had been that way since the express
+ * peerDependencies move.
+ *
+ * Nothing caught it, and that is the interesting part. Changesets bumps *workspace*
+ * versions; this file is copied template content, not a workspace, so no release step
+ * touches it. `docs:check` validates links and catalogues, not dependency ranges. The
+ * only mechanism was remembering — and twenty releases is a fair sample of how well
+ * that works.
+ *
+ * So the fix is not just the bump. Releasing a server minor now has to bump this pin
+ * too, and this test is what says so, at the release that introduces the drift rather
+ * than a year later.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const CLI = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+const REPO = dirname(dirname(CLI));
+
+function readJson<T>(...parts: string[]): T {
+  return JSON.parse(readFileSync(join(...parts), 'utf8')) as T;
+}
+
+/**
+ * Does a caret range admit this version?
+ *
+ * Hand-rolled rather than pulling in `semver`, because the CLI has no runtime
+ * dependency on it and adding one to satisfy a test is the wrong trade. Only the
+ * shapes this repo actually writes are handled: `^x.y.z` and an exact version. A
+ * range this cannot parse throws rather than silently passing — a test that quietly
+ * approves an unrecognised pin is worse than no test.
+ */
+function caretAdmits(range: string, version: string): boolean {
+  const v = version.split('.').map(Number);
+  if (v.length !== 3 || v.some(Number.isNaN)) throw new Error(`unparseable version: ${version}`);
+
+  if (/^\d+\.\d+\.\d+$/.test(range)) return range === version;
+
+  const m = /^\^(\d+)\.(\d+)\.(\d+)$/.exec(range);
+  if (!m) throw new Error(`unhandled range shape, teach this test about it: ${range}`);
+  const [lo0, lo1, lo2] = [Number(m[1]), Number(m[2]), Number(m[3])];
+  const [hi0, hi1, hi2] = v as [number, number, number];
+
+  // Below the floor is out, whatever the majors do.
+  if (hi0 < lo0) return false;
+  if (hi0 === lo0 && (hi1 < lo1 || (hi1 === lo1 && hi2 < lo2))) return false;
+
+  // npm treats a 0.x caret as minor-locked: ^0.7.0 is >=0.7.0 <0.8.0. That is the
+  // whole reason the pin went stale, so it is the case worth being explicit about.
+  if (lo0 === 0) return hi0 === 0 && hi1 === lo1;
+  return hi0 === lo0;
+}
+
+describe('caretAdmits', () => {
+  // The helper decides whether the assertion below means anything, so it is tested
+  // before it is trusted.
+  it('locks a 0.x caret to its minor', () => {
+    expect(caretAdmits('^0.7.0', '0.7.5')).toBe(true);
+    expect(caretAdmits('^0.7.0', '0.8.0')).toBe(false);
+    expect(caretAdmits('^0.7.0', '0.27.0')).toBe(false);
+    expect(caretAdmits('^0.27.0', '0.27.1')).toBe(true);
+  });
+
+  it('allows minors on a stable major', () => {
+    expect(caretAdmits('^5.2.1', '5.9.0')).toBe(true);
+    expect(caretAdmits('^5.2.1', '6.0.0')).toBe(false);
+    expect(caretAdmits('^5.2.1', '5.2.0')).toBe(false);
+  });
+
+  it('matches an exact pin exactly', () => {
+    expect(caretAdmits('0.27.0', '0.27.0')).toBe(true);
+    expect(caretAdmits('0.27.0', '0.27.1')).toBe(false);
+  });
+
+  it('refuses to guess at a range shape it does not know', () => {
+    expect(() => caretAdmits('>=0.27 <1', '0.27.0')).toThrow(/unhandled range shape/);
+    expect(() => caretAdmits('~0.27.0', '0.27.0')).toThrow(/unhandled range shape/);
+  });
+});
+
+describe('onesub init templates', () => {
+  const serverVersion = readJson<{ version: string }>(REPO, 'packages/server/package.json').version;
+
+  it('scaffolds a project that can install the current server', () => {
+    const range = readJson<{ dependencies: Record<string, string> }>(CLI, 'templates/package.json')
+      .dependencies['@onesub/server'];
+
+    expect(range).toBeDefined();
+    expect(
+      caretAdmits(range!, serverVersion),
+      `templates/package.json pins @onesub/server ${range}, which cannot install ` +
+        `${serverVersion}. On a 0.x version a caret admits only patches, so bump the ` +
+        `pin in the same change as the server release.`,
+    ).toBe(true);
+  });
+
+  it('keeps every template the CLI copies present', () => {
+    // A missing template makes `onesub init` produce a half-scaffolded project, and
+    // the failure surfaces at the user rather than here.
+    const src = readFileSync(join(CLI, 'src/index.ts'), 'utf8');
+    const declared = [...src.matchAll(/\{\s*src:\s*'([^']+)'/g)].map((m) => m[1]!);
+
+    expect(declared.length).toBeGreaterThan(3);
+    for (const file of declared) {
+      expect(() => readFileSync(join(CLI, 'templates', file), 'utf8')).not.toThrow();
+    }
+  });
+});

--- a/packages/cli/templates/.env.example
+++ b/packages/cli/templates/.env.example
@@ -7,8 +7,12 @@ APPLE_SHARED_SECRET=your_shared_secret
 # Service account JSON from Google Cloud Console (single-line)
 GOOGLE_PACKAGE_NAME=com.yourapp.id
 GOOGLE_SERVICE_ACCOUNT_KEY={"type":"service_account","project_id":"..."}
-# Optional: push endpoint URL for Pub/Sub JWT verification
+# REQUIRED IN PRODUCTION: the Pub/Sub push endpoint URL, verified as the OIDC `aud`.
+# Without it the Google webhook cannot attribute a request to Google and answers 401
+# when NODE_ENV=production. Leave it unset for local development.
 # GOOGLE_PUSH_AUDIENCE=https://api.yourapp.com/onesub/webhook/google
+# Restricts push tokens to your Pub/Sub service account; set it with the audience.
+# GOOGLE_PUSH_SERVICE_ACCOUNT_EMAIL=push@your-project.iam.gserviceaccount.com
 
 # ── Database ────────────────────────────────────────────
 # Uncomment for Postgres; leave unset for in-memory (dev only)

--- a/packages/cli/templates/package.json
+++ b/packages/cli/templates/package.json
@@ -8,7 +8,7 @@
     "start": "tsx server.ts"
   },
   "dependencies": {
-    "@onesub/server": "^0.7.0",
+    "@onesub/server": "^0.27.0",
     "dotenv": "^16.4.5",
     "express": "^5.2.1",
     "pg": "^8.13.0"

--- a/packages/cli/templates/server.ts
+++ b/packages/cli/templates/server.ts
@@ -28,7 +28,10 @@ app.use(
       ? {
           packageName: process.env.GOOGLE_PACKAGE_NAME,
           serviceAccountKey: process.env.GOOGLE_SERVICE_ACCOUNT_KEY,
+          // Required in production: without it the RTDN webhook cannot attribute a
+          // request to Google and refuses it. See docs/SECURITY.md.
           pushAudience: process.env.GOOGLE_PUSH_AUDIENCE,
+          pushServiceAccountEmail: process.env.GOOGLE_PUSH_SERVICE_ACCOUNT_EMAIL,
         }
       : undefined,
     database: { url: dbUrl ?? '' },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -156,7 +156,7 @@ server.tool(
 
 server.tool(
   'onesub_simulate_webhook',
-  "Send a simulated Apple or Google webhook notification to an onesub server to test lifecycle transitions without real store credentials. Builds a fake (unsigned) payload and POSTs it to /onesub/webhook/apple or /onesub/webhook/google. Requires the server to have skipJwsVerification: true (set automatically by `npx @onesub/cli dev`). Apple types: SUBSCRIBED, DID_RENEW, DID_RECOVER, OFFER_REDEEMED, DID_FAIL_TO_RENEW, GRACE_PERIOD_EXPIRED, EXPIRED, REFUND, REVOKE. Google types: purchased, renewed, recovered, restarted, canceled, revoked, expired, on_hold, grace_period, paused, price_change_confirmed.",
+  "Send a simulated Apple or Google webhook notification to an onesub server to test lifecycle transitions without real store credentials. Builds a fake (unsigned) payload and POSTs it to /onesub/webhook/apple or /onesub/webhook/google. Requires the server to have skipJwsVerification: true (set automatically by `npx @onesub/cli dev`). Against a server running with NODE_ENV=production the Google endpoint also needs google.pushAudience or google.allowUnauthenticatedWebhook, or it answers 401. Apple types: SUBSCRIBED, DID_RENEW, DID_RECOVER, OFFER_REDEEMED, DID_FAIL_TO_RENEW, GRACE_PERIOD_EXPIRED, EXPIRED, REFUND, REVOKE. Google types: purchased, renewed, recovered, restarted, canceled, revoked, expired, on_hold, grace_period, paused, price_change_confirmed.",
   {
     serverUrl: simulateWebhookInputSchema.serverUrl,
     platform: simulateWebhookInputSchema.platform,


### PR DESCRIPTION
Checked what else in the repo needed updating after 0.27.0's breaking change, and found something worse than the thing I was looking for.

## `onesub init` has been scaffolding 0.7.x

`packages/cli/templates/package.json` pinned `@onesub/server: ^0.7.0`. **A caret on a `0.x` version admits only patches**, so `^0.7.0` resolves to `0.7.x` — every scaffolded project got a server from twenty minors ago: no log formatter, no conditional Google webhook mount, no webhook authentication. Stale since the express-peerDependencies move.

**Nothing caught it for twenty releases, and the reason is structural.** Changesets bumps *workspace* versions; `templates/` is copied content, not a workspace, so no release step reads it. `docs:check` validates links and catalogues, not dependency ranges. The only mechanism was remembering.

So the bump is the easy half. `packages/cli/src/__tests__/templates.test.ts` — the first test in this package — fails when the pin cannot install the current server version, with a message naming the fix. Its caret helper is tested before it is trusted, and **throws on a range shape it does not recognise** rather than passing: a guard that silently approves an unparsed pin is worse than no guard.

Verified by mutation: reverting the pin to `^0.7.0` produces
> `templates/package.json pins @onesub/server ^0.7.0, which cannot install 0.27.0. On a 0.x version a caret admits only patches, so bump the pin in the same change as the server release.`

## Consumers of the 0.27.0 breaking change

| file | was | now |
|---|---|---|
| `templates/.env.example` | `GOOGLE_PUSH_AUDIENCE` labelled *Optional*, commented | labelled **required in production**, still commented, `+ GOOGLE_PUSH_SERVICE_ACCOUNT_EMAIL` |
| `templates/server.ts` | `pushAudience` only | `+ pushServiceAccountEmail`, with the 401 consequence in a comment |
| `examples/server/server.js` | **no `pushAudience` at all** | both push fields from env, unset by default |
| `examples/server/package.json` | `^0.14.0` | `^0.27.0` |
| `examples/expo-app/package.json` | sdk `^0.7.0` | `^0.10.6` |
| `SKILL.md` | `pushAudience?` "for JWT verification"; no `allowUnauthenticatedWebhook` | required-in-production, opt-in documented |
| `docs/DEPLOYMENT.md` | "accepts any well-formed notification body" | 401 in production; also fixed a *"below"* pointing at a section that is above |

`SKILL.md` mattered most: it is what an agent reads when adding OneSub to another app, so a wrong config block means the generated config 401s in production.

The audience stays **commented out** in `.env.example` on purpose — uncommenting would hand every developer a placeholder audience, which fails verification in *every* environment, not just production.

## Verification

| Check | Result |
|---|---|
| `npm test` (with `DATABASE_URL`) | **879 passed** (873 → 879) |
| `npm run build` / `type-check` | pass / 0 errors |
| `npm run size -w @onesub/server` | 38.06 / 38.40 KB vs 40 KB |
| `npm run docs:check` | pass |
| `pwsh ./validate-unity-packages.ps1` | pass |
| Each of the 4 commits, independently | build + full suite + docs green |

**Real scaffolder run** — `node packages/cli/dist/index.js init` in a temp dir produces `"@onesub/server": "^0.27.0"` and the new `.env.example` wording.

**Real example server**, booted the way `bench.yml` does:

```text
NODE_ENV unset      → /health 200,  webhook/google 200
NODE_ENV=production → webhook/google 401
                      [onesub] … will reject every request with 401
```

## Two things found on the way, not changed here

- **A local `npm install --no-save bullmq` breaks `webhook-queue-integration.test.ts`.** The test is named "bullmq not installed" and asserts that path; hoisting bullmq to the root silently changes what it tests. `bench.yml` does exactly that install (documented, for the example server), but never runs `npm test`, so CI is unaffected. Left alone — it is pre-existing and fixing it means changing how that suite detects bullmq.
- **Compiled tests ship inside the published packages** — `packages/server/dist/__tests__` exists and `files: ["dist", …]` includes it. Repo-wide and pre-existing; matching it here rather than diverging in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)