### PR TITLE
fix(purchase): restore an already-consumed Google consumable instead of rejecting it

### DIFF
--- a/.changeset/consumed-token-restore.md
+++ b/.changeset/consumed-token-restore.md
@@ -1,0 +1,21 @@
+---
+'@onesub/server': patch
+---
+
+Stop rejecting a legitimate restore of an already-consumed Google consumable.
+
+onesub consumes a consumable the moment it validates it, so every later look at a
+purchase it already recorded — an in-session restore, a pending order the store
+re-surfaces, a retry after a dropped response — came back with
+`consumptionState: 1`. `validateGoogleProductReceipt` returned `null` for that,
+which the validate route turned into `422 RECEIPT_VALIDATION_FAILED`, so the
+idempotent-restore path a few lines below was unreachable for Android consumables.
+
+Clients read a 422 as an authoritative verdict about the receipt: they stop
+retrying and never confirm the order. The result was a purchase onesub had on
+record being silently lost to a player who had already been charged.
+
+The provider now reports `alreadyConsumed` instead of deciding, and the route
+rejects only when the token is consumed **and** no purchase row exists — which is
+the actual replay signal. Purchase state, receipt age and missing order id remain
+hard failures, and non-consumables are unaffected.

--- a/packages/server/src/__tests__/consumed-token-restore.test.ts
+++ b/packages/server/src/__tests__/consumed-token-restore.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Route behaviour for a Google consumable whose token Google already reports as
+ * consumed.
+ *
+ * This is the normal state of every purchase onesub has already handled: it
+ * consumes a consumable the moment it validates it. So a consumed token arrives
+ * whenever the client looks at the same purchase again — an in-session restore,
+ * a pending order the store re-surfaces, a retry after a dropped response.
+ *
+ * The provider used to answer all of those with `null`, which the route turned
+ * into `422 RECEIPT_VALIDATION_FAILED`. The Unity client reads a 422 as an
+ * authoritative verdict about the receipt, so it stopped retrying and never
+ * confirmed the order — a purchase onesub had on record was silently lost to a
+ * player who had already been charged.
+ *
+ * Restore and replay are now told apart the only way they can be: by whether a
+ * purchase with that transactionId is on record.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import { generateKeyPairSync } from 'crypto';
+import type { PurchaseInfo } from '@onesub/shared';
+import { createOneSubMiddleware } from '../index.js';
+import { InMemorySubscriptionStore, InMemoryPurchaseStore } from '../store.js';
+import { urlHost } from './test-utils.js';
+
+const { privateKey } = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+});
+
+const PACKAGE_NAME = 'com.example.app';
+const PRODUCT_ID = 'credits_100';
+const ORDER_ID = 'GPA.consumed-order';
+
+function googleConfig() {
+  return {
+    packageName: PACKAGE_NAME,
+    serviceAccountKey: JSON.stringify({
+      client_email: `test-${Math.random()}@test.iam.gserviceaccount.com`,
+      private_key: privateKey,
+      token_uri: 'https://oauth2.googleapis.com/token',
+    }),
+  };
+}
+
+/**
+ * Records every `:consume` / `:acknowledge` call the route makes.
+ *
+ * These matter as much as the status code: rejecting a replayed token is only
+ * correct if the token is also left untouched. A mock that answers *any*
+ * androidpublisher URL would happily absorb a consume call and let a
+ * mis-positioned guard pass, so side-effect URLs are captured separately.
+ */
+let sideEffectCalls: string[] = [];
+
+/** Google answers "completed, already consumed" for the product lookup. */
+function mockConsumedToken(overrides: Record<string, unknown> = {}) {
+  const productPurchase = {
+    purchaseState: 0,
+    consumptionState: 1,
+    purchaseTimeMillis: String(Date.now()),
+    orderId: ORDER_ID,
+    ...overrides,
+  };
+
+  vi.spyOn(global, 'fetch').mockImplementation(async (url) => {
+    const raw = String(typeof url === 'string' ? url : (url as Request).url ?? url);
+    const host = urlHost(url);
+    if (host === 'oauth2.googleapis.com') {
+      return {
+        ok: true,
+        json: async () => ({ access_token: 'test_access_token', expires_in: 3600 }),
+        text: async () => '',
+      } as Response;
+    }
+    if (host === 'androidpublisher.googleapis.com') {
+      if (raw.includes(':consume') || raw.includes(':acknowledge')) {
+        sideEffectCalls.push(raw.includes(':consume') ? 'consume' : 'acknowledge');
+        return { ok: true, json: async () => ({}), text: async () => '' } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => productPurchase,
+        text: async () => JSON.stringify(productPurchase),
+      } as Response;
+    }
+    throw new Error(`[test] Unexpected fetch URL: ${raw}`);
+  });
+}
+
+/** Lets the fire-and-forget consume/acknowledge calls land before we assert. */
+async function settle() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function recordedPurchase(userId: string): PurchaseInfo {
+  return {
+    userId,
+    productId: PRODUCT_ID,
+    platform: 'google',
+    type: 'consumable',
+    transactionId: ORDER_ID,
+    purchasedAt: new Date().toISOString(),
+    quantity: 1,
+  };
+}
+
+function buildApp(purchaseStore: InMemoryPurchaseStore) {
+  const app = express();
+  app.use(
+    createOneSubMiddleware({
+      database: { url: '' },
+      google: googleConfig(),
+      store: new InMemorySubscriptionStore(),
+      purchaseStore,
+    }),
+  );
+  return app;
+}
+
+function validate(app: express.Express, userId: string) {
+  return request(app)
+    .post('/onesub/purchase/validate')
+    .send({
+      platform: 'google',
+      receipt: 'purchase_token_abc',
+      userId,
+      productId: PRODUCT_ID,
+      type: 'consumable',
+    });
+}
+
+describe('already-consumed Google consumable', () => {
+  beforeEach(() => {
+    sideEffectCalls = [];
+    mockConsumedToken();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('restores a purchase already recorded for the same user', async () => {
+    const purchaseStore = new InMemoryPurchaseStore();
+    await purchaseStore.savePurchase(recordedPurchase('player-1'));
+
+    const res = await validate(buildApp(purchaseStore), 'player-1');
+
+    expect(res.status).toBe(200);
+    expect(res.body.valid).toBe(true);
+    expect(res.body.action).toBe('restored');
+    // The client makes fulfillment idempotent off this id, so it has to survive.
+    expect(res.body.purchase.transactionId).toBe(ORDER_ID);
+  });
+
+  it('refuses to hand a recorded consumable to a different user', async () => {
+    const purchaseStore = new InMemoryPurchaseStore();
+    await purchaseStore.savePurchase(recordedPurchase('player-1'));
+
+    const res = await validate(buildApp(purchaseStore), 'player-2');
+
+    expect(res.status).toBe(409);
+    expect(res.body.errorCode).toBe('TRANSACTION_BELONGS_TO_OTHER_USER');
+  });
+
+  // The one case that is genuinely suspicious: something consumed this token and
+  // it was not us.
+  //
+  // Asserting the 422 alone is not enough — that would still pass if the guard
+  // were moved below savePurchase or below the consume call, which is exactly the
+  // regression this whole change could introduce. So assert what must NOT have
+  // happened too: no row written, no token touched.
+  it('rejects a consumed token it has no record of, without writing or consuming', async () => {
+    const purchaseStore = new InMemoryPurchaseStore();
+
+    const res = await validate(buildApp(purchaseStore), 'player-1');
+    await settle();
+
+    expect(res.status).toBe(422);
+    expect(res.body.errorCode).toBe('RECEIPT_VALIDATION_FAILED');
+    expect(res.body.valid).toBe(false);
+
+    expect(await purchaseStore.getPurchaseByTransactionId(ORDER_ID)).toBeFalsy();
+    expect(await purchaseStore.getPurchasesByUserId('player-1')).toEqual([]);
+    expect(sideEffectCalls).toEqual([]);
+  });
+
+  // A restore is a read. It must not re-consume a token Google already consumed.
+  it('does not re-consume when restoring a recorded purchase', async () => {
+    const purchaseStore = new InMemoryPurchaseStore();
+    await purchaseStore.savePurchase(recordedPurchase('player-1'));
+
+    const res = await validate(buildApp(purchaseStore), 'player-1');
+    await settle();
+
+    expect(res.status).toBe(200);
+    expect(sideEffectCalls).toEqual([]);
+    // Still exactly one row — a restore must not duplicate the purchase.
+    expect(await purchaseStore.getPurchasesByUserId('player-1')).toHaveLength(1);
+  });
+
+  // The Unity client infers "was this a verdict about the receipt?" from the
+  // status code, and every response has to stay parseable as an onesub result.
+  it('keeps every response shape the shipped client can read', async () => {
+    const purchaseStore = new InMemoryPurchaseStore();
+    await purchaseStore.savePurchase(recordedPurchase('player-1'));
+
+    const restored = await validate(buildApp(purchaseStore), 'player-1');
+    expect(restored.body).toHaveProperty('valid');
+
+    const replay = await validate(buildApp(new InMemoryPurchaseStore()), 'player-1');
+    expect(replay.body).toHaveProperty('valid', false);
+    expect(replay.body).toHaveProperty('error');
+    expect(replay.body).toHaveProperty('errorCode');
+    // Never 401/403/408/429 from onesub itself: the client treats that class as
+    // "we never heard a verdict" and keeps the order pending.
+    expect([401, 403, 408, 429]).not.toContain(replay.status);
+  });
+
+  // Non-consumables legitimately report consumptionState=1 after acknowledgement.
+  // The new flag is scoped to consumables, so their path must be untouched.
+  it('leaves non-consumables alone', async () => {
+    const purchaseStore = new InMemoryPurchaseStore();
+
+    const res = await request(buildApp(purchaseStore))
+      .post('/onesub/purchase/validate')
+      .send({
+        platform: 'google',
+        receipt: 'purchase_token_abc',
+        userId: 'player-1',
+        productId: 'premium_unlock',
+        type: 'non_consumable',
+      });
+    await settle();
+
+    // Accepted as a fresh purchase, and acknowledged rather than consumed.
+    expect(res.status).toBe(200);
+    expect(res.body.valid).toBe(true);
+    expect(await purchaseStore.getPurchaseByTransactionId(ORDER_ID)).toBeTruthy();
+    expect(sideEffectCalls).toEqual(['acknowledge']);
+  });
+
+  it('still rejects a consumed token whose purchase was canceled', async () => {
+    vi.restoreAllMocks();
+    mockConsumedToken({ purchaseState: 1 });
+
+    const purchaseStore = new InMemoryPurchaseStore();
+    await purchaseStore.savePurchase(recordedPurchase('player-1'));
+
+    const res = await validate(buildApp(purchaseStore), 'player-1');
+
+    expect(res.status).toBe(422);
+  });
+});

--- a/packages/server/src/__tests__/provider-log-fields.test.ts
+++ b/packages/server/src/__tests__/provider-log-fields.test.ts
@@ -245,7 +245,10 @@ describe('google: rejections carry productId, and never the purchaseToken', () =
     ]);
   });
 
