### PR TITLE
chore: point package homepage at onesub.pryzm.gg

### DIFF
--- a/.changeset/homepage-landing-page.md
+++ b/.changeset/homepage-landing-page.md
@@ -1,0 +1,16 @@
+---
+'@onesub/cli': patch
+'@onesub/mcp-server': patch
+'@onesub/providers': patch
+'@onesub/server': patch
+'@onesub/shared': patch
+'@jeonghwanko/onesub-sdk': patch
+---
+
+Point each package's `homepage` at https://onesub.pryzm.gg
+
+npm renders `homepage` as the package's headline link, and every package pointed it at the
+GitHub repository — the same destination npm already derives from `repository`, so the two
+links were redundant and neither introduced the project. They now separate: `homepage` goes
+to the landing page, `repository` still goes to the source. No `repository`, `bugs`, or
+`files` entry changes, and nothing in the shipped code or type surface is affected.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/jeonghwanko/onesub.git",
     "directory": "packages/cli"
   },
-  "homepage": "https://github.com/jeonghwanko/onesub",
+  "homepage": "https://onesub.pryzm.gg",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/jeonghwanko/onesub.git",
     "directory": "packages/mcp-server"
   },
-  "homepage": "https://github.com/jeonghwanko/onesub",
+  "homepage": "https://onesub.pryzm.gg",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -33,7 +33,7 @@
     "url": "https://github.com/jeonghwanko/onesub.git",
     "directory": "packages/providers"
   },
-  "homepage": "https://github.com/jeonghwanko/onesub",
+  "homepage": "https://onesub.pryzm.gg",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -40,7 +40,7 @@
     "url": "https://github.com/jeonghwanko/onesub.git",
     "directory": "packages/sdk"
   },
-  "homepage": "https://github.com/jeonghwanko/onesub",
+  "homepage": "https://onesub.pryzm.gg",
   "license": "MIT",
   "dependencies": {
     "@onesub/shared": "0.16.1"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -50,7 +50,7 @@
     "url": "https://github.com/jeonghwanko/onesub.git",
     "directory": "packages/server"
   },
-  "homepage": "https://github.com/jeonghwanko/onesub",
+  "homepage": "https://onesub.pryzm.gg",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/jeonghwanko/onesub.git",
     "directory": "packages/shared"
   },
-  "homepage": "https://github.com/jeonghwanko/onesub",
+  "homepage": "https://onesub.pryzm.gg",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
npm renders `homepage` as a package's headline link, and all six published packages pointed it at the GitHub repository — the same destination npm already derives from `repository`. The two links were redundant, and neither introduced the project to someone landing on the npm page.

They now separate: **`homepage` → the landing page, `repository` → the source.**

```diff
-  "homepage": "https://github.com/jeonghwanko/onesub",
+  "homepage": "https://onesub.pryzm.gg",
```

Applied to `@onesub/cli`, `@onesub/mcp-server`, `@onesub/providers`, `@onesub/server`, `@onesub/shared`, and `@jeonghwanko/onesub-sdk`. `repository`, `files`, exports, and dependencies are untouched, so nothing in the shipped code or type surface changes.

## Changeset

Six patch bumps. `changeset status` also lists `@onesub/dashboard` — it is private and pulled in as a dependent of `@onesub/shared` via `updateInternalDependencies: patch`, so it takes a version bump but does not publish.

⚠️ The changeset was written **by hand** rather than through `npm run changeset`. The Changesets CLI is a TTY prompt and cannot be driven from a non-interactive session. Its package detection was checked against the prompt's own list (the same six), and `changeset status` confirms the resulting plan.

## Verification

| Check | Result |
|---|---|
| `npm run build` | pass |
| `npm run package:check` | pass — all six archives (`@onesub/server` 75 files / 362,209 B, etc.) |
| `npm run docs:check` | pass — 50 Markdown files, 7 workspaces, 25 routes |
| `npm test` | 873 passed, 1 file skipped (Postgres, no `DATABASE_URL`) |
| `npm run size -w @onesub/server` | esm 38.11 kB / cjs 38.45 kB — both under the 40 kB budget |
| `validate-unity-packages.ps1` | **not run** — no Unity package is touched |

🤖 Generated with [Claude Code](https://claude.com/claude-code)