### PR TITLE
ci: publish npm packages with trusted OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,5 +197,3 @@ jobs:
           title: 'chore(release): version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- remove the long-lived NPM_TOKEN and NODE_AUTH_TOKEN from the release job
- retain id-token: write so npm 11.6.2 can exchange GitHub's OIDC identity for publish credentials
- keep GITHUB_TOKEN only for Changesets PR/repository operations

## Registry configuration
Trusted publishing was created and read back successfully for all six public packages, restricted to jeonghwanko/onesub and .github/workflows/ci.yml with publish permission.

## Rollout safety
The existing GitHub NPM_TOKEN secret is intentionally retained until PR #175 publishes @onesub/server through this workflow. After that real publish succeeds, the legacy secret can be deleted.