-  it('a replayed consumable is attributable to an order', async () => {
+  // The replay warning moved to routes/purchase.ts, which is the only place that
+  // can tell a replay from a legitimate restore of a purchase we already have on
+  // record. The provider no longer decides, so it no longer warns.
+  it('does not call an already-consumed consumable a replay on its own', async () => {
     mockPlayFetch({
       purchaseState: 0,
       consumptionState: 1,
@@ -254,11 +257,15 @@ describe('google: rejections carry productId, and never the purchaseToken', () =
     });
     const lines = capture();
 
-    await validateGoogleProductReceipt('token_abc', 'coins_50', googleConfig('replay'), 'consumable');
+    const result = await validateGoogleProductReceipt(
+      'token_abc',
+      'coins_50',
+      googleConfig('replay'),
+      'consumable',
+    );
 
-    expect(lines).toEqual([
-      '[onesub/google] Consumable already consumed — possible replay attack productId=coins_50 orderId=GPA.1234',
-    ]);
+    expect(result?.alreadyConsumed).toBe(true);
+    expect(lines).toEqual([]);
   });
 
   it('does not log the purchaseToken, which can cancel a subscription', async () => {

--- a/packages/server/src/__tests__/providers.test.ts
+++ b/packages/server/src/__tests__/providers.test.ts
@@ -339,7 +339,15 @@ describe('validateGoogleProductReceipt', () => {
     expect(result).toBeNull();
   });
 
-  it('returns null for consumable when consumptionState is 1 (already consumed)', async () => {
+  // onesub consumes a consumable as soon as it validates it, so a consumed token
+  // is what every *legitimate* second look at an already-recorded purchase looks
+  // like — a restore, a re-surfaced pending order, a retry after a dropped
+  // response. Returning null here made the route answer all of those with an
+  // authoritative "receipt rejected", which the client treats as final: it stops
+  // retrying and never confirms, losing a purchase onesub had already recorded.
+  // The provider now reports the fact; only the route can tell replay from
+  // restore, because only the route can look for the recorded purchase.
+  it('reports an already-consumed consumable instead of rejecting it', async () => {
     mockGoogleFetch({
       purchaseState: 0,
       consumptionState: 1,
@@ -348,6 +356,42 @@ describe('validateGoogleProductReceipt', () => {
     });
     const result = await validateGoogleProductReceipt(
       'token_consumed',
+      'credits_100',
+      makeGoogleConfig(),
+      'consumable',
+    );
+    expect(result).not.toBeNull();
+    expect(result?.transactionId).toBe('GPA.already_consumed');
+    expect(result?.alreadyConsumed).toBe(true);
+  });
+
+  it('does not flag a fresh consumable as already consumed', async () => {
+    mockGoogleFetch({
+      purchaseState: 0,
+      consumptionState: 0,
+      purchaseTimeMillis: String(Date.now()),
+      orderId: 'GPA.fresh',
+    });
+    const result = await validateGoogleProductReceipt(
+      'token_fresh',
+      'credits_100',
+      makeGoogleConfig(),
+      'consumable',
+    );
+    expect(result?.alreadyConsumed).toBe(false);
+  });
+
+  // purchaseState and receipt age are still hard failures — only the
+  // consumption check moved to the route.
+  it('still rejects a canceled purchase even though consumption no longer blocks', async () => {
+    mockGoogleFetch({
+      purchaseState: 1,
+      consumptionState: 1,
+      purchaseTimeMillis: String(Date.now()),
+      orderId: 'GPA.canceled_consumed',
+    });
+    const result = await validateGoogleProductReceipt(
+      'token_canceled_consumed',
       'credits_100',
       makeGoogleConfig(),
       'consumable',

--- a/packages/server/src/providers/google.ts
+++ b/packages/server/src/providers/google.ts
@@ -615,6 +615,18 @@ export interface GoogleProductResult {
    * (backward-compatible).
    */
   obfuscatedExternalAccountId?: string;
+  /**
+   * Google reports this token as already consumed. That is *not* by itself a
+   * replay: onesub consumes a consumable as soon as it validates it, so every
+   * legitimate re-validation of a purchase we already recorded — an in-session
+   * restore, a pending order the client re-surfaces, a retry after a dropped
+   * response — arrives with this set.
+   *
+   * The caller decides: consumed **and** already in the purchase store is an
+   * idempotent restore; consumed with **no** record is a token something else
+   * consumed, which is the actual replay signal.
+   */
+  alreadyConsumed?: boolean;
 }
 
 /**
@@ -667,15 +679,20 @@ export async function validateGoogleProductReceipt(
     return null;
   }
 
-  // For consumables: consumptionState 1 means already consumed by a previous request.
-  // This is the primary replay-attack signal for consumables on Android.
-  if (type === 'consumable' && purchase.consumptionState === 1) {
-    log.warn('[onesub/google] Consumable already consumed — possible replay attack', {
-      productId,
-      orderId: purchase.orderId,
-    });
-    return null;
-  }
+  // For consumables, consumptionState 1 means the token has already been consumed.
+  //
+  // This used to return null, which the route turned into an authoritative 422
+  // "receipt validation failed". That made the idempotent-restore path below
+  // unreachable for Android consumables: onesub consumes a token the moment it
+  // validates it, so any *legitimate* second look at a purchase we already
+  // recorded — a restore, a re-surfaced pending order, a retry after a dropped
+  // response — was answered as a rejected receipt. The client reads an
+  // authoritative rejection as final, stops retrying, and never confirms the
+  // order, so a purchase onesub itself had recorded was lost to the player.
+  //
+  // Report it instead and let the route decide, because only the route can tell
+  // the two cases apart by looking for the recorded purchase.
+  const alreadyConsumed = type === 'consumable' && purchase.consumptionState === 1;
 
   // Reject receipts older than the configured window (see
   // productReceiptMaxAgeHours — raise it for migrations / e2e).
@@ -704,6 +721,7 @@ export async function validateGoogleProductReceipt(
       ? new Date(parseInt(purchase.purchaseTimeMillis, 10)).toISOString()
       : new Date().toISOString(),
     obfuscatedExternalAccountId: purchase.obfuscatedExternalAccountId,
+    alreadyConsumed,
   };
 }
 

--- a/packages/server/src/routes/purchase.ts
+++ b/packages/server/src/routes/purchase.ts
@@ -130,6 +130,9 @@ export function createPurchaseRouter(
       // appAccountToken / Google obfuscatedExternalAccountId). Null when the
       // client didn't set one (legacy purchases / apps not yet on the bound SDK).
       let boundAccountId: string | null = null;
+      // Google says this token was already consumed. Only meaningful once we know
+      // whether we have a record of it — see the replay guard before the INSERT.
+      let alreadyConsumed = false;
 
       if (platform === 'apple') {
         if (!appConfig.apple) {
@@ -157,6 +160,7 @@ export function createPurchaseRouter(
           transactionId = result.transactionId;
           purchasedAt = result.purchasedAt;
           boundAccountId = result.obfuscatedExternalAccountId ?? null;
+          alreadyConsumed = result.alreadyConsumed === true;
         }
       }
 
@@ -231,6 +235,22 @@ export function createPurchaseRouter(
           action,
         };
         res.status(200).json(response);
+        return;
+      }
+
+      // Past the restore path above, so this token has no recorded purchase. A
+      // consumable that Google reports as already consumed and that we have no
+      // record of was consumed by something that is not us — that is the actual
+      // replay signal, and the only case that still deserves a hard rejection.
+      // (Before, *every* consumed token landed here as a 422, including the
+      // restores handled above.)
+      if (alreadyConsumed) {
+        log.warn('[onesub/purchase] consumed token with no recorded purchase — possible replay attack', {
+          transactionId,
+          productId,
+          userId,
+        });
+        sendError(res, 422, ONESUB_ERROR_CODE.RECEIPT_VALIDATION_FAILED, 'Receipt validation failed', NO_PURCHASE);
         return;
       }
 


### PR DESCRIPTION
## The bug

onesub consumes a consumable the moment it validates it. So every later look at a purchase it had **already recorded** — an in-session restore, a pending order the store re-surfaces, a retry after a dropped response — comes back from Google with `consumptionState: 1`.

`validateGoogleProductReceipt` returned `null` for that, and the route turned it into `422 RECEIPT_VALIDATION_FAILED` **before ever reaching the idempotent-restore lookup a few lines below**. The restore path was unreachable for Android consumables.

That is worse than a wrong status code. Clients read a 422 as an authoritative verdict about the receipt: they stop retrying and never confirm the order. A purchase onesub itself had on record was silently lost to a player who had already been charged.

## The fix

The provider reports `alreadyConsumed` rather than deciding, because only the route can tell the two cases apart — by looking for the recorded purchase:

| situation | before | after |
|---|---|---|
| consumed + row for this user | 422 | **200 `action:'restored'`** (existing code path) |
| consumed + row for another user | 422 | 409 `TRANSACTION_BELONGS_TO_OTHER_USER` |
| consumed + no row (real replay) | 422 | 422, still logged |

Strictly widens 2xx. No shipped client can regress: the only behaviour change is 422 → 200 for a case where the client currently loses the purchase.

Unchanged: `purchaseState`, receipt age and missing order id are still hard failures; the account-binding guard still runs first; non-consumables are untouched.

## Tests

The replay case now also asserts that **nothing was written** and that `:consume`/`:acknowledge` were **never called**. Without those, the test would still pass if the guard were moved below `savePurchase` — the exact regression this change could introduce.

Verified by mutation: neutering the guard (`if (false && alreadyConsumed)`) fails 2 tests. Added coverage for the non-consumable path and for restore-not-re-consuming.

Full suite: 652 passed, 39 skipped.

## Note for the deploy

A changeset is included (patch). findthem pins `^0.27.0`, so it picks this up on reinstall once released — no dependency bump needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)