### PR TITLE
fix(apple): name the product and app on an invalid-purchase-type rejection

### DIFF
--- a/.changeset/apple-invalid-type-attribution.md
+++ b/.changeset/apple-invalid-type-attribution.md
@@ -1,0 +1,15 @@
+---
+'@onesub/server': patch
+---
+
+Name the product and app when a subscription is sent to the product endpoint.
+
+`validateAppleConsumableReceipt` rejects a receipt whose type is not
+`Consumable`/`Non-Consumable`, but logged only the type. On a host serving several
+apps that says a subscription went to the wrong endpoint and nothing else — not
+which app, not which product, not whose purchase just failed with a 422.
+
+Eleven of these landed over four days in 2026-07 and none could be attributed from
+the logs; identifying the source took correlating warning timestamps against
+successful-purchase rows in the database. The line now carries `productId` (from the
+receipt, falling back to the requested id) and `bundleId`.

--- a/packages/server/src/__tests__/provider-log-fields.test.ts
+++ b/packages/server/src/__tests__/provider-log-fields.test.ts
@@ -128,6 +128,40 @@ describe('apple: rejections carry the identifier an operator would filter on', (
     ]);
   });
 
+  // A subscription sent to the product endpoint is a client-side routing bug, and
+  // the operator's first question is always "which app, which product". Logging
+  // only the type answered neither: eleven of these landed over four days on a
+  // multi-app host and not one could be attributed.
+  it('a subscription sent to the product endpoint names the product and the app', async () => {
+    const lines = capture();
+
+    await validateAppleConsumableReceipt(
+      makeJws(applePayload({ type: 'Auto-Renewable Subscription', productId: 'premium.monthly' })),
+      APPLE_CONFIG,
+    );
+
+    // The type is quoted because it contains a space — that is the formatter
+    // keeping the field boundary unambiguous, not an artifact.
+    expect(lines).toEqual([
+      '[onesub/apple] Invalid purchase type for product validation ' +
+        'type="Auto-Renewable Subscription" productId=premium.monthly bundleId=com.example.app',
+    ]);
+  });
+
+  // The receipt is the authority on which product it is, but a receipt that omits
+  // productId must still be attributable — fall back to what the caller asked for.
+  it('falls back to the requested product when the receipt omits one', async () => {
+    const lines = capture();
+
+    await validateAppleConsumableReceipt(
+      makeJws(applePayload({ type: 'Auto-Renewable Subscription', productId: undefined })),
+      APPLE_CONFIG,
+      'premium.monthly',
+    );
+
+    expect(lines[0]).toContain('productId=premium.monthly');
+  });
+
   it('a revoked purchase is attributable', async () => {
     // Without productId/transactionId this line said only "Purchase was
     // revoked/refunded" — true, and useless: an operator could not tell whose.

--- a/packages/server/src/providers/apple.ts
+++ b/packages/server/src/providers/apple.ts
@@ -397,8 +397,18 @@ export async function validateAppleConsumableReceipt(
   }
 
   // Must be a one-time purchase type (not a subscription)
+  //
+  // productId and bundleId are what make this line actionable. Without them the
+  // warning says only that *someone* sent a subscription to the product endpoint:
+  // in 2026-07 eleven of these landed over four days on a host serving several
+  // apps, and the logs could not attribute a single one — not to an app, let
+  // alone to a product — so nobody could tell whose purchase had just failed.
   if (tx.type !== 'Consumable' && tx.type !== 'Non-Consumable') {
-    log.warn('[onesub/apple] Invalid purchase type for product validation', { type: tx.type });
+    log.warn('[onesub/apple] Invalid purchase type for product validation', {
+      type: tx.type,
+      productId: tx.productId ?? expectedProductId,
+      bundleId: tx.bundleId,
+    });
     return null;
   }
 


### PR DESCRIPTION
`validateAppleConsumableReceipt` rejects a receipt whose type is not `Consumable`/`Non-Consumable`, but logged only the type:

```
[onesub/apple] Invalid purchase type for product validation: Auto-Renewable Subscription
```

On a host serving several apps that says a subscription reached the product endpoint and nothing else — **not which app, not which product, not whose purchase just failed with a 422.**

Eleven of these landed over four days in 2026-07 on the shared production host. None could be attributed from the logs. Narrowing it down required pulling warning timestamps out of pm2 logs and correlating them against successful-purchase rows in Postgres — and even then the result was an inference, not an identification.

## After

```
[onesub/apple] Invalid purchase type for product validation type="Auto-Renewable Subscription" productId=premium.monthly bundleId=com.example.app
```

`productId` comes from the receipt (the authority on what it actually is) and falls back to the requested id, so a receipt that omits one is still attributable. `bundleId` identifies the app.

Both field names are already in the `log-format.ts` vocabulary that `field-vocabulary.test.ts` enforces.

## Tests

Two cases added to `provider-log-fields.test.ts` — the full line, and the fallback when the receipt omits `productId`. Full suite: 654 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)