### PR TITLE
ci: avoid token npmrc during OIDC publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,8 @@ jobs:
         with:
           node-version: 22
           cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
+          # Keep setup-node from creating token-based .npmrc auth; npm's default
+          # registry plus id-token permission activates trusted OIDC publishing.
 
       - name: Install dependencies
         run: corepack npm ci


### PR DESCRIPTION
## Failure evidence
The first tokenless publish run correctly detected OIDC, but setup-node had exported NPM_CONFIG_USERCONFIG and generated token-based npmrc auth because registry-url was set. npm then returned misleading E404 responses for both existing scoped packages before completing the OIDC exchange.

## Fix
- stop setup-node from creating a token-auth npmrc in the release job
- rely on npm's default public registry and the existing id-token: write permission
- retain the already-verified Trusted Publisher mappings

Merging this PR automatically retries the unpublished @onesub/server 0.27.4 and @onesub/cli 0.1.47 releases. The legacy NPM_TOKEN secret remains present but is not injected into the job.