### PR TITLE
ci: scope Node 24 to npm release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          # Trusted publishing requires the npm 11 line bundled with Node 24;
-          # Changesets invokes npm publish directly rather than through Corepack.
-          node-version: 24
+          node-version: 22
           cache: 'npm'
       - name: Install dependencies
         run: corepack npm ci
@@ -182,7 +180,9 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          # Trusted publishing requires the npm 11 line bundled with Node 24;
+          # Changesets invokes npm publish directly rather than through Corepack.
+          node-version: 24
           cache: 'npm'
           # Keep setup-node from creating token-based .npmrc auth; npm's default
           # registry plus id-token permission activates trusted OIDC publishing.


### PR DESCRIPTION
## Correction
The previous patch matched the first setup-node block: it moved the regular CI job to Node 24 while leaving release on Node 22. The release logs exposed this by showing /node/22.23.2/... during publish.

## Exact fix
- restore the main CI job to Node 22
- set only the release job (identified by fetch-depth: 0 and id-token: write) to Node 24
- keep token npmrc disabled

This preserves Node 22 compatibility validation and gives the child npm publish process an OIDC-capable npm.