### PR TITLE
ci: use OIDC-capable npm for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,9 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          # Trusted publishing requires the npm 11 line bundled with Node 24;
+          # Changesets invokes npm publish directly rather than through Corepack.
+          node-version: 24
           cache: 'npm'
       - name: Install dependencies
         run: corepack npm ci


### PR DESCRIPTION
## Failure evidence
After removing token npmrc configuration, the release changed from E404 to ENEEDAUTH. changesets/action detected GitHub OIDC, but the child npm publish process used the Node 22 bundled npm rather than the Corepack-pinned outer command.

## Fix
- run the release job on Node 24, whose bundled npm supports Trusted Publishing
- keep the normal build/test jobs on Node 22, preserving the repository compatibility contract
- retain tokenless config and id-token: write

The next master run retries the two unpublished versions. The legacy secret remains uninjected until the registry confirms success